### PR TITLE
No longer forcing ConfigMessages to be segmented

### DIFF
--- a/nRFMeshProvision/Classes/Mesh Messages/ConfigMessage.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/ConfigMessage.swift
@@ -217,16 +217,6 @@ internal extension ConfigNetAndAppKeyMessage {
     
 }
 
-public extension ConfigMessage {
-    
-    var isSegmented: Bool {
-        // By default, all Config Messages will be sent as segmented to make
-        // them more reliable.
-        return true
-    }
-    
-}
-
 public extension ConfigModelMessage {
     
     var modelId: UInt32 {


### PR DESCRIPTION
This PR ends the times where all `ConfigMessages` are force to be segmented. As the acknowledged messages are now implemented it is no longer required and speeds up the configuration process.