### PR TITLE
Most device status replies

### DIFF
--- a/nRFMeshProvision/Classes/GenericModelController/GenericModelControllerStates/GenericOnOffGetControllerState.swift
+++ b/nRFMeshProvision/Classes/GenericModelController/GenericModelControllerStates/GenericOnOffGetControllerState.swift
@@ -93,8 +93,10 @@ class GenericOnOffGetControllerState: NSObject, GenericModelControllerStateProto
                 if result is GenericOnOffStatusMessage {
                     let genericOnOffStatus = result as! GenericOnOffStatusMessage
                     target.delegate?.receivedGenericOnOffStatusMessage(genericOnOffStatus)
+                    /*
                     let nextState = SleepConfiguratorState(withTargetProxyNode: target, destinationAddress: destinationAddress, andStateManager: stateManager)
                     target.switchToState(nextState)
+                    */
                 }
             } else {
                 print("ignoring non GenericOnOffStatus message")


### PR DESCRIPTION
I found that after masking the above code, the group is switched, and the status of the corresponding device can be received. The same operation GenericOnOffSetControllerState can also obtain the status information of most devices. When the number of devices is large, the status of some devices is not available Reply. 

https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/issues/43