### PR TITLE
Error handling

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		52547F0C231E9C670002AA7B /* RemoveAddressesFromFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52547F0B231E9C670002AA7B /* RemoveAddressesFromFilter.swift */; };
 		52547F0E231E9C960002AA7B /* FilterStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52547F0D231E9C960002AA7B /* FilterStatus.swift */; };
 		52547F162327C7570002AA7B /* KeySet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52547F152327C7570002AA7B /* KeySet.swift */; };
+		52547F182329210F0002AA7B /* MeshNetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52547F172329210F0002AA7B /* MeshNetworkError.swift */; };
 		52568D4722DDE8E800B7B236 /* MeshNetwork+Groups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52568D4622DDE8E800B7B236 /* MeshNetwork+Groups.swift */; };
 		52568D4922DDEA4400B7B236 /* Group+MeshNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52568D4822DDEA4400B7B236 /* Group+MeshNetwork.swift */; };
 		525A3C0022AD2167000D3791 /* ConfigMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 525A3BFF22AD2167000D3791 /* ConfigMessage.swift */; };
@@ -400,6 +401,7 @@
 		52547F0B231E9C670002AA7B /* RemoveAddressesFromFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveAddressesFromFilter.swift; sourceTree = "<group>"; };
 		52547F0D231E9C960002AA7B /* FilterStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterStatus.swift; sourceTree = "<group>"; };
 		52547F152327C7570002AA7B /* KeySet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeySet.swift; sourceTree = "<group>"; };
+		52547F172329210F0002AA7B /* MeshNetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeshNetworkError.swift; sourceTree = "<group>"; };
 		52568D4622DDE8E800B7B236 /* MeshNetwork+Groups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MeshNetwork+Groups.swift"; sourceTree = "<group>"; };
 		52568D4822DDEA4400B7B236 /* Group+MeshNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Group+MeshNetwork.swift"; sourceTree = "<group>"; };
 		525A3BFF22AD2167000D3791 /* ConfigMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigMessage.swift; sourceTree = "<group>"; };
@@ -688,6 +690,7 @@
 			children = (
 				529B757822411970008F1CE7 /* MeshNetworkManager.swift */,
 				5231404F230BE2540074325A /* MeshNetworkDelegate.swift */,
+				52547F172329210F0002AA7B /* MeshNetworkError.swift */,
 				52547F02231E8CAA0002AA7B /* ProxyFilter.swift */,
 				529B757C22423DEE008F1CE7 /* Storage.swift */,
 				5283529C2282CC720097B949 /* Mesh API */,
@@ -1482,6 +1485,7 @@
 				52A9C1962310027D0036792A /* GenericDefaultTransitionTimeStatus.swift in Sources */,
 				523F776222C4DEE60030EA6A /* ConfigNetKeyList.swift in Sources */,
 				5283529E2282CCE60097B949 /* Provisioner+Ranges.swift in Sources */,
+				52547F182329210F0002AA7B /* MeshNetworkError.swift in Sources */,
 				528352402271EF770097B949 /* MeshNetwork+Ranges.swift in Sources */,
 				523F775E22C4CE9A0030EA6A /* ConfigNetKeyStatus.swift in Sources */,
 				52A9C1AC23100D2A0036792A /* GenericPowerLastStatus.swift in Sources */,

--- a/Example/nRFMeshProvision/View Controllers/Groups/GroupControlViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Groups/GroupControlViewController.swift
@@ -160,7 +160,7 @@ extension GroupControlViewController: ModelGroupViewCellDelegate {
     
     func send(_ message: MeshMessage, description: String, using applicationKey: ApplicationKey) {
         start(description) {
-            MeshNetworkManager.instance.send(message, to: self.group, using: applicationKey)
+            try? MeshNetworkManager.instance.send(message, to: self.group, using: applicationKey)
         }
     }
     
@@ -168,7 +168,8 @@ extension GroupControlViewController: ModelGroupViewCellDelegate {
 
 extension GroupControlViewController: MeshNetworkDelegate {
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                     sentFrom source: Address, to destination: Address) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -177,13 +178,15 @@ extension GroupControlViewController: MeshNetworkDelegate {
         }
     }
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, to destination: Address) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                     sentFrom localElement: Element, to destination: Address) {
         done()
     }
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage, to destination: Address, error: Error) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage,
+                     from localElement: Element, to destination: Address, error: Error) {
         done() {
-            self.presentAlert(title: "Error", message: "Message could not be sent.")
+            self.presentAlert(title: "Error", message: error.localizedDescription)
         }
     }
 }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ConfigurationViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ConfigurationViewController.swift
@@ -357,26 +357,26 @@ private extension ConfigurationViewController {
     
     @objc func getCompositionData() {
         start("Requesting Composition Data...") {
-            MeshNetworkManager.instance.send(ConfigCompositionDataGet(), to: self.node)
+            try? MeshNetworkManager.instance.send(ConfigCompositionDataGet(), to: self.node)
         }
     }
     
     func getTtl() {
         start("Requesting default TTL...") {
-            MeshNetworkManager.instance.send(ConfigDefaultTtlGet(), to: self.node)
+            try? MeshNetworkManager.instance.send(ConfigDefaultTtlGet(), to: self.node)
         }
     }
     
     func setTtl(_ ttl: UInt8) {
         start("Setting TTL to \(ttl)...") {
-            MeshNetworkManager.instance.send(ConfigDefaultTtlSet(ttl: ttl), to: self.node)
+            try? MeshNetworkManager.instance.send(ConfigDefaultTtlSet(ttl: ttl), to: self.node)
         }
     }
     
     /// Sends a message to the node that will reset its state to unprovisioned.
     func resetNode() {
         start("Resetting node...") {
-            MeshNetworkManager.instance.send(ConfigNodeReset(), to: self.node)
+            try? MeshNetworkManager.instance.send(ConfigNodeReset(), to: self.node)
         }
     }
     
@@ -395,7 +395,8 @@ private extension ConfigurationViewController {
 
 extension ConfigurationViewController: MeshNetworkDelegate {
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                     sentFrom source: Address, to destination: Address) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -431,7 +432,8 @@ extension ConfigurationViewController: MeshNetworkDelegate {
         }
     }
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage, to destination: Address, error: Error) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage,
+                     from localElement: Element, to destination: Address, error: Error) {
         done() {
             self.presentAlert(title: "Error", message: error.localizedDescription)
             self.refreshControl?.endRefreshing()

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ElementViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ElementViewController.swift
@@ -131,7 +131,8 @@ class ElementViewController: UITableViewController {
 
 extension ElementViewController: MeshNetworkDelegate {
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                     sentFrom source: Address, to destination: Address) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/ConfigurationServerViewCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/ConfigurationServerViewCell.swift
@@ -118,7 +118,8 @@ class ConfigurationServerViewCell: ModelViewCell {
         return true
     }
     
-    override func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) -> Bool {
+    override func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                              sentFrom source: Address, to destination: Address) -> Bool {
         switch message {
             
         case is ConfigRelayStatus:

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/GenericLevelViewCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/GenericLevelViewCell.swift
@@ -109,7 +109,8 @@ class GenericLevelViewCell: ModelViewCell {
         readButton.isEnabled = isEnabled
     }
     
-    override func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) -> Bool {
+    override func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                              sentFrom source: Address, to destination: Address) -> Bool {
         switch message {
         case let status as GenericLevelStatus:
             let level = floorf(0.1 + (Float(status.level) + 32768.0) / 655.35)
@@ -131,7 +132,8 @@ class GenericLevelViewCell: ModelViewCell {
         return false
     }
     
-    override func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, to destination: Address) -> Bool {
+    override func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                              sentFrom localElement: Element, to destination: Address) -> Bool {
         // For acknowledged messages wait for the Acknowledgement Message.
         return acknowledgmentSwitch.isOn
     }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/GenericOnOffViewCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/GenericOnOffViewCell.swift
@@ -76,7 +76,8 @@ class GenericOnOffViewCell: ModelViewCell {
         readButton.isEnabled = isEnabled
     }
     
-    override func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) -> Bool {
+    override func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                              sentFrom source: Address, to destination: Address) -> Bool {
         switch message {
         case let status as GenericOnOffStatus:
             currentStatusLabel.text = status.isOn ? "ON" : "OFF"
@@ -96,7 +97,8 @@ class GenericOnOffViewCell: ModelViewCell {
         return false
     }
     
-    override func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, to destination: Address) -> Bool {
+    override func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                              sentFrom localElement: Element, to destination: Address) -> Bool {
         // For acknowledged messages wait for the Acknowledgement Message.
         return acknowledgmentSwitch.isOn
     }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/ModelViewCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/ModelViewCell.swift
@@ -56,7 +56,7 @@ class ModelViewCell: UITableViewCell {
     func startRefreshing() -> Bool {
         return false
     }
-
+    
     /// A callback called whenever a Mesh Message has been received
     /// from the mesh network.
     ///
@@ -66,9 +66,12 @@ class ModelViewCell: UITableViewCell {
     ///   - message:     The received message.
     ///   - source:      The Unicast Address of the Element from which
     ///                  the message was sent.
+    ///   - destination: The address to which the message was sent.
     /// - returns: `True`, when another request has been made, `false` if
     ///            the request has complete.
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) -> Bool {
+    func meshNetwork(_ meshNetwork: MeshNetwork,
+                     didDeliverMessage message: MeshMessage,
+                     sentFrom source: Address, to destination: Address) -> Bool {
         return false
     }
     
@@ -77,14 +80,16 @@ class ModelViewCell: UITableViewCell {
     /// a Unicast Address were acknowledged by the target Node.
     ///
     /// - parameters:
-    ///   - meshNetwork: The mesh network to which the message has
-    ///                  been sent.
-    ///   - message:     The message that has been sent.
-    ///   - source:      The Unicast Address of the Element to which
-    ///                  the message was sent.
+    ///   - meshNetwork:  The mesh network to which the message has
+    ///                   been sent.
+    ///   - message:      The message that has been sent.
+    ///   - localElement: The local Element used as a source of this message.
+    ///   - destination:  The address to which the message was sent.
     /// - returns: `True`, when another request has been made or an Acknowledgement
     ///            is expected, `false` if the request has complete.
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, to destination: Address) -> Bool {
+    func meshNetwork(_ meshNetwork: MeshNetwork,
+                     didDeliverMessage message: MeshMessage,
+                     sentFrom localElement: Element, to destination: Address) -> Bool {
         return false
     }
 

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/VendorModelViewCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/VendorModelViewCell.swift
@@ -88,7 +88,8 @@ class VendorModelViewCell: ModelViewCell, UITextFieldDelegate {
         return true
     }
     
-    override func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) -> Bool {
+    override func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                              sentFrom source: Address, to destination: Address) -> Bool {
         switch message {
         case let message as UnknownMessage where
             (message.opCode & 0xC0FFFF) == (0xC00000 | UInt32(model.companyIdentifier!.bigEndian)):
@@ -101,7 +102,8 @@ class VendorModelViewCell: ModelViewCell, UITextFieldDelegate {
         return false
     }
     
-    override func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, to destination: Address) -> Bool {
+    override func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                              sentFrom localElement: Element, to destination: Address) -> Bool {
         // For acknowledged messages wait for the Acknowledgement Message.
         return acknowledgmentSwitch.isOn
     }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelBindAppKeyViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelBindAppKeyViewController.swift
@@ -94,7 +94,7 @@ private extension ModelBindAppKeyViewController {
         }
         let selectedAppKey = keys[selectedIndexPath.row]
         start("Binding Application Key...") {
-            MeshNetworkManager.instance.send(ConfigModelAppBind(applicationKey: selectedAppKey, to: self.model), to: self.model)
+            try? MeshNetworkManager.instance.send(ConfigModelAppBind(applicationKey: selectedAppKey, to: self.model), to: self.model)
         }
     }
     
@@ -102,7 +102,8 @@ private extension ModelBindAppKeyViewController {
 
 extension ModelBindAppKeyViewController: MeshNetworkDelegate {
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                     sentFrom source: Address, to destination: Address) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -142,7 +143,8 @@ extension ModelBindAppKeyViewController: MeshNetworkDelegate {
         }
     }
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage, to destination: Address, error: Error) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage,
+                     from localElement: Element, to destination: Address, error: Error) {
         done() {
             self.presentAlert(title: "Error", message: error.localizedDescription)
         }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
@@ -325,13 +325,13 @@ extension ModelViewController: ModelViewCellDelegate {
     
     func send(_ message: MeshMessage, description: String) {
         start(description) {
-            MeshNetworkManager.instance.send(message, to: self.model)
+            try? MeshNetworkManager.instance.send(message, to: self.model)
         }
     }
     
     func send(_ message: ConfigMessage, description: String) {
         start(description) {
-            MeshNetworkManager.instance.send(message, to: self.model)
+            try? MeshNetworkManager.instance.send(message, to: self.model)
         }
     }
     
@@ -360,13 +360,13 @@ private extension ModelViewController {
                     self.done()
                     return
             }
-            MeshNetworkManager.instance.send(message, to: self.model)
+            try? MeshNetworkManager.instance.send(message, to: self.model)
         }
     }
     
     func reloadPublication() {
         start("Reading Publication settings...") {
-            MeshNetworkManager.instance.send(ConfigModelPublicationGet(for: self.model), to: self.model)
+            try? MeshNetworkManager.instance.send(ConfigModelPublicationGet(for: self.model), to: self.model)
         }
     }
     
@@ -378,7 +378,7 @@ private extension ModelViewController {
                     self.done()
                     return
             }
-            MeshNetworkManager.instance.send(message, to: self.model)
+            try? MeshNetworkManager.instance.send(message, to: self.model)
         }
     }
     
@@ -388,14 +388,14 @@ private extension ModelViewController {
     /// - parameter applicationKey: The Application Key to unbind.
     func unbindApplicationKey(_ applicationKey: ApplicationKey) {
         start("Unbinding Application Key") {
-            MeshNetworkManager.instance.send(ConfigModelAppUnbind(applicationKey: applicationKey, to: self.model), to: self.model)
+            try? MeshNetworkManager.instance.send(ConfigModelAppUnbind(applicationKey: applicationKey, to: self.model), to: self.model)
         }
     }
     
     /// Removes the publicaton from the model.
     func removePublication() {
         start("Removing Publication...") {
-            MeshNetworkManager.instance.send(ConfigModelPublicationSet(disablePublicationFor: self.model), to: self.model)
+            try? MeshNetworkManager.instance.send(ConfigModelPublicationSet(disablePublicationFor: self.model), to: self.model)
         }
     }
     
@@ -409,7 +409,7 @@ private extension ModelViewController {
                 ConfigModelSubscriptionVirtualAddressDelete(group: group, from: self.model) else {
                     return
             }
-            MeshNetworkManager.instance.send(message, to: self.model)
+            try? MeshNetworkManager.instance.send(message, to: self.model)
         }
     }
     
@@ -417,7 +417,8 @@ private extension ModelViewController {
 
 extension ModelViewController: MeshNetworkDelegate {
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                     sentFrom source: Address, to destination: Address) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -495,7 +496,8 @@ extension ModelViewController: MeshNetworkDelegate {
             }
             
         default:
-            let isMore = modelViewCell?.meshNetwork(meshNetwork, didDeliverMessage: message, from: source) ?? false
+            let isMore = modelViewCell?.meshNetwork(meshNetwork, didDeliverMessage: message,
+                                                    sentFrom: source, to: destination) ?? false
             if !isMore {
                 done()
                 
@@ -511,7 +513,8 @@ extension ModelViewController: MeshNetworkDelegate {
         }
     }
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, to destination: Address) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                     sentFrom localElement: Element, to destination: Address) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -525,14 +528,16 @@ extension ModelViewController: MeshNetworkDelegate {
             break
             
         default:
-            let isMore = modelViewCell?.meshNetwork(meshNetwork, didDeliverMessage: message, to: destination) ?? false
+            let isMore = modelViewCell?.meshNetwork(meshNetwork, didDeliverMessage: message,
+                                                    sentFrom: localElement, to: destination) ?? false
             if !isMore {
                 done()
             }
         }
     }
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage, to destination: Address, error: Error) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage,
+                     from localElement: Element, to destination: Address, error: Error) {
         done() {
             self.presentAlert(title: "Error", message: error.localizedDescription)
             self.refreshControl?.endRefreshing()

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeAddAppKeyViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeAddAppKeyViewController.swift
@@ -29,7 +29,7 @@ class NodeAddAppKeyViewController: ProgressViewController {
         }
         let selectedAppKey = keys[selectedIndexPath.row]
         start("Adding Application Key...") {
-            MeshNetworkManager.instance.send(ConfigAppKeyAdd(applicationKey: selectedAppKey), to: self.node)
+            try? MeshNetworkManager.instance.send(ConfigAppKeyAdd(applicationKey: selectedAppKey), to: self.node)
         }
     }
     
@@ -96,7 +96,8 @@ class NodeAddAppKeyViewController: ProgressViewController {
 
 extension NodeAddAppKeyViewController: MeshNetworkDelegate {
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                     sentFrom source: Address, to destination: Address) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -136,7 +137,8 @@ extension NodeAddAppKeyViewController: MeshNetworkDelegate {
         }
     }
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage, to destination: Address, error: Error) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage,
+                     from localElement: Element, to destination: Address, error: Error) {
         done() {
             self.presentAlert(title: "Error", message: error.localizedDescription)
         }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeAddNetworkKeyViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeAddNetworkKeyViewController.swift
@@ -29,7 +29,7 @@ class NodeAddNetworkKeyViewController: ProgressViewController {
         }
         let selectedNetworkKey = keys[selectedIndexPath.row]
         start("Adding Network Key...") {
-            MeshNetworkManager.instance.send(ConfigNetKeyAdd(networkKey: selectedNetworkKey), to: self.node)
+            try? MeshNetworkManager.instance.send(ConfigNetKeyAdd(networkKey: selectedNetworkKey), to: self.node)
         }
     }
     
@@ -93,7 +93,8 @@ class NodeAddNetworkKeyViewController: ProgressViewController {
 
 extension NodeAddNetworkKeyViewController: MeshNetworkDelegate {
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                     sentFrom source: Address, to destination: Address) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -133,7 +134,8 @@ extension NodeAddNetworkKeyViewController: MeshNetworkDelegate {
         }
     }
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage, to destination: Address, error: Error) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage,
+                     from localElement: Element, to destination: Address, error: Error) {
         done() {
             self.presentAlert(title: "Error", message: error.localizedDescription)
         }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeNetworkKeysViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeNetworkKeysViewController.swift
@@ -114,10 +114,7 @@ class NodeNetworkKeysViewController: ProgressViewController, Editable {
                 }
             }
         } else {
-            // Otherwise, just try removing it.
-            start("Deleting Network Key...") {
-                self.deleteNetworkKeyAt(indexPath)
-            }
+            deleteNetworkKeyAt(indexPath)            
         }
     }
 }
@@ -126,20 +123,24 @@ private extension NodeNetworkKeysViewController {
     
     @objc func readKeys(_ sender: Any) {
         start("Reading Network Keys...") {
-            MeshNetworkManager.instance.send(ConfigNetKeyGet(), to: self.node)
+            try? MeshNetworkManager.instance.send(ConfigNetKeyGet(), to: self.node)
         }
     }
     
     func deleteNetworkKeyAt(_ indexPath: IndexPath) {
-        let networkKey = node.networkKeys[indexPath.row]
-        MeshNetworkManager.instance.send(ConfigNetKeyDelete(networkKey: networkKey), to: node)
+        // Otherwise, just try removing it.
+        start("Deleting Network Key...") {
+            let networkKey = self.node.networkKeys[indexPath.row]
+            try? MeshNetworkManager.instance.send(ConfigNetKeyDelete(networkKey: networkKey), to: self.node)
+        }
     }
     
 }
 
 extension NodeNetworkKeysViewController: MeshNetworkDelegate {
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                     sentFrom source: Address, to destination: Address) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -181,7 +182,8 @@ extension NodeNetworkKeysViewController: MeshNetworkDelegate {
         }
     }
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage, to destination: Address, error: Error) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage,
+                     from localElement: Element, to destination: Address, error: Error) {
         done() {
             self.presentAlert(title: "Error", message: error.localizedDescription)
             self.refreshControl?.endRefreshing()

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationViewController.swift
@@ -327,7 +327,7 @@ private extension SetPublicationViewController {
                     self.done()
                     return
             }
-            MeshNetworkManager.instance.send(message, to: self.model)
+            try? MeshNetworkManager.instance.send(message, to: self.model)
         }
     }
     
@@ -354,7 +354,8 @@ extension SetPublicationViewController: DestinationDelegate {
 
 extension SetPublicationViewController: MeshNetworkDelegate {
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                     sentFrom source: Address, to destination: Address) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -393,7 +394,8 @@ extension SetPublicationViewController: MeshNetworkDelegate {
         }
     }
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage, to destination: Address, error: Error) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage,
+                     from localElement: Element, to destination: Address, error: Error) {
         done() {
             self.presentAlert(title: "Error", message: error.localizedDescription)
         }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SubscribeViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SubscribeViewController.swift
@@ -100,7 +100,7 @@ private extension SubscribeViewController {
                     self.done()
                     return
             }
-            MeshNetworkManager.instance.send(message, to: self.model)
+            try? MeshNetworkManager.instance.send(message, to: self.model)
         }
     }
     
@@ -108,7 +108,8 @@ private extension SubscribeViewController {
 
 extension SubscribeViewController: MeshNetworkDelegate {
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                     sentFrom source: Address, to destination: Address) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -147,7 +148,8 @@ extension SubscribeViewController: MeshNetworkDelegate {
         }
     }
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage, to destination: Address, error: Error) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, failedToDeliverMessage message: MeshMessage,
+                     from localElement: Element, to destination: Address, error: Error) {
         done() {
             self.presentAlert(title: "Error", message: error.localizedDescription)
         }

--- a/Example/nRFMeshProvision/View Controllers/Network/NetworkViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/NetworkViewController.swift
@@ -177,7 +177,8 @@ extension NetworkViewController: EditProvisionerDelegate {
 
 extension NetworkViewController: MeshNetworkDelegate {
     
-    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage, from source: Address) {
+    func meshNetwork(_ meshNetwork: MeshNetwork, didDeliverMessage message: MeshMessage,
+                     sentFrom source: Address, to destination: Address) {
         switch message {
             
         case is ConfigNodeReset:

--- a/MeshNetworkError.swift
+++ b/MeshNetworkError.swift
@@ -1,0 +1,23 @@
+//
+//  MeshNetworkError.swift
+//  nRFMeshProvision
+//
+//  Created by Aleksander Nowakowski on 11/09/2019.
+//
+
+import Foundation
+
+public enum MeshNetworkError: Error {
+    /// Thrown when trying to send a mesh message before setting up the mesh network.
+    case noNetwork
+}
+
+extension MeshNetworkError: LocalizedError {
+    
+    public var errorDescription: String? {
+        switch self {
+        case .noNetwork: return NSLocalizedString("Mesh Network not created.", comment: "")
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Layers/Access Layer/AccessError.swift
+++ b/nRFMeshProvision/Classes/Layers/Access Layer/AccessError.swift
@@ -18,19 +18,23 @@ public enum AccessError: Error {
     /// Thrown when the destination Address is not known and the
     /// library cannot determine the Network Key to use.
     case invalidDestination
-    /// Error thrown when the Provisioner is trying to remove
+    /// Thrown when trying to send a message from a Model that
+    /// does not have any Application Key bound to it.
+    case modelNotBoundToAppKey
+    /// Error thrown when the Provisioner is trying to delete
     /// the last Network Key from the Node.
-    case cannotRemove
+    case cannotDelete
 }
 
 extension AccessError: LocalizedError {
     
     public var errorDescription: String? {
         switch self {
-        case .invalidSource:      return NSLocalizedString("Local Provisioner does not have Unicast Address specified.", comment: "")
-        case .invalidElement:     return NSLocalizedString("Element does not belong to the local Node.", comment: "")
-        case .invalidDestination: return NSLocalizedString("The destination address is unknown.", comment: "")
-        case .cannotRemove:       return NSLocalizedString("Cannot remove the last Network Key.", comment: "")
+        case .invalidSource:         return NSLocalizedString("Local Provisioner does not have Unicast Address specified.", comment: "")
+        case .invalidElement:        return NSLocalizedString("Element does not belong to the local Node.", comment: "")
+        case .invalidDestination:    return NSLocalizedString("The destination address is unknown.", comment: "")
+        case .modelNotBoundToAppKey: return NSLocalizedString("No Application Key bound to the given Model.", comment: "")
+        case .cannotDelete:          return NSLocalizedString("Cannot delete the last Network Key.", comment: "")
         }
     }
     

--- a/nRFMeshProvision/Classes/Layers/NetworkManager.swift
+++ b/nRFMeshProvision/Classes/Layers/NetworkManager.swift
@@ -142,17 +142,26 @@ internal class NetworkManager {
     ///
     /// - parameter message: The mesh message that was received.
     /// - parameter source:  The source Unicast Address.
-    func notifyAbout(newMessage message: MeshMessage, from source: Address) {
-        meshNetworkManager.delegate?.meshNetwork(meshNetwork!, didDeliverMessage: message, from: source)
+    /// - parameter destination: The destination address of the message received.
+    func notifyAbout(newMessage message: MeshMessage, from source: Address, to destination: Address) {
+        meshNetworkManager.delegate?.meshNetwork(meshNetwork!, didDeliverMessage: message,
+                                                 sentFrom: source, to: destination)
     }
     
-    /// Notifies the delegate about the mesh message being sent to the given
+    /// Notifies the delegate about delivering the mesh message to the given
     /// destination address.
     ///
-    /// - parameter message: The mesh message that was sent.
-    /// - parameter source:  The destination address.
-    func notifyAbout(message: MeshMessage, sentTo destination: Address) {
-        meshNetworkManager.delegate?.meshNetwork(meshNetwork!, didDeliverMessage: message, to: destination)
+    /// - parameter message:     The mesh message that was sent.
+    /// - parameter source:      The source Unicast Address.
+    /// - parameter destination: The destination address.
+    func notifyAbout(deliveringMessage message: MeshMessage,
+                     from source: Address, to destination: Address) {
+        guard let localNode = meshNetwork?.localProvisioner?.node,
+              let localElement = localNode.elements.first(where: { $0.unicastAddress == source}) else {
+            return
+        }
+        meshNetworkManager.delegate?.meshNetwork(meshNetwork!, didDeliverMessage: message,
+                                                 sentFrom: localElement, to: destination)
     }
     
     /// Notifies the delegate about an error during sending the mesh message
@@ -160,12 +169,16 @@ internal class NetworkManager {
     ///
     /// - parameter error:   The error that occurred.
     /// - parameter message: The mesh message that failed to be sent.
+    /// - parameter source:  The source Unicast Address.
     /// - parameter source:  The destination address.
-    func notifyAbout(_ error: Error, duringSendingMessage message: MeshMessage, to destination: Address) {
-        meshNetworkManager.delegate?.meshNetwork(meshNetwork!, failedToDeliverMessage: message, to: destination, error: error)
+    func notifyAbout(_ error: Error, duringSendingMessage message: MeshMessage,
+                     from source: Address, to destination: Address) {
+        guard let localNode = meshNetwork?.localProvisioner?.node,
+            let localElement = localNode.elements.first(where: { $0.unicastAddress == source}) else {
+                return
+        }
+        meshNetworkManager.delegate?.meshNetwork(meshNetwork!, failedToDeliverMessage: message,
+                                                 from: localElement, to: destination, error: error)
     }
     
-    func notifyAbout(proxyConfigurationMessage message: ProxyConfigurationMessage) {
-        
-    }
 }

--- a/nRFMeshProvision/Classes/MeshNetworkDelegate.swift
+++ b/nRFMeshProvision/Classes/MeshNetworkDelegate.swift
@@ -12,28 +12,39 @@ public protocol MeshNetworkDelegate: class {
     /// A callback called whenever a Mesh Message has been received
     /// from the mesh network.
     ///
+    /// The `source` is given as an Address, instead of an Element, as
+    /// the message may be sent by an unknown Node, or a Node which
+    /// Elements are unknown.
+    ///
+    /// The `destination` address may be a Unicast Address of a local
+    /// Element, a Group or Virtual Address, but also any other address
+    /// if it was added to the Proxy Filter, e.g. a Unicast Address of
+    /// an Element on a remote Node.
+    ///
     /// - parameters:
     ///   - meshNetwork: The mesh network from which the message has
     ///                  been received.
     ///   - message:     The received message.
     ///   - source:      The Unicast Address of the Element from which
     ///                  the message was sent.
+    ///   - destination: The address to which the message was sent.
     func meshNetwork(_ meshNetwork: MeshNetwork,
                      didDeliverMessage message: MeshMessage,
-                     from source: Address)
+                     sentFrom source: Address, to destination: Address)
     
     /// A callback called when an unsegmented message was sent to the
     /// `transmitter`, or when all segments of a segmented message targetting
     /// a Unicast Address were acknowledged by the target Node.
     ///
     /// - parameters:
-    ///   - meshNetwork: The mesh network to which the message has
-    ///                  been sent.
-    ///   - message:     The message that has been sent.
-    ///   - destination: The address to which the message was sent.
+    ///   - meshNetwork:  The mesh network to which the message has
+    ///                   been sent.
+    ///   - message:      The message that has been sent.
+    ///   - localElement: The local Element used as a source of this message.
+    ///   - destination:  The address to which the message was sent.
     func meshNetwork(_ meshNetwork: MeshNetwork,
                      didDeliverMessage message: MeshMessage,
-                     to destination: Address)
+                     sentFrom localElement: Element, to destination: Address)
     
     /// A callback called when a message failed to be sent to the target
     /// Node. For unsegmented messages this may happen when the `transmitter`
@@ -51,18 +62,17 @@ public protocol MeshNetworkDelegate: class {
     /// - `LowerTransportError.timeout` - when the segmented message targetting
     ///   a Unicast Address was not acknowledgned before the `retransmissionLimit`
     ///   was reached.
-    /// - `AccessError.invalidSource` - when the local Provisioner does not have
-    ///   a Unicast Address specified.
     ///
     /// - parameters:
-    ///   - meshNetwork: The mesh network to which the message has
-    ///                  been sent.
-    ///   - message:     The message that has failed to be delivered.
-    ///   - destination: The address to which the message was being sent.
-    ///   - error:       The error that occurred.
+    ///   - meshNetwork:  The mesh network to which the message has
+    ///                   been sent.
+    ///   - message:      The message that has failed to be delivered.
+    ///   - localElement: The local Element used as a source of this message.
+    ///   - destination:  The address to which the message was sent.
+    ///   - error:        The error that occurred.
     func meshNetwork(_ meshNetwork: MeshNetwork,
                      failedToDeliverMessage message: MeshMessage,
-                     to destination: Address,
+                     from localElement: Element, to destination: Address,
                      error: Error)
     
 }
@@ -71,13 +81,13 @@ public extension MeshNetworkDelegate {
     
     func meshNetwork(_ meshNetwork: MeshNetwork,
                      didDeliverMessage message: MeshMessage,
-                     to destination: Address) {
+                     sentFrom localElement: Element, to destination: Address) {
         // Empty.
     }
     
     func meshNetwork(_ meshNetwork: MeshNetwork,
                      failedToDeliverMessage message: MeshMessage,
-                     to destination: Address,
+                     from localElement: Element, to destination: Address,
                      error: Error) {
         // Empty.
     }

--- a/nRFMeshProvision/Classes/ProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter.swift
@@ -231,7 +231,7 @@ internal extension ProxyFilter {
             // Handle buffered messages.
             guard buffer.isEmpty else {
                 let message = buffer.removeFirst()
-                manager.send(message)
+                try? manager.send(message)
                 return
             }
             busy = false
@@ -281,7 +281,11 @@ private extension ProxyFilter {
             return
         }
         busy = true
-        manager.send(message)
+        do {
+            try manager.send(message)
+        } catch {
+            busy = false
+        }
     }
     
 }


### PR DESCRIPTION
All `MeshNetworkManager`'s `send...` methods can now throw instead of either ignoring an error, or reporting it with a delegate.
Also, the delegates got the source and destination parameters. Otherwise it would not be possible to get the target model if a message was received from the network (assuming multiple Elements on the local node). However, still their **names are super confusing**.
https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/blob/6b39e966eeba13ad443cf413dd7ff32d0281c9dd/nRFMeshProvision/Classes/MeshNetworkDelegate.swift#L31-L33
and
https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/blob/6b39e966eeba13ad443cf413dd7ff32d0281c9dd/nRFMeshProvision/Classes/MeshNetworkDelegate.swift#L45-L47

Another thing is, that during sending, the source Element is lost somewhere, and the lib needs to find it again for the delegate to report it. Requires improvement.