### PR TITLE
Release 1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 ## Changelog
+- **1.0**:
+    - Adds a better approach for GenericOnOffSet messages to be sent to all subscribed addresses on the target element. If no subscriptions are present, messages will be sent to the element's unicast.
+    - Adds element unicast address within the node view to allow easier configuration.
+    - Adds Application Version and build numbers in the settings view.
+    - Adds a more descriptive title depending on OOB type in the user input view.
+    - Fixes some typos and misplaced text in the bundled application.
+    - Bugfix: Fixed a crash when the input OOB length won't fit within an UIn16 value.
+    - Bugfix: Input and Output OOB actions where wrongly parsed as Octets instead of bit fields, causing a crash when a node supports more than one action type.
+    - Bugfix: Fixed a bug causing Output OOB action types that are not Numeric OOB to never trigger due to a legacy check that's no longer required.
+
 - **0.4**:
     - Adds GenericOnOffServer control.
     - Adds UI improvement in Element view, now subscription,publication and both states are shown on the cell.

--- a/Example/nRFMeshProvision/Info.plist
+++ b/Example/nRFMeshProvision/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4</string>
+	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>5</string>
+	<string>6</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSBluetoothPeripheralUsageDescription</key>

--- a/Example/nRFMeshProvision/ViewControllers/NodeModelsView/ModelConfigurationView/ModelConfigurationTableViewController.swift
+++ b/Example/nRFMeshProvision/ViewControllers/NodeModelsView/ModelConfigurationView/ModelConfigurationTableViewController.swift
@@ -222,7 +222,19 @@ class ModelConfigurationTableViewController: UITableViewController, ProvisionedM
         let elementIdx = selectedModelIndexPath.section
         let unicast = nodeEntry.nodeUnicast!
         let elementAddress = Data([unicast[0], unicast[1] + UInt8(elementIdx)])
-        targetNode.nodeGenericOnOffSet(elementAddress, onDestinationAddress: nodeEntry.nodeUnicast!, withtargetState: targetstate)
+
+        if let element = nodeEntry.elements?[selectedModelIndexPath.section] {
+            let targetModel = element.allSigAndVendorModels()[selectedModelIndexPath.row]
+            if let addresses = element.subscriptionAddressesForModelId(targetModel) {
+                for anAddress in addresses {
+                    targetNode.nodeGenericOnOffSet(elementAddress, onDestinationAddress: anAddress, withtargetState: targetstate)
+                }
+            } else {
+                 targetNode.nodeGenericOnOffSet(elementAddress, onDestinationAddress: nodeEntry.nodeUnicast!, withtargetState: targetstate)
+            }
+        } else {
+            targetNode.nodeGenericOnOffSet(elementAddress, onDestinationAddress: nodeEntry.nodeUnicast!, withtargetState: targetstate)
+        }
     }
 
     // MARK: - ProvisionedMeshNodeDelegate

--- a/Example/nRFMeshProvision/ViewControllers/NodeModelsView/ModelConfigurationView/ModelConfigurationTableViewController.swift
+++ b/Example/nRFMeshProvision/ViewControllers/NodeModelsView/ModelConfigurationView/ModelConfigurationTableViewController.swift
@@ -494,7 +494,7 @@ class ModelConfigurationTableViewController: UITableViewController, ProvisionedM
             if let element = nodeEntry.elements?[selectedModelIndexPath.section] {
                 let targetModel = element.allSigAndVendorModels()[selectedModelIndexPath.row]
                 if let keyIndex = element.boundAppKeyIndexForModelId(targetModel) {
-                    aCell.textLabel?.text = "Key Binded"
+                    aCell.textLabel?.text = "Key Bound"
                     aCell.detailTextLabel?.text = "Key index \(keyIndex.hexString())"
                 } else {
                     aCell.textLabel?.text = "None"

--- a/Example/nRFMeshProvision/ViewControllers/NodeModelsView/NodeModelsTableViewController.swift
+++ b/Example/nRFMeshProvision/ViewControllers/NodeModelsView/NodeModelsTableViewController.swift
@@ -52,7 +52,9 @@ class NodeModelsTableViewController: UITableViewController, ProvisionedMeshNodeD
         if section == nodeEntry.elements?.count {
             return "Node Reset"
         } else {
-            return "Element \(section)"
+            let unicast = nodeEntry.nodeUnicast!
+            let elementAddress = Data([unicast[0], unicast[1] + UInt8(section)])
+            return "Element \(section). Unicast: \(elementAddress.hexString())"
         }
     }
 

--- a/Example/nRFMeshProvision/ViewControllers/ProvisioningView/MeshProvisioningDataTableViewController.swift
+++ b/Example/nRFMeshProvision/ViewControllers/ProvisioningView/MeshProvisioningDataTableViewController.swift
@@ -481,21 +481,40 @@ extension MeshProvisioningDataTableViewController: CBCentralManagerDelegate {
 }
 
 extension MeshProvisioningDataTableViewController: UnprovisionedMeshNodeDelegate {
+
     func nodeShouldDisconnect(_ aNode: UnprovisionedMeshNode) {
         if aNode == targetNode {
             centralManager.cancelPeripheralConnection(aNode.blePeripheral())
         }
     }
-    
-    func nodeRequiresUserInput(_ aNode: UnprovisionedMeshNode,
-                               completionHandler aHandler: @escaping (String) -> Void) {
+
+    func nodeRequiresUserInput(_ aNode: UnprovisionedMeshNode, outputAction: OutputOutOfBoundActions, length: UInt8, completionHandler aHandler: @escaping (String) -> (Void)) {
+        var titleString: String?
+        switch outputAction {
+            case .beep:
+                titleString = "Please enter number of beeps"
+            case .blink:
+                titleString = "Please enter number of blinks"
+            case .outputNumeric:
+                titleString = "please enter the numeric code"
+            case .outputAlphaNumeric:
+                titleString = "Please enter the alphanumeric code"
+            default:
+                titleString = "Please enter the confirmation code"
+        }
+
         let alertView = UIAlertController(title: "Device request",
-                                          message: "please enter confirmation code",
+                                          message: titleString!,
                                           preferredStyle: UIAlertControllerStyle.alert)
         var textField: UITextField?
         alertView.addTextField { (aTextField) in
-            aTextField.placeholder = "1234"
-            aTextField.keyboardType = .decimalPad
+            if outputAction == .outputAlphaNumeric {
+                aTextField.placeholder = "ABC123"
+                aTextField.keyboardType = .asciiCapable
+            } else {
+                aTextField.placeholder = "1234"
+                aTextField.keyboardType = .decimalPad
+            }
             textField = aTextField
         }
         let okAction = UIAlertAction(title: "Ok", style: .default) { (_) in
@@ -510,7 +529,7 @@ extension MeshProvisioningDataTableViewController: UnprovisionedMeshNodeDelegate
         alertView.addAction(cancelAction)
         self.present(alertView, animated: true, completion: nil)
     }
-    
+
     func nodeDidCompleteDiscovery(_ aNode: UnprovisionedMeshNode) {
         if aNode == targetNode {
             discoveryCompleted()

--- a/Example/nRFMeshProvision/ViewControllers/SettingsView/SettingsViewController.swift
+++ b/Example/nRFMeshProvision/ViewControllers/SettingsView/SettingsViewController.swift
@@ -378,6 +378,10 @@ class SettingsViewController: UIViewController, UITextFieldDelegate, UITableView
         return aCell
     }
 
+    func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        return indexPath.section != 4
+    }
+
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let section = indexPath.section
         let row = indexPath.row
@@ -452,7 +456,7 @@ class SettingsViewController: UIViewController, UITextFieldDelegate, UITableView
             if row == 0 {
                 var versionNumber: String = "N/A"
                 if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
-                    versionNumber = "v\(version)"
+                    versionNumber = "V \(version)"
                 }
                 return versionNumber
             } else if row == 1 {

--- a/Example/nRFMeshProvision/ViewControllers/SettingsView/SettingsViewController.swift
+++ b/Example/nRFMeshProvision/ViewControllers/SettingsView/SettingsViewController.swift
@@ -14,11 +14,12 @@ class SettingsViewController: UIViewController, UITextFieldDelegate, UITableView
     // MARK: - Properties
     var meshManager: NRFMeshManager!
     let reuseIdentifier = "SettingsTableViewCell"
-    let sectionTitles = ["Global Settings", "Network Settings", "App keys", "Mesh State"]
+    let sectionTitles = ["Global Settings", "Network Settings", "App keys", "Mesh State", "About"]
     let rowTitles   = [["Network Name", "Global TTL", "Provisioner Unicast"],
                        ["Network Key", "Key Index", "Flags", "IV Index"],
                        ["Manage App Keys"],
-                       ["Reset Mesh State"]]
+                       ["Reset Mesh State"],
+                       ["Application Version", "Build Number"]]
 
     // MARK: - Outlets and actions
     @IBOutlet weak var settingsTable: UITableView!
@@ -356,6 +357,7 @@ class SettingsViewController: UIViewController, UITextFieldDelegate, UITableView
         case 1: return 4
         case 2: return 1
         case 3: return 1
+        case 4: return 2
         default: return 0
         }
    }
@@ -443,6 +445,22 @@ class SettingsViewController: UIViewController, UITextFieldDelegate, UITableView
         } else if section == 3 {
             if row == 0 {
                 return "Forget Network"
+            } else {
+                return "N/A"
+            }
+        } else if section == 4 {
+            if row == 0 {
+                var versionNumber: String = "N/A"
+                if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+                    versionNumber = "v\(version)"
+                }
+                return versionNumber
+            } else if row == 1 {
+                var buildNumber: String = "N/A"
+                if let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
+                    buildNumber = build
+                }
+                return buildNumber
             } else {
                 return "N/A"
             }

--- a/nRFMeshProvision.podspec
+++ b/nRFMeshProvision.podspec
@@ -8,16 +8,16 @@
 
 Pod::Spec.new do |s|
   s.name             = 'nRFMeshProvision'
-  s.version          = '0.4'
-  s.summary          = 'A Bluetooth Mesh compliant provisioner and configurator'
+  s.version          = '1.0'
+  s.summary          = 'A Bluetooth Mesh library'
   s.description      = <<-DESC
-An early alpha version of the Bluetooth Mesh specification, this library will allow you to provision and configure bluetooth Mesh compliant nodes.
-This is a preview version that will have missing features and capabilities that are going to be added in the near future.
+  nRF Mesh is a Bluetooth Mesh compliant library that has many features such as provisioning, configuration and control of Bluetooth Mesh compliant nodes.
+This Library is under extensive development and will have missing features and capabilities that are going to be added in the near future.
                        DESC
-  s.homepage         = 'https://github.com/NordicPlayground/IOS-nRF-Mesh-Library'
+  s.homepage         = 'https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library'
   s.license          = { :type => 'BSD-3-Clause', :file => 'LICENSE' }
   s.author           = { 'mostafaberg' => 'mostafa.berg@nordicsemi.no' }
-  s.source           = { :git => 'https://github.com/NordicPlayground/IOS-nRF-Mesh-Library.git', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/nordictweets'
   s.platform         = :ios
   s.static_framework = true

--- a/nRFMeshProvision/Classes/MeshPDUs/ModelMessages/GenericOnOffSetMessage.swift
+++ b/nRFMeshProvision/Classes/MeshPDUs/ModelMessages/GenericOnOffSetMessage.swift
@@ -14,6 +14,9 @@ public struct GenericOnOffSetMessage {
     public init(withTargetState aTargetState: Data) {
         opcode = Data([0x82, 0x02])
         payload = aTargetState
+        //Sequence number used as TID
+        let tid = Data([SequenceNumber().sequenceData().last!])
+        payload.append(tid)
     }
 
     public func assemblePayload(withMeshState aState: MeshState, toAddress aDestinationAddress: Data) -> [Data]? {

--- a/nRFMeshProvision/Classes/Provisioner/ProvisioningHelpers/InputOutOfBoundActions.swift
+++ b/nRFMeshProvision/Classes/Provisioner/ProvisioningHelpers/InputOutOfBoundActions.swift
@@ -7,10 +7,59 @@
 
 import Foundation
 
-enum InputOutOfBoundActions: UInt16 {
+public enum InputOutOfBoundActions: UInt16 {
     case noInput            = 0x00
     case push               = 0x01
     case twist              = 0x02
     case inputNumber        = 0x04
     case inputAlphaNumeric  = 0x08
+    
+    public func toByteValue() -> UInt8? {
+        switch self {
+        case .noInput:
+            return nil
+        case .push:
+            return 0
+        case .twist:
+            return 1
+        case .inputNumber:
+            return 2
+        case .inputAlphaNumeric:
+            return 3
+        }
+    }
+    
+    public static func allValues() -> [InputOutOfBoundActions] {
+        return [
+            .push,
+            .twist,
+            .inputNumber,
+            .inputAlphaNumeric
+        ]
+    }
+    
+    public static func calculateInputActionsFromBitmask(aBitMask: UInt16) -> [InputOutOfBoundActions] {
+        var supportedActions = [InputOutOfBoundActions]()
+        for anAction in InputOutOfBoundActions.allValues() {
+            if  aBitMask & anAction.rawValue == anAction.rawValue {
+                supportedActions.append(anAction)
+            }
+        }
+        return supportedActions
+    }
+
+    public func description() -> String {
+        switch self {
+        case .noInput:
+            return "No input"
+        case .push:
+            return "Push"
+        case .twist:
+            return "Twist"
+        case .inputNumber:
+            return "Input number"
+        case .inputAlphaNumeric:
+            return "Input alphanumeric"
+        }
+    }
 }

--- a/nRFMeshProvision/Classes/Provisioner/ProvisioningHelpers/OutputOutOfBoundActions.swift
+++ b/nRFMeshProvision/Classes/Provisioner/ProvisioningHelpers/OutputOutOfBoundActions.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum OutputOutOfBoundActions: UInt16 {
+public enum OutputOutOfBoundActions: UInt16 {
     case noOutput           = 0x0000
     case blink              = 0x0001
     case beep               = 0x0002
@@ -17,6 +17,8 @@ enum OutputOutOfBoundActions: UInt16 {
     
     public func toByteValue() -> UInt8? {
         switch self {
+        case .noOutput:
+            return nil
         case .blink:
             return 0
         case .beep:
@@ -27,11 +29,27 @@ enum OutputOutOfBoundActions: UInt16 {
             return 3
         case .outputAlphaNumeric:
             return 4
-        default:
-            return nil
         }
-   }
+    }
     
+    public static func allValues() -> [OutputOutOfBoundActions] {
+        return [.blink,
+                .beep,
+                .vibrate,
+                .outputNumeric,
+                .outputAlphaNumeric]
+    }
+
+    public static func calculateOutputActionsFromBitMask(aBitMask: UInt16) -> [OutputOutOfBoundActions] {
+        var supportedActions = [OutputOutOfBoundActions]()
+        for anAction in OutputOutOfBoundActions.allValues() {
+            if  aBitMask & anAction.rawValue == anAction.rawValue {
+                supportedActions.append(anAction)
+            }
+        }
+        return supportedActions
+    }
+
     public func description() -> String {
         switch self {
         case .noOutput:

--- a/nRFMeshProvision/Classes/Provisioner/ProvisioningStates/ConfirmationProvisioningState.swift
+++ b/nRFMeshProvision/Classes/Provisioner/ProvisioningStates/ConfirmationProvisioningState.swift
@@ -80,7 +80,7 @@ class ConfirmationProvisioningState: NSObject, ProvisioningStateProtocol {
         print("confirmationKey: \(confirmationKey!.hexString())")
         //Next step is to calculate the confirmation provisioner value
         //This is done by calculating AES-CMAC of (Random value || AuthVAlue) with salt (confirmationKey)
-        let intValue                    = CFSwapInt16BigToHost(UInt16(anInput)!)
+        let intValue                    = CFSwapInt32BigToHost(UInt32(anInput)!)
         let authBytes                   = Data(bytes: self.toByteArray(intValue)).leftPad(length: 16)
         print("authBytes: \(authBytes)")
         target.receivedProvisionerUserInput(authBytes)

--- a/nRFMeshProvision/Classes/Provisioner/ProvisioningStates/ConfirmationProvisioningState.swift
+++ b/nRFMeshProvision/Classes/Provisioner/ProvisioningStates/ConfirmationProvisioningState.swift
@@ -53,7 +53,6 @@ class ConfirmationProvisioningState: NSObject, ProvisioningStateProtocol {
                     target.requireUserInput(outputActionType: targetAction, outputLength: actionLength) { (anInput) -> (Void) in
                         DispatchQueue.main.async {
                             self.didreceiveUserInput(anInput)
-
                         }
                     }
                 }

--- a/nRFMeshProvision/Classes/Provisioner/ProvisioningStates/StartProvisionProvisioningState.swift
+++ b/nRFMeshProvision/Classes/Provisioner/ProvisioningStates/StartProvisionProvisioningState.swift
@@ -66,11 +66,10 @@ class StartProvisionProvisioningState: NSObject, ProvisioningStateProtocol {
         if outputOutOfBoundAction! == .noOutput {
             startPDU.append(contentsOf: [0x00, 0x00, 0x00 ]) //No OOB = 0, Action = 0 & size = 0
         } else {
-            if outputOutOfBoundAction! == .outputNumeric {
-                startPDU.append(contentsOf: [0x02, //Output OOB opcode, better implementation TBD when we support all methods
-                                             outputOutOfBoundAction.toByteValue()!,
-                                             outputOutOfBoundSize])
-            }
+            //Output OOB only is supported, InputOOB will be implemented in the near future.
+            startPDU.append(contentsOf: [0x02,
+                                         outputOutOfBoundAction.toByteValue()!,
+                                         outputOutOfBoundSize])
         }
 
         print("Provision Start PDU Sent: \(startPDU.hexString())")

--- a/nRFMeshProvision/Classes/Provisioner/ProvisioningStates/StartProvisionProvisioningState.swift
+++ b/nRFMeshProvision/Classes/Provisioner/ProvisioningStates/StartProvisionProvisioningState.swift
@@ -20,9 +20,9 @@ class StartProvisionProvisioningState: NSObject, ProvisioningStateProtocol {
     private var publicKeyAvailability           : PublicKeyInformationAvailability!
     private var staticOutOfBoundAvailability    : StaticOutOfBoundInformationAvailability!
     private var outputOutOfBoundSize            : UInt8!
-    private var outputOutOfBoundAction          : OutputOutOfBoundActions!
+    private var outputOutOfBoundActions         : [OutputOutOfBoundActions]!
     private var inputOutOfBoundSize             : UInt8!
-    private var inputOutOfBoundAction           : InputOutOfBoundActions!
+    private var inputOutOfBoundActions          : [InputOutOfBoundActions]!
     
     func humanReadableName() -> String {
         return "ProvisioningStart"
@@ -41,15 +41,15 @@ class StartProvisionProvisioningState: NSObject, ProvisioningStateProtocol {
         dataOutCharacteristic   = discovery.dataOutCharacteristic
     }
    
-    public func setCapabilities(_ someCapabilities: (elementcount: Int, algorithm: ProvisioningAlgorithm, publicKeyAvailability: PublicKeyInformationAvailability, staticOutOfBoundAvailability: StaticOutOfBoundInformationAvailability, outOfBoundSize: UInt8, outOfBoundAction: OutputOutOfBoundActions, inputOutOfBoundsize: UInt8, inputOutOfBoundAction: InputOutOfBoundActions)) {
+    public func setCapabilities(_ someCapabilities: (elementcount: Int, algorithm: ProvisioningAlgorithm, publicKeyAvailability: PublicKeyInformationAvailability, staticOutOfBoundAvailability: StaticOutOfBoundInformationAvailability, outOfBoundSize: UInt8, outOfBoundAction: [OutputOutOfBoundActions], inputOutOfBoundsize: UInt8, inputOutOfBoundAction: [InputOutOfBoundActions])) {
         elementCount                    = someCapabilities.elementcount
         algorithm                       = someCapabilities.algorithm
         publicKeyAvailability           = someCapabilities.publicKeyAvailability
         staticOutOfBoundAvailability    = someCapabilities.staticOutOfBoundAvailability
         outputOutOfBoundSize            = someCapabilities.outOfBoundSize
-        outputOutOfBoundAction          = someCapabilities.outOfBoundAction
+        outputOutOfBoundActions         = someCapabilities.outOfBoundAction
         inputOutOfBoundSize             = someCapabilities.inputOutOfBoundsize
-        inputOutOfBoundAction           = someCapabilities.inputOutOfBoundAction
+        inputOutOfBoundActions          = someCapabilities.inputOutOfBoundAction
     }
 
     func execute() {
@@ -63,12 +63,13 @@ class StartProvisionProvisioningState: NSObject, ProvisioningStateProtocol {
         let fipsEllipticAlgorithm   : UInt8 = 0x00 //FIPS P-256
         let oobpubkeyAvailability   : UInt8 = 0x00 //No OOB public key has been used
         var startPDU = Data([0x03, provisionStartCommand, fipsEllipticAlgorithm, oobpubkeyAvailability])
-        if outputOutOfBoundAction! == .noOutput {
+        if outputOutOfBoundActions.count == 0 || outputOutOfBoundActions.contains(.noOutput) {
+            //Prefer no OOB
             startPDU.append(contentsOf: [0x00, 0x00, 0x00 ]) //No OOB = 0, Action = 0 & size = 0
         } else {
-            //Output OOB only is supported, InputOOB will be implemented in the near future.
+            //If there is no noOutput OOB action, use the first possible action
             startPDU.append(contentsOf: [0x02,
-                                         outputOutOfBoundAction.toByteValue()!,
+                                         outputOutOfBoundActions.first!.toByteValue()!,
                                          outputOutOfBoundSize])
         }
 

--- a/nRFMeshProvision/Classes/UnprovisionedNode/UnprovisionedMeshNode.swift
+++ b/nRFMeshProvision/Classes/UnprovisionedNode/UnprovisionedMeshNode.swift
@@ -77,9 +77,9 @@ public class UnprovisionedMeshNode: NSObject, UnprovisionedMeshNodeProtocol {
     }
    
     // MARK: UnprovisionedMeshNodeDelegate
-    func requireUserInput(anInput: @escaping ((String) -> (Void))) {
+    func requireUserInput(outputActionType: OutputOutOfBoundActions, outputLength: UInt8, anInput: @escaping ((String) -> (Void))) {
         logDelegate?.logUserInputRequired()
-        delegate?.nodeRequiresUserInput(self, completionHandler: { (aString) -> (Void) in
+        delegate?.nodeRequiresUserInput(self, outputAction: outputActionType, length: outputLength, completionHandler: { (aString) -> (Void) in
             anInput(aString)
         })
     }

--- a/nRFMeshProvision/Classes/UnprovisionedNode/UnprovisionedMeshNodeDelegate.swift
+++ b/nRFMeshProvision/Classes/UnprovisionedNode/UnprovisionedMeshNodeDelegate.swift
@@ -9,7 +9,11 @@ import Foundation
 
 public protocol UnprovisionedMeshNodeDelegate {
     func nodeDidCompleteDiscovery(_ aNode: UnprovisionedMeshNode)
-    func nodeRequiresUserInput(_ aNode: UnprovisionedMeshNode, completionHandler aHandler: @escaping (String) -> (Void))
+    func nodeRequiresUserInput(_ aNode: UnprovisionedMeshNode,
+                               outputAction: OutputOutOfBoundActions,
+                               length: UInt8,
+                               completionHandler aHandler: @escaping (String) -> (Void)
+    )
     func nodeShouldDisconnect(_ aNode: UnprovisionedMeshNode)
     func nodeProvisioningCompleted(_ aNode: UnprovisionedMeshNode)
     func nodeProvisioningFailed(_ aNode: UnprovisionedMeshNode, withErrorCode anErrorCode: ProvisioningErrorCodes)

--- a/nRFMeshProvision/Classes/UnprovisionedNode/UnprovisionedMeshNodeProtocol.swift
+++ b/nRFMeshProvision/Classes/UnprovisionedNode/UnprovisionedMeshNodeProtocol.swift
@@ -67,7 +67,7 @@ protocol UnprovisionedMeshNodeProtocol {
     func calculatedDeviceKey(_ aDeviceKey: Data)
 
     // MARK: - Data input
-    func requireUserInput(anInput: (@escaping (String) -> (Void)))
+    func requireUserInput(outputActionType: OutputOutOfBoundActions, outputLength: UInt8, anInput: (@escaping (_ value: String) -> (Void)))
 
     // MARK: - State related
     func switchToState(_ nextState : ProvisioningStateProtocol)


### PR DESCRIPTION
- Adds a better approach for GenericOnOffSet messages to be sent to all subscribed addresses on the target element. If no subscriptions are present, messages will be sent to the element's unicast.
- Adds element unicast address within the node view to allow easier configuration.
- Adds Application Version and build numbers in the settings view.
- Adds a more descriptive title depending on OOB type in the user input view.
- Fixes some typos and misplaced text in the bundled application.
- Bugfix: Fixed a crash when the input OOB length won't fit within an UIn16 value.
- Bugfix: Input and Output OOB actions where wrongly parsed as Octets instead of bit fields, causing a crash when a node supports more than one action type.
- Bugfix: Fixed a bug causing Output OOB action types that are not Numeric OOB to never trigger due to a legacy check that's no longer required.