### PR TITLE
Update Travis to newest xcode (10.1) and iphonesimulator (12.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # * http://www.objc.io/issue-6/travis-ci.html
 # * https://github.com/supermarin/xcpretty#usage
 
-osx_image: xcode7.3
+osx_image: xcode10.1
 language: objective-c
 # cache: cocoapods
 # podfile: Example/Podfile
@@ -10,5 +10,5 @@ language: objective-c
 # - gem install cocoapods # Since Travis is not always on latest version
 # - pod install --project-directory=Example
 script:
-- set -o pipefail && xcodebuild test -enableCodeCoverage YES -workspace Example/nRFMeshProvision.xcworkspace -scheme nRFMeshProvision-Example -sdk iphonesimulator9.3 ONLY_ACTIVE_ARCH=NO | xcpretty
+- set -o pipefail && xcodebuild test -enableCodeCoverage YES -workspace Example/nRFMeshProvision.xcworkspace -scheme nRFMeshProvision-Example -sdk iphonesimulator12.1 ONLY_ACTIVE_ARCH=NO | xcpretty
 - pod lib lint


### PR DESCRIPTION
Updates Travis to newest xcode (10.1) and iphonesimulator (12.1) versions.

Currently fails on
```
$ set -o pipefail && xcodebuild test -enableCodeCoverage YES -workspace Example/nRFMeshProvision.xcworkspace -scheme nRFMeshProvision-Example -sdk iphonesimulator12.1 ONLY_ACTIVE_ARCH=NO | xcpretty
xcodebuild: error: The workspace named "nRFMeshProvision" does not contain a scheme named "nRFMeshProvision-Example". The "-list" option can be used to find the names of the schemes in the workspace.
The command "set -o pipefail && xcodebuild test -enableCodeCoverage YES -workspace Example/nRFMeshProvision.xcworkspace -scheme nRFMeshProvision-Example -sdk iphonesimulator12.1 ONLY_ACTIVE_ARCH=NO | xcpretty" exited with 65.
```