### PR TITLE
Vendor model example

### DIFF
--- a/Example/nRFMeshProvision.xcodeproj/project.pbxproj
+++ b/Example/nRFMeshProvision.xcodeproj/project.pbxproj
@@ -67,6 +67,12 @@
 		5288C20423704EF300321ED3 /* ConnectionModeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5288C20323704EF300321ED3 /* ConnectionModeCell.swift */; };
 		5288C2062370571100321ED3 /* ProxySelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5288C2052370571100321ED3 /* ProxySelectorViewController.swift */; };
 		5288C20823705C8D00321ED3 /* ProxyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5288C20723705C8D00321ED3 /* ProxyCell.swift */; };
+		5288C20A2371A89900321ED3 /* SimpleOnOffClientDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5288C2092371A89900321ED3 /* SimpleOnOffClientDelegate.swift */; };
+		5288C20E2371A91900321ED3 /* SimpleOnOffSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5288C20D2371A91900321ED3 /* SimpleOnOffSet.swift */; };
+		5288C2102371B0F700321ED3 /* SimpleOnOffGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5288C20F2371B0F700321ED3 /* SimpleOnOffGet.swift */; };
+		5288C2122371B16500321ED3 /* SimpleOnOffSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5288C2112371B16500321ED3 /* SimpleOnOffSetUnacknowledged.swift */; };
+		5288C2142371B32200321ED3 /* SimpleOnOffStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5288C2132371B32200321ED3 /* SimpleOnOffStatus.swift */; };
+		5288C2162371BC1300321ED3 /* SimpleOnOffClientCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5288C2152371BC1300321ED3 /* SimpleOnOffClientCell.swift */; };
 		528AB9F8228D847C000BE9DC /* NetworkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528AB9F7228D847C000BE9DC /* NetworkViewController.swift */; };
 		528AB9FA228D856C000BE9DC /* ProvisioningViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528AB9F9228D856C000BE9DC /* ProvisioningViewDelegate.swift */; };
 		5294DADA22B109810041370E /* Pdus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5294DAD922B109810041370E /* Pdus.swift */; };
@@ -191,6 +197,12 @@
 		5288C20323704EF300321ED3 /* ConnectionModeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionModeCell.swift; sourceTree = "<group>"; };
 		5288C2052370571100321ED3 /* ProxySelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxySelectorViewController.swift; sourceTree = "<group>"; };
 		5288C20723705C8D00321ED3 /* ProxyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyCell.swift; sourceTree = "<group>"; };
+		5288C2092371A89900321ED3 /* SimpleOnOffClientDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleOnOffClientDelegate.swift; sourceTree = "<group>"; };
+		5288C20D2371A91900321ED3 /* SimpleOnOffSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleOnOffSet.swift; sourceTree = "<group>"; };
+		5288C20F2371B0F700321ED3 /* SimpleOnOffGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleOnOffGet.swift; sourceTree = "<group>"; };
+		5288C2112371B16500321ED3 /* SimpleOnOffSetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleOnOffSetUnacknowledged.swift; sourceTree = "<group>"; };
+		5288C2132371B32200321ED3 /* SimpleOnOffStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleOnOffStatus.swift; sourceTree = "<group>"; };
+		5288C2152371BC1300321ED3 /* SimpleOnOffClientCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleOnOffClientCell.swift; sourceTree = "<group>"; };
 		528AB9F7228D847C000BE9DC /* NetworkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkViewController.swift; sourceTree = "<group>"; };
 		528AB9F9228D856C000BE9DC /* ProvisioningViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvisioningViewDelegate.swift; sourceTree = "<group>"; };
 		5294DAD922B109810041370E /* Pdus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pdus.swift; sourceTree = "<group>"; };
@@ -465,6 +477,26 @@
 			path = Provisioning;
 			sourceTree = "<group>";
 		};
+		5288C20B2371A8E000321ED3 /* Simple OnOff */ = {
+			isa = PBXGroup;
+			children = (
+				5288C20C2371A90200321ED3 /* Messages */,
+				5288C2092371A89900321ED3 /* SimpleOnOffClientDelegate.swift */,
+			);
+			path = "Simple OnOff";
+			sourceTree = "<group>";
+		};
+		5288C20C2371A90200321ED3 /* Messages */ = {
+			isa = PBXGroup;
+			children = (
+				5288C20D2371A91900321ED3 /* SimpleOnOffSet.swift */,
+				5288C20F2371B0F700321ED3 /* SimpleOnOffGet.swift */,
+				5288C2112371B16500321ED3 /* SimpleOnOffSetUnacknowledged.swift */,
+				5288C2132371B32200321ED3 /* SimpleOnOffStatus.swift */,
+			);
+			path = Messages;
+			sourceTree = "<group>";
+		};
 		529B757322410784008F1CE7 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
@@ -525,6 +557,7 @@
 		52DF5D8D22968F7C00C297C1 /* Mesh Network */ = {
 			isa = PBXGroup;
 			children = (
+				5288C20B2371A8E000321ED3 /* Simple OnOff */,
 				52DF5D8E229691BD00C297C1 /* NetworkConnection.swift */,
 				52E54CDC23438B2E00478F05 /* GenericOnOffClientDelegate.swift */,
 				52E54CDE23438D2600478F05 /* GenericOnOffServerDelegate.swift */,
@@ -551,6 +584,7 @@
 				52E54CD32343874000478F05 /* GenericOnOffServerCell.swift */,
 				52E54CD52343875400478F05 /* GenericLevelClientCell.swift */,
 				52E54CD72343876000478F05 /* GenericLevelServerCell.swift */,
+				5288C2152371BC1300321ED3 /* SimpleOnOffClientCell.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -853,6 +887,7 @@
 				52DF5D8C228DAA0500C297C1 /* NodeViewCell.swift in Sources */,
 				52CD0A50232FA6CD00A9A181 /* ProxyViewController.swift in Sources */,
 				528AB9FA228D856C000BE9DC /* ProvisioningViewDelegate.swift in Sources */,
+				5288C2162371BC1300321ED3 /* SimpleOnOffClientCell.swift in Sources */,
 				5288C20423704EF300321ED3 /* ConnectionModeCell.swift in Sources */,
 				52547F28232A3F470002AA7B /* RangeView.swift in Sources */,
 				52314041230192C50074325A /* ModelViewCell.swift in Sources */,
@@ -862,6 +897,7 @@
 				528AB9F8228D847C000BE9DC /* NetworkViewController.swift in Sources */,
 				523F778722CCDE250030EA6A /* SetPublicationViewController.swift in Sources */,
 				52CD0A622330DCFF00A9A181 /* CustomAddressCell.swift in Sources */,
+				5288C2122371B16500321ED3 /* SimpleOnOffSetUnacknowledged.swift in Sources */,
 				52547F29232A3F470002AA7B /* FabView.swift in Sources */,
 				52A9C17D230EB9490036792A /* GenericOnOffViewCell.swift in Sources */,
 				52E54CD62343875400478F05 /* GenericLevelClientCell.swift in Sources */,
@@ -874,11 +910,13 @@
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 				523F776C22C6324A0030EA6A /* ProgressViewController.swift in Sources */,
 				52547F25232A3F470002AA7B /* EditProvisionerViewController.swift in Sources */,
+				5288C2102371B0F700321ED3 /* SimpleOnOffGet.swift in Sources */,
 				529B756D223FE7F1008F1CE7 /* RootViewController.swift in Sources */,
 				52CD0A53232FA79300A9A181 /* FilterTypeCell.swift in Sources */,
 				523F776822C615CE0030EA6A /* NodeAppKeysViewController.swift in Sources */,
 				523F777922CB57190030EA6A /* ModelViewController.swift in Sources */,
 				522AFFE022C2376C00521EDC /* ElementViewController.swift in Sources */,
+				5288C20E2371A91900321ED3 /* SimpleOnOffSet.swift in Sources */,
 				523F779722CE2BF60030EA6A /* SetPublicationDestinationsViewController.swift in Sources */,
 				52E54CD023437D3D00478F05 /* ModelControlCell.swift in Sources */,
 				523F776422C4EDD90030EA6A /* SwitchCell.swift in Sources */,
@@ -896,6 +934,7 @@
 				529B7572223FFC39008F1CE7 /* AppKeysViewController.swift in Sources */,
 				52E54CD22343871E00478F05 /* GenericOnOffClientCell.swift in Sources */,
 				52E54CCD23437B9700478F05 /* ElementSectionView.swift in Sources */,
+				5288C2142371B32200321ED3 /* SimpleOnOffStatus.swift in Sources */,
 				5251498122E0E36600CBF1E3 /* AddGroupViewController.swift in Sources */,
 				52835258227AEDA30097B949 /* DeviceCell.swift in Sources */,
 				52E54CD82343876000478F05 /* GenericLevelServerCell.swift in Sources */,
@@ -905,6 +944,7 @@
 				529B7570223FF1AE008F1CE7 /* SettingsViewController.swift in Sources */,
 				526021F62343660200E88F06 /* ControlViewCell.swift in Sources */,
 				52A9C1C52313D7D80036792A /* GenericLevelViewCell.swift in Sources */,
+				5288C20A2371A89900321ED3 /* SimpleOnOffClientDelegate.swift in Sources */,
 				529B759C2243BA10008F1CE7 /* NetworkKeysViewController.swift in Sources */,
 				52518B3122E0B18400A1FD1E /* GroupsViewController.swift in Sources */,
 				5283528222806D7C0097B949 /* NetworkKeySelectionViewController.swift in Sources */,

--- a/Example/nRFMeshProvision/AppDelegate.swift
+++ b/Example/nRFMeshProvision/AppDelegate.swift
@@ -98,10 +98,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // Set up local Elements on the phone.
         let element0 = Element(name: "Primary Element", location: .first, models: [
+            // 4 generic models defined by Bluetooth SIG:
             Model(sigModelId: 0x1000, delegate: GenericOnOffServerDelegate()),
             Model(sigModelId: 0x1002, delegate: GenericLevelServerDelegate()),
             Model(sigModelId: 0x1001, delegate: GenericOnOffClientDelegate()),
-            Model(sigModelId: 0x1003, delegate: GenericLevelClientDelegate())
+            Model(sigModelId: 0x1003, delegate: GenericLevelClientDelegate()),
+            // An simple vendor model:
+            Model(modelId: 0x0001, companyId: 0x0059, delegate: SimpleOnOffClientDelegate())
         ])
         let element1 = Element(name: "Secondary Element", location: .second, models: [
             Model(sigModelId: 0x1000, delegate: GenericOnOffServerDelegate()),

--- a/Example/nRFMeshProvision/Mesh Network/Simple OnOff/Messages/SimpleOnOffGet.swift
+++ b/Example/nRFMeshProvision/Mesh Network/Simple OnOff/Messages/SimpleOnOffGet.swift
@@ -1,0 +1,56 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import nRFMeshProvision
+
+struct SimpleOnOffGet: AcknowledgedStaticVendorMessage {    
+    // The Op Code cosists of:
+    // 0xC0-0000 - Vendor Op Code bitmask
+    // 0x02-0000 - The Op Code defined by...
+    // 0x00-5900 - Nordic Semiconductor ASA company ID (in Little Endian) as defined here:
+    //             https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/
+    static let opCode: UInt32 = 0xC25900
+    static let responseType: StaticMeshMessage.Type = SimpleOnOffStatus.self
+    
+    var parameters: Data? {
+        return Data()
+    }
+    
+    init() {
+    }
+    
+    init?(parameters: Data) {
+        guard parameters.count == 0 else {
+            return nil
+        }
+    }
+    
+}

--- a/Example/nRFMeshProvision/Mesh Network/Simple OnOff/Messages/SimpleOnOffSet.swift
+++ b/Example/nRFMeshProvision/Mesh Network/Simple OnOff/Messages/SimpleOnOffSet.swift
@@ -1,0 +1,61 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import nRFMeshProvision
+
+struct SimpleOnOffSet: AcknowledgedStaticVendorMessage {
+    // The Op Code cosists of:
+    // 0xC0-0000 - Vendor Op Code bitmask
+    // 0x01-0000 - The Op Code defined by...
+    // 0x00-5900 - Nordic Semiconductor ASA company ID (in Little Endian) as defined here:
+    //             https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/
+    static let opCode: UInt32 = 0xC15900
+    static let responseType: StaticMeshMessage.Type = SimpleOnOffStatus.self
+    
+    var parameters: Data? {
+        return Data([isOn ? 0x01 : 0x00])
+    }
+    
+    /// The state.
+    let isOn: Bool
+    
+    init(_ isOn: Bool) {
+        self.isOn = isOn
+    }
+    
+    init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        isOn = parameters[0] == 0x01
+    }
+    
+}

--- a/Example/nRFMeshProvision/Mesh Network/Simple OnOff/Messages/SimpleOnOffSetUnacknowledged.swift
+++ b/Example/nRFMeshProvision/Mesh Network/Simple OnOff/Messages/SimpleOnOffSetUnacknowledged.swift
@@ -1,0 +1,60 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import nRFMeshProvision
+
+struct SimpleOnOffSetUnacknowledged: StaticVendorMessage {
+    // The Op Code cosists of:
+    // 0xC0-0000 - Vendor Op Code bitmask
+    // 0x03-0000 - The Op Code defined by...
+    // 0x00-5900 - Nordic Semiconductor ASA company ID (in Little Endian) as defined here:
+    //             https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/
+    static let opCode: UInt32 = 0xC35900
+    
+    var parameters: Data? {
+        return Data([isOn ? 0x01 : 0x00])
+    }
+    
+    /// The state.
+    let isOn: Bool
+    
+    init(_ isOn: Bool) {
+        self.isOn = isOn
+    }
+    
+    init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        isOn = parameters[0] == 0x01
+    }
+    
+}

--- a/Example/nRFMeshProvision/Mesh Network/Simple OnOff/Messages/SimpleOnOffStatus.swift
+++ b/Example/nRFMeshProvision/Mesh Network/Simple OnOff/Messages/SimpleOnOffStatus.swift
@@ -1,0 +1,60 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import nRFMeshProvision
+
+struct SimpleOnOffStatus: StaticVendorMessage {
+    // The Op Code cosists of:
+    // 0xC0-0000 - Vendor Op Code bitmask
+    // 0x04-0000 - The Op Code defined by...
+    // 0x00-5900 - Nordic Semiconductor ASA company ID (in Little Endian) as defined here:
+    //             https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/
+    static let opCode: UInt32 = 0xC45900
+    
+    var parameters: Data? {
+        return Data([isOn ? 0x01 : 0x00])
+    }
+    
+    /// The state.
+    let isOn: Bool
+    
+    init(_ isOn: Bool) {
+        self.isOn = isOn
+    }
+    
+    init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        isOn = parameters[0] == 0x01
+    }
+    
+}

--- a/Example/nRFMeshProvision/Mesh Network/Simple OnOff/SimpleOnOffClientDelegate.swift
+++ b/Example/nRFMeshProvision/Mesh Network/Simple OnOff/SimpleOnOffClientDelegate.swift
@@ -1,0 +1,123 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import nRFMeshProvision
+
+/// This is an implementation of a simple Vendor Model defined in nRF Mesh SDK from
+/// Nordic Semiconductor.
+///
+/// The Simple OnOff Client model can send 3 types of messages:
+/// - 0x01 - Simple OnOff Set
+/// - 0x02 - Simple OnOff Get
+/// - 0x03 - Simple OnOff Set Unacknowledged
+///
+/// and it can receive one status message for Get and Set:
+/// - 0x04 - Simple OnOff Status
+///
+/// Messages in this library are sent using the `MeshNetworkManager`, not
+/// from the Model delegate.
+///
+/// - seeAlso: https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.meshsdk.v3.2.0/md_models_vendor_simple_on_off_README.html?cp=5_2_2_3_1
+class SimpleOnOffClientDelegate: ModelDelegate {
+    let messageTypes: [UInt32 : MeshMessage.Type]
+    let isSubscriptionSupported: Bool = false
+    
+    init() {
+        // This Model Delegate is able to receive SimpleOnOffStatus messages.
+        // It needs to declare the op code and the type in the `messageTypes`
+        // so the library know to what type a message with such op code should
+        // be instantiated.
+        let types: [StaticVendorMessage.Type] = [
+            SimpleOnOffStatus.self
+        ]
+        messageTypes = types.toMap()
+    }
+    
+    func model(_ model: Model,
+               didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
+               from source: Address, sentTo destination: MeshAddress) -> MeshMessage {
+        // This method will never be called for this Model, as the single message
+        // type it supports (defines in `messageTypes`) is unacknowledged.
+        fatalError("What has just happend?")
+    }
+    
+    func model(_ model: Model,
+               didReceiveUnacknowledgedMessage message: MeshMessage,
+               from source: Address, sentTo destination: MeshAddress) {
+        // A Simple OnOff Server may send status messages that do not reply
+        // to any acknowledged messages, for example may publish the state
+        // periodically. Such message will be delivered here if it was configured
+        // to be sent to this Element's Unicast Address.
+        
+        switch message {
+        case let status as SimpleOnOffStatus:
+            let manager = MeshNetworkManager.instance
+            let logger = manager.logger
+            let node = manager.meshNetwork?.node(withAddress: source)
+            let element = node?.element(withAddress: source)
+            let nodeName = node?.name ?? "Unknown Device"
+            let elementName = element != nil ? element?.name ?? "Element \(element!.index + 1)" : "Unknown Element"
+            logger?.log(message: "The Simple OnOff State on \(elementName) on \(nodeName) is now: \(status.isOn)",
+                        ofCategory: .model, withLevel: .application)
+        default:
+            // Other message types will not be delivered here, as the `messageTypes`
+            // map declares only the above one.
+            break
+        }
+    }
+    
+    func model(_ model: Model,
+               didReceiveResponse response: MeshMessage,
+               toAcknowledgedMessage request: AcknowledgedMeshMessage, from source: Address) {
+        // This message for sure did not change the state.
+        let stateNotChanged = request is SimpleOnOffGet
+        
+        // This is where the status for the requests is delivered.
+        switch response {
+        case let status as SimpleOnOffStatus:
+            let manager = MeshNetworkManager.instance
+            let logger = manager.logger
+            let node = manager.meshNetwork?.node(withAddress: source)
+            let element = node?.element(withAddress: source)
+            let nodeName = node?.name ?? "Unknown Device"
+            let verb = stateNotChanged ? "is" : "changed to"
+            let elementName = element != nil ? element?.name ?? "Element \(element!.index + 1)" : "Unknown Element"
+            logger?.log(message: "State of Simple OnOff on \(elementName) on \(nodeName) \(verb): \(status.isOn)",
+                        ofCategory: .model, withLevel: .application)
+        default:
+            // Other message types will not be delivered here, as the `messageTypes`
+            // map declares only the above one.
+            break
+        }
+    }
+    
+    
+}

--- a/Example/nRFMeshProvision/UI/Base.lproj/Control.storyboard
+++ b/Example/nRFMeshProvision/UI/Base.lproj/Control.storyboard
@@ -218,6 +218,60 @@
                                     <outlet property="icon" destination="KSw-i1-MGx" id="iXu-jC-jtn"/>
                                 </connections>
                             </collectionViewCell>
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="00590001" id="XSm-FN-yJm" customClass="SimpleOnOffClientCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
+                                <rect key="frame" x="16" y="330" width="130" height="130"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="WPp-KP-9Qd">
+                                    <rect key="frame" x="0.0" y="0.0" width="130" height="130"/>
+                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <subviews>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="bottom" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="groups_generic_onoff_outline" translatesAutoresizingMaskIntoConstraints="NO" id="w88-ff-jaJ">
+                                            <rect key="frame" x="0.0" y="0.0" width="130" height="72"/>
+                                            <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                                        </imageView>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Oib-i6-1MV">
+                                            <rect key="frame" x="0.0" y="82" width="65" height="48"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="48" id="Chc-EM-btV"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                            <state key="normal" title="ON"/>
+                                            <connections>
+                                                <action selector="onTapped:" destination="XSm-FN-yJm" eventType="touchUpInside" id="YwK-ky-gDG"/>
+                                            </connections>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yfd-1S-qki">
+                                            <rect key="frame" x="65" y="82" width="65" height="48"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="48" id="0cz-uc-R2g"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                            <state key="normal" title="OFF"/>
+                                            <connections>
+                                                <action selector="offTapped:" destination="XSm-FN-yJm" eventType="touchUpInside" id="yan-NY-uui"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                    <color key="backgroundColor" cocoaTouchSystemColor="tableCellGroupedBackgroundColor"/>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="Oib-i6-1MV" secondAttribute="bottom" id="2wm-ak-vFv"/>
+                                        <constraint firstItem="w88-ff-jaJ" firstAttribute="leading" secondItem="WPp-KP-9Qd" secondAttribute="leading" id="8Hl-9r-NDn"/>
+                                        <constraint firstAttribute="trailing" secondItem="Oib-i6-1MV" secondAttribute="trailing" multiplier="2" id="OYd-l5-RW1"/>
+                                        <constraint firstItem="Yfd-1S-qki" firstAttribute="leading" secondItem="Oib-i6-1MV" secondAttribute="trailing" id="R4f-5W-7WM"/>
+                                        <constraint firstAttribute="trailing" secondItem="w88-ff-jaJ" secondAttribute="trailing" id="Rbn-LI-VsB"/>
+                                        <constraint firstAttribute="trailing" secondItem="Yfd-1S-qki" secondAttribute="trailing" id="UyQ-PH-gtv"/>
+                                        <constraint firstAttribute="bottom" secondItem="w88-ff-jaJ" secondAttribute="bottom" multiplier="1.8" id="ejr-4y-s2m"/>
+                                        <constraint firstAttribute="bottom" secondItem="Yfd-1S-qki" secondAttribute="bottom" id="nL0-Vj-fX9"/>
+                                        <constraint firstItem="w88-ff-jaJ" firstAttribute="top" secondItem="WPp-KP-9Qd" secondAttribute="top" id="uHe-6k-IU5"/>
+                                        <constraint firstItem="Oib-i6-1MV" firstAttribute="leading" secondItem="WPp-KP-9Qd" secondAttribute="leading" id="z6W-U8-9d9"/>
+                                    </constraints>
+                                </collectionViewCellContentView>
+                                <connections>
+                                    <outlet property="icon" destination="w88-ff-jaJ" id="AeB-UF-WWR"/>
+                                    <outlet property="offButton" destination="Yfd-1S-qki" id="H6P-SF-yRO"/>
+                                    <outlet property="onButton" destination="Oib-i6-1MV" id="9FY-bI-yWC"/>
+                                </connections>
+                            </collectionViewCell>
                         </cells>
                         <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" reuseIdentifier="element" id="NIO-oH-X2Q" customClass="ElementSectionView" customModule="nRFMeshProvision_Example" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="50"/>

--- a/Example/nRFMeshProvision/View Controllers/Control/ControlViewCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Control/ControlViewCell.swift
@@ -124,7 +124,7 @@ class ControlViewController: ProgressCollectionViewController {
         let section = sections[indexPath.section]
         let model = section.models[indexPath.row]
         let element = model.parentElement!
-        let name = model.name ?? "Unknown Model"
+        let name = model.isSimpleOnOffClient ? "Simple OnOff Client" : model.name ?? "Unknown Model"
         var message: String?
         if !model.subscriptions.isEmpty {
             let groups = model.subscriptions.map({ $0.name }).joined(separator: ", ")
@@ -203,12 +203,17 @@ private extension Model {
         return modelIdentifier == 0x1000 ||
                modelIdentifier == 0x1001 ||
                modelIdentifier == 0x1002 ||
-               modelIdentifier == 0x1003
+               modelIdentifier == 0x1003 ||
+               (modelIdentifier == 0x0001 && companyIdentifier == 0x0059)
     }
     
     var modelId: UInt32 {
         let companyId = isBluetoothSIGAssigned ? 0 : companyIdentifier!
         return (UInt32(companyId) << 16) | UInt32(modelIdentifier)
+    }
+    
+    var isSimpleOnOffClient: Bool {
+        return modelIdentifier == 0x0001 && companyIdentifier == 0x0059
     }
     
 }

--- a/Example/nRFMeshProvision/View Controllers/Control/Model/SimpleOnOffClientCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Control/Model/SimpleOnOffClientCell.swift
@@ -1,0 +1,67 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import UIKit
+import nRFMeshProvision
+
+class SimpleOnOffClientCell: BaseModelControlCell<SimpleOnOffClientDelegate> {
+    
+    @IBOutlet weak var icon: UIImageView!
+    @IBOutlet weak var onButton: UIButton!
+    @IBAction func onTapped(_ sender: UIButton) {
+        publishSimpleOnOffMessage(turnOn: true)
+    }
+    @IBOutlet weak var offButton: UIButton!
+    @IBAction func offTapped(_ sender: UIButton) {
+        publishSimpleOnOffMessage(turnOn: false)
+    }
+    
+    override func setup(_ model: SimpleOnOffClientDelegate?) {
+        // On iOS 12.x tinted icons are initially black.
+        // Forcing adjustment mode fixes the bug.
+        icon.tintAdjustmentMode = .normal
+        
+        let localProvisioner = MeshNetworkManager.instance.meshNetwork?.localProvisioner
+        let isEnabled = localProvisioner?.hasConfigurationCapabilities ?? false
+        
+        onButton.isEnabled = isEnabled
+        offButton.isEnabled = isEnabled
+    }
+}
+
+private extension SimpleOnOffClientCell {
+    
+    func publishSimpleOnOffMessage(turnOn: Bool) {
+        let label = turnOn ? "Turning ON..." : "Turning OFF..."
+        delegate?.publish(SimpleOnOffSetUnacknowledged(turnOn),
+                          description: label, fromModel: model)
+    }
+    
+}


### PR DESCRIPTION
This PR adds a simple vendor model support to the sample app.
It is based on Simple On Off model from nRF Mesh SDK 3.2: https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.meshsdk.v3.2.0/md_models_vendor_simple_on_off_README.html?cp=5_2_2_3_1