### PR TITLE
Fixing MTU and Proxy filter related issues

### DIFF
--- a/Example/nRFMeshProvision/Mesh Network/NetworkConnection.swift
+++ b/Example/nRFMeshProvision/Mesh Network/NetworkConnection.swift
@@ -93,6 +93,9 @@ class NetworkConnection: NSObject, Bearer {
         }
         set {
             UserDefaults.standard.set(newValue, forKey: connectionModeKey)
+            if newValue && isStarted && centralManager.state == .poweredOn {
+                centralManager.scanForPeripherals(withServices: [MeshProxyService.uuid], options: nil)
+            }
         }
     }
     
@@ -102,7 +105,7 @@ class NetworkConnection: NSObject, Bearer {
         super.init()
         centralManager.delegate = self
         
-        // By dafult the connection mode is automatic.
+        // By default, the connection mode is automatic.
         UserDefaults.standard.register(defaults: [connectionModeKey : true])
     }
     

--- a/Example/nRFMeshProvision/View Controllers/Groups/BottomSheetViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Groups/BottomSheetViewController.swift
@@ -57,7 +57,7 @@ class BottomSheetViewController: UITableViewController {
         let cell = tableView.dequeueReusableCell(withIdentifier: "item", for: indexPath)
         let model = models[indexPath.row]
         let element = model.parentElement!
-        cell.textLabel?.text = "\(model.parentElement.name ?? "Element \(element.index + 1)")"
+        cell.textLabel?.text = "\(model.parentElement?.name ?? "Element \(element.index + 1)")"
         cell.detailTextLabel?.text = "\(element.parentNode!.name ?? "Unknown node")"
         return cell
     }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ConfigurationViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ConfigurationViewController.swift
@@ -436,7 +436,7 @@ extension ConfigurationViewController: MeshNetworkDelegate {
             }
             return
         }
-        // Is the message targetting the current Node?
+        // Is the message targeting the current Node?
         guard node.unicastAddress == source else {
             return
         }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ElementViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ElementViewController.swift
@@ -163,7 +163,7 @@ extension ElementViewController: MeshNetworkDelegate {
             navigationController?.popToRootViewController(animated: true)
             return
         }
-        // Is the message targetting the current Node?
+        // Is the message targeting the current Node?
         guard element.unicastAddress == source else {
             return
         }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/ModelViewCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/ModelViewCell.swift
@@ -97,7 +97,7 @@ class ModelViewCell: UITableViewCell {
     }
     
     /// A callback called when an unsegmented message was sent to the
-    /// `transmitter`, or when all segments of a segmented message targetting
+    /// `transmitter`, or when all segments of a segmented message targeting
     /// a Unicast Address were acknowledged by the target Node.
     ///
     /// - parameters:

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelBindAppKeyViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelBindAppKeyViewController.swift
@@ -115,8 +115,10 @@ private extension ModelBindAppKeyViewController {
             return
         }
         let selectedAppKey = keys[selectedIndexPath.row]
+        guard let message = ConfigModelAppBind(applicationKey: selectedAppKey, to: self.model) else {
+            return
+        }
         start("Binding Application Key...") {
-            let message = ConfigModelAppBind(applicationKey: selectedAppKey, to: self.model)
             return try MeshNetworkManager.instance.send(message, to: self.model)
         }
     }
@@ -144,7 +146,7 @@ extension ModelBindAppKeyViewController: MeshNetworkDelegate {
             return
         }
         // Is the message targetting the current Node?
-        guard model.parentElement.parentNode!.unicastAddress == source else {
+        guard model.parentElement?.parentNode?.unicastAddress == source else {
             return
         }
         

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelBindAppKeyViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelBindAppKeyViewController.swift
@@ -145,7 +145,7 @@ extension ModelBindAppKeyViewController: MeshNetworkDelegate {
             }
             return
         }
-        // Is the message targetting the current Node?
+        // Is the message targeting the current Node?
         guard model.parentElement?.parentNode?.unicastAddress == source else {
             return
         }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
@@ -447,7 +447,7 @@ extension ModelViewController: MeshNetworkDelegate {
             }
             return
         }
-        // Is the message targetting the current Node or Model?
+        // Is the message targeting the current Node or Model?
         guard model.parentElement?.unicastAddress == source ||
              (model.parentElement?.parentNode!.unicastAddress == source
                 && message is ConfigMessage) else {

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
@@ -390,7 +390,9 @@ private extension ModelViewController {
     }
     
     func reloadPublication() {
-        let message = ConfigModelPublicationGet(for: model)
+        guard let message = ConfigModelPublicationGet(for: model) else {
+            return
+        }
         send(message, description: "Reading Publication settings...")
     }
     
@@ -406,13 +408,17 @@ private extension ModelViewController {
     ///
     /// - parameter applicationKey: The Application Key to unbind.
     func unbindApplicationKey(_ applicationKey: ApplicationKey) {
-        let message = ConfigModelAppUnbind(applicationKey: applicationKey, to: model)
+        guard let message = ConfigModelAppUnbind(applicationKey: applicationKey, to: model) else {
+            return
+        }
         send(message, description: "Unbinding Application Key...")
     }
     
     /// Removes the publicaton from the model.
     func removePublication() {
-        let message = ConfigModelPublicationSet(disablePublicationFor: model)
+        guard let message = ConfigModelPublicationSet(disablePublicationFor: model) else {
+            return
+        }
         send(message, description: "Removing Publication...")
     }
     
@@ -442,8 +448,9 @@ extension ModelViewController: MeshNetworkDelegate {
             return
         }
         // Is the message targetting the current Node or Model?
-        guard model.parentElement.unicastAddress == source ||
-            (model.parentElement.parentNode!.unicastAddress == source && message is ConfigMessage) else {
+        guard model.parentElement?.unicastAddress == source ||
+             (model.parentElement?.parentNode!.unicastAddress == source
+                && message is ConfigMessage) else {
             return
         }
         

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeAddAppKeyViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeAddAppKeyViewController.swift
@@ -136,7 +136,7 @@ extension NodeAddAppKeyViewController: MeshNetworkDelegate {
             }
             return
         }
-        // Is the message targetting the current Node?
+        // Is the message targeting the current Node?
         guard node.unicastAddress == source else {
             return
         }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeAddNetworkKeyViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeAddNetworkKeyViewController.swift
@@ -134,7 +134,7 @@ extension NodeAddNetworkKeyViewController: MeshNetworkDelegate {
             }
             return
         }
-        // Is the message targetting the current Node?
+        // Is the message targeting the current Node?
         guard node.unicastAddress == source else {
             return
         }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeAppKeysViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeAppKeysViewController.swift
@@ -179,7 +179,7 @@ extension NodeAppKeysViewController: MeshNetworkDelegate {
             }
             return
         }
-        // Is the message targetting the current Node?
+        // Is the message targeting the current Node?
         guard node.unicastAddress == source else {
             return
         }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeNetworkKeysViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeNetworkKeysViewController.swift
@@ -180,7 +180,7 @@ extension NodeNetworkKeysViewController: MeshNetworkDelegate {
             }
             return
         }
-        // Is the message targetting the current Node?
+        // Is the message targeting the current Node?
         guard node.unicastAddress == source else {
             return
         }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationViewController.swift
@@ -401,7 +401,7 @@ extension SetPublicationViewController: MeshNetworkDelegate {
             return
         }
         // Is the message targetting the current Node?
-        guard model.parentElement.parentNode!.unicastAddress == source else {
+        guard model.parentElement?.parentNode?.unicastAddress == source else {
             return
         }
         

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationViewController.swift
@@ -400,7 +400,7 @@ extension SetPublicationViewController: MeshNetworkDelegate {
             }
             return
         }
-        // Is the message targetting the current Node?
+        // Is the message targeting the current Node?
         guard model.parentElement?.parentNode?.unicastAddress == source else {
             return
         }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SubscribeViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SubscribeViewController.swift
@@ -146,7 +146,7 @@ extension SubscribeViewController: MeshNetworkDelegate {
             return
         }
         // Is the message targetting the current Node?
-        guard model.parentElement.parentNode!.unicastAddress == source else {
+        guard model.parentElement?.parentNode?.unicastAddress == source else {
             return
         }
         

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SubscribeViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SubscribeViewController.swift
@@ -145,7 +145,7 @@ extension SubscribeViewController: MeshNetworkDelegate {
             }
             return
         }
-        // Is the message targetting the current Node?
+        // Is the message targeting the current Node?
         guard model.parentElement?.parentNode?.unicastAddress == source else {
             return
         }

--- a/nRFMeshProvision/Classes/Bearer/GATT/BaseGattProxyBearer.swift
+++ b/nRFMeshProvision/Classes/Bearer/GATT/BaseGattProxyBearer.swift
@@ -109,7 +109,7 @@ open class BaseGattProxyBearer<Service: MeshService>: NSObject, Bearer, CBCentra
     }
     
     open func close() {
-        if basePeripheral.state == .connected || basePeripheral?.state == .connecting {
+        if basePeripheral?.state == .connected || basePeripheral?.state == .connecting {
             logger?.v(.bearer, "Cancelling connection...")
             centralManager.cancelPeripheralConnection(basePeripheral)            
         }

--- a/nRFMeshProvision/Classes/Layers/Access Layer/AccessLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Access Layer/AccessLayer.swift
@@ -362,7 +362,7 @@ private extension AccessLayer {
                         }
                         // Deliver the message to the Model if it was signed with an
                         // Application Key bound to this Model and the message is
-                        // targetting this Element, or the Model is subscribed to the
+                        // targeting this Element, or the Model is subscribed to the
                         // destination address.
                         if model.isBoundTo(keySet.applicationKey) && (
                             accessPdu.destination.address == Address.allNodes ||
@@ -388,7 +388,7 @@ private extension AccessLayer {
                let delegate = configurationServerModel.delegate,
                let configMessage = delegate.decode(accessPdu) {
                 newMessage = configMessage
-                // Is this message targetting the local Node?
+                // Is this message targeting the local Node?
                 if accessPdu.destination.address == firstElement.unicastAddress {
                     logger?.i(.foundationModel, "\(configMessage) received from: \(accessPdu.source.hex)")
                     if let response = delegate.model(configurationServerModel, didReceiveMessage: configMessage,
@@ -407,7 +407,7 @@ private extension AccessLayer {
                       let delegate = configurationClientModel.delegate,
                       let configMessage = delegate.decode(accessPdu) {
                 newMessage = configMessage
-                // Is this message targetting the local Node?
+                // Is this message targeting the local Node?
                 if accessPdu.destination.address == firstElement.unicastAddress {
                     logger?.i(.foundationModel, "\(configMessage) received from: \(accessPdu.source.hex)")
                     if let response = delegate.model(configurationClientModel, didReceiveMessage: configMessage,

--- a/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationServerHandler.swift
+++ b/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationServerHandler.swift
@@ -83,7 +83,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) -> MeshMessage {
-        let localNode = model.parentElement.parentNode!
+        let localNode = model.parentElement!.parentNode!
         
         switch request {
             
@@ -337,7 +337,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
                         return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidAddress)
                     }
                 }
-                return ConfigModelSubscriptionStatus(confirmAdding: group!, to: model)
+                return ConfigModelSubscriptionStatus(confirmAdding: group!, to: model)!
             } else {
                 return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidModel)
             }
@@ -366,7 +366,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
                         return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidAddress)
                     }
                 }
-                return ConfigModelSubscriptionStatus(confirmAdding: group!, to: model)
+                return ConfigModelSubscriptionStatus(confirmAdding: group!, to: model)!
             } else {
                 return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidModel)
             }
@@ -378,7 +378,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
                     return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidAddress)
                 }
                 model.unsubscribe(from: request.address)
-                return ConfigModelSubscriptionStatus(confirmDeleting: request.address, from: model)
+                return ConfigModelSubscriptionStatus(confirmDeleting: request.address, from: model)!
             } else {
                 return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidModel)
             }
@@ -402,7 +402,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
                         return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidAddress)
                     }
                 }
-                return ConfigModelSubscriptionStatus(confirmAdding: group!, to: model)
+                return ConfigModelSubscriptionStatus(confirmAdding: group!, to: model)!
             } else {
                 return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidModel)
             }
@@ -428,7 +428,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
                         return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidAddress)
                     }
                 }
-                return ConfigModelSubscriptionStatus(confirmAdding: group!, to: model)
+                return ConfigModelSubscriptionStatus(confirmAdding: group!, to: model)!
             } else {
                 return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidModel)
             }
@@ -440,7 +440,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
                 if let group = meshNetwork.group(withAddress: address) {
                     model.unsubscribe(from: group)
                 }
-                return ConfigModelSubscriptionStatus(confirmDeleting: address.address, from: model)
+                return ConfigModelSubscriptionStatus(confirmDeleting: address.address, from: model)!
             } else {
                 return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidModel)
             }
@@ -449,7 +449,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
             if let element = localNode.element(withAddress: request.elementAddress),
                let model = element.model(withModelId: request.modelId) {
                 model.unsubscribeFromAll()
-                return ConfigModelSubscriptionStatus(confirmDeletingAllFrom: model)
+                return ConfigModelSubscriptionStatus(confirmDeletingAllFrom: model)!
             } else {
                 return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidModel)
             }

--- a/nRFMeshProvision/Classes/Layers/Lower Transport Layer/LowerTransportLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Lower Transport Layer/LowerTransportLayer.swift
@@ -76,7 +76,7 @@ internal class LowerTransportLayer {
     /// and `sequenceZero` field in 13 least significant bits.
     /// See `UInt32(keyFor:sequenceZero)` below.
     var incompleteTimers: [UInt32 : BackgroundTimer]
-    /// The map of acknowledgment timers. After receiving a segment targetting
+    /// The map of acknowledgment timers. After receiving a segment targeting
     /// any of the Unicast Addresses of one of the Elements of the local Node, a
     /// timer is started that will send the Segment Acknowledgment Message for
     /// segments received until than. The timer is invalidated when the message
@@ -387,7 +387,7 @@ private extension LowerTransportLayer {
                 let allSegments = incompleteSegments.removeValue(forKey: key)!
                 let message = allSegments.reassembled
                 logger?.i(.lowerTransport, "\(message) received")
-                // If the access message was targetting directly the local Provisioner...
+                // If the access message was targeting directly the local Provisioner...
                 if let provisionerNode = meshNetwork.localProvisioner?.node,
                     networkPdu.destination == provisionerNode.unicastAddress {
                     // ...invalidate timers...
@@ -526,7 +526,7 @@ private extension LowerTransportLayer {
               let ttl = segmentTtl[sequenceZero] else {
             return
         }
-        /// Segment Acknowledgment Message is expected when the message is targetting
+        /// Segment Acknowledgment Message is expected when the message is targeting
         /// a Unicast Address.
         var ackExpected: Bool?
         

--- a/nRFMeshProvision/Classes/Layers/Network Layer/NetworkLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/NetworkLayer.swift
@@ -163,7 +163,7 @@ internal class NetworkLayer {
             handle(incomingPdu: networkPdu.pdu, ofType: type)
             
             if isLocalUnicastAddress(networkPdu.destination) {
-                // No need to send messages targetting local Unicast Addresses.
+                // No need to send messages targeting local Unicast Addresses.
                 return
             }
             // If the message was sent locally, don't report Bearer closer error.

--- a/nRFMeshProvision/Classes/Layers/Upper Transport Layer/HeartbeatMessage.swift
+++ b/nRFMeshProvision/Classes/Layers/Upper Transport Layer/HeartbeatMessage.swift
@@ -69,7 +69,7 @@ internal struct HearbeatMessage {
     /// - parameter features:    Currently active features of the node.
     /// - parameter source:      The source address.
     /// - parameter destination: The destination address.
-    init(withInitialTtl ttl: UInt8, andFeatures features: Features, from source: Address, targetting destination: Address) {
+    init(withInitialTtl ttl: UInt8, andFeatures features: Features, from source: Address, targeting destination: Address) {
         self.opCode = 0x0A
         self.initTtl = ttl
         self.features = features

--- a/nRFMeshProvision/Classes/Layers/Upper Transport Layer/UpperTransportLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Upper Transport Layer/UpperTransportLayer.swift
@@ -44,7 +44,7 @@ internal class UpperTransportLayer {
     /// Upper Transport PDU to that destination has been either completed
     /// or cancelled.
     ///
-    /// This map contains queues of messages targetting each destination.
+    /// This map contains queues of messages targeting each destination.
     private var queues: [Address : [(pdu: UpperTransportPdu, ttl: UInt8?, networkKey: NetworkKey)]]
     
     init(_ networkManager: NetworkManager) {

--- a/nRFMeshProvision/Classes/Mesh API/MeshNetwork+Nodes.swift
+++ b/nRFMeshProvision/Classes/Mesh API/MeshNetwork+Nodes.swift
@@ -88,7 +88,7 @@ public extension MeshNetwork {
     ///            this mesh network, `false` otherwise.
     func matches(networkId: Data) -> Bool {
         return networkKeys.contains {
-            $0.networkId == networkId
+            $0.networkId == networkId || $0.oldNetworkId == networkId
         }
     }
     

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelAppBind.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelAppBind.swift
@@ -48,9 +48,12 @@ public struct ConfigModelAppBind: AcknowledgedConfigMessage, ConfigAppKeyMessage
     public let modelIdentifier: UInt16
     public let companyIdentifier: UInt16?
     
-    public init(applicationKey: ApplicationKey, to model: Model) {
+    public init?(applicationKey: ApplicationKey, to model: Model) {
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
         self.applicationKeyIndex = applicationKey.index
-        self.elementAddress = model.parentElement.unicastAddress
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelAppUnbind.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelAppUnbind.swift
@@ -48,9 +48,12 @@ public struct ConfigModelAppUnbind: AcknowledgedConfigMessage, ConfigAppKeyMessa
     public let modelIdentifier: UInt16
     public let companyIdentifier: UInt16?
     
-    public init(applicationKey: ApplicationKey, to model: Model) {
+    public init?(applicationKey: ApplicationKey, to model: Model) {
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
         self.applicationKeyIndex = applicationKey.index
-        self.elementAddress = model.parentElement.unicastAddress
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelPublicationGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelPublicationGet.swift
@@ -47,8 +47,11 @@ public struct ConfigModelPublicationGet: AcknowledgedConfigMessage, ConfigAnyMod
     public let modelIdentifier: UInt16
     public let companyIdentifier: UInt16?
     
-    public init(for model: Model) {
-        self.elementAddress = model.parentElement.unicastAddress
+    public init?(for model: Model) {
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelPublicationSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelPublicationSet.swift
@@ -59,15 +59,21 @@ public struct ConfigModelPublicationSet: AcknowledgedConfigMessage, ConfigAnyMod
             // ConfigModelPublicationVirtualAddressSet should be used instead.
             return nil
         }
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
         self.publish = publish
-        self.elementAddress = model.parentElement.unicastAddress
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }
     
-    public init(disablePublicationFor model: Model) {
+    public init?(disablePublicationFor model: Model) {
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
         self.publish = Publish()
-        self.elementAddress = model.parentElement.unicastAddress
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelPublicationVirtualAddressSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelPublicationVirtualAddressSet.swift
@@ -60,8 +60,11 @@ public struct ConfigModelPublicationVirtualAddressSet: AcknowledgedConfigMessage
             // ConfigModelPublicationSet should be used instead.
             return nil
         }
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
         self.publish = publish
-        self.elementAddress = model.parentElement.unicastAddress
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionAdd.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionAdd.swift
@@ -53,8 +53,11 @@ public struct ConfigModelSubscriptionAdd: AcknowledgedConfigMessage, ConfigAddre
             // ConfigModelSubscriptionVirtualAddressAdd should be used instead.
             return nil
         }
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
         self.address = group.address.address
-        self.elementAddress = model.parentElement.unicastAddress
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionDelete.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionDelete.swift
@@ -53,8 +53,11 @@ public struct ConfigModelSubscriptionDelete: AcknowledgedConfigMessage, ConfigAd
             // ConfigModelSubscriptionVirtualAddressDelete should be used instead.
             return nil
         }
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
         self.address = group.address.address
-        self.elementAddress = model.parentElement.unicastAddress
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionDeleteAll.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionDeleteAll.swift
@@ -47,8 +47,11 @@ public struct ConfigModelSubscriptionDeleteAll: AcknowledgedConfigMessage, Confi
     public let modelIdentifier: UInt16
     public let companyIdentifier: UInt16?
     
-    public init(from model: Model) {
-        self.elementAddress = model.parentElement.unicastAddress
+    public init?(from model: Model) {
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionOverwrite.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionOverwrite.swift
@@ -53,8 +53,11 @@ public struct ConfigModelSubscriptionOverwrite: AcknowledgedConfigMessage, Confi
             // ConfigModelSubscriptionVirtualAddressOverwrite should be used instead.
             return nil
         }
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
         self.address = group.address.address
-        self.elementAddress = model.parentElement.unicastAddress
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionStatus.swift
@@ -72,26 +72,35 @@ public struct ConfigModelSubscriptionStatus: ConfigStatusMessage, ConfigAddressM
         self.status = status
     }
     
-    public init(confirmAdding group: Group, to model: Model) {
+    public init?(confirmAdding group: Group, to model: Model) {
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
         self.status = .success
         self.address = group.address.address
-        self.elementAddress = model.parentElement.unicastAddress
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }
     
-    public init(confirmDeleting address: Address, from model: Model) {
+    public init?(confirmDeleting address: Address, from model: Model) {
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
         self.status = .success
         self.address = address
-        self.elementAddress = model.parentElement.unicastAddress
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }
     
-    public init(confirmDeletingAllFrom model: Model) {
+    public init?(confirmDeletingAllFrom model: Model) {
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
         self.status = .success
         self.address = Address.unassignedAddress
-        self.elementAddress = model.parentElement.unicastAddress
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionVirtualAddressAdd.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionVirtualAddressAdd.swift
@@ -55,8 +55,11 @@ public struct ConfigModelSubscriptionVirtualAddressAdd: AcknowledgedConfigMessag
             // ConfigModelSubscriptionAdd should be used instead.
             return nil
         }
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
         self.virtualLabel = label
-        self.elementAddress = model.parentElement.unicastAddress
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionVirtualAddressDelete.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionVirtualAddressDelete.swift
@@ -55,8 +55,11 @@ public struct ConfigModelSubscriptionVirtualAddressDelete: AcknowledgedConfigMes
             // ConfigModelSubscriptionDelete should be used instead.
             return nil
         }
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
         self.virtualLabel = label
-        self.elementAddress = model.parentElement.unicastAddress
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionVirtualAddressOverwrite.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionVirtualAddressOverwrite.swift
@@ -54,8 +54,11 @@ public struct ConfigModelSubscriptionVirtualAddressOverwrite: AcknowledgedConfig
             // ConfigModelSubscriptionOverwrite should be used instead.
             return nil
         }
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
         self.virtualLabel = label
-        self.elementAddress = model.parentElement.unicastAddress
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = model.companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigSIGModelAppGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigSIGModelAppGet.swift
@@ -46,7 +46,10 @@ public struct ConfigSIGModelAppGet: AcknowledgedConfigMessage, ConfigModelMessag
             // Use ConfigVendorModelAppGet instead.
             return nil
         }
-        self.elementAddress = model.parentElement.unicastAddress
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
     }
     

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigSIGModelSubscriptionGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigSIGModelSubscriptionGet.swift
@@ -46,7 +46,10 @@ public struct ConfigSIGModelSubscriptionGet: AcknowledgedConfigMessage, ConfigMo
             // Use ConfigVendorModelSubscriptionGet instead.
             return nil
         }
-        self.elementAddress = model.parentElement.unicastAddress
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
     }
     

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigVendorModelAppGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigVendorModelAppGet.swift
@@ -47,7 +47,10 @@ public struct ConfigVendorModelAppGet: AcknowledgedConfigMessage, ConfigVendorMo
             // Use ConfigSIGModelAppGet instead.
             return nil
         }
-        self.elementAddress = model.parentElement.unicastAddress
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigVendorModelSubscriptionGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigVendorModelSubscriptionGet.swift
@@ -47,7 +47,10 @@ public struct ConfigVendorModelSubscriptionGet: AcknowledgedConfigMessage, Confi
             // Use ConfigSIGModelSubscriptionGet instead.
             return nil
         }
-        self.elementAddress = model.parentElement.unicastAddress
+        guard let elementAddress = model.parentElement?.unicastAddress else {
+            return nil
+        }
+        self.elementAddress = elementAddress
         self.modelIdentifier = model.modelIdentifier
         self.companyIdentifier = companyIdentifier
     }

--- a/nRFMeshProvision/Classes/Mesh Model/Model.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Model.swift
@@ -73,7 +73,7 @@ public class Model: Codable {
     public let delegate: ModelDelegate?
     
     /// Parent Element.
-    public internal(set) weak var parentElement: Element!
+    public internal(set) weak var parentElement: Element?
     
     internal init(modelId: UInt32) {
         self.modelId   = modelId

--- a/nRFMeshProvision/Classes/Mesh Model/Model.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Model.swift
@@ -60,7 +60,7 @@ public class Model: Codable {
     /// not known to the local database, and those are not returned.
     /// Use `isSubscribed(to:)` to check other Groups.
     public var subscriptions: [Group] {
-        return parentElement.parentNode?.meshNetwork?.groups
+        return parentElement?.parentNode?.meshNetwork?.groups
             .filter({ subscribe.contains($0._address )}) ?? []
     }
     /// The configuration of this Model's publication.

--- a/nRFMeshProvision/Classes/MeshNetworkDelegate.swift
+++ b/nRFMeshProvision/Classes/MeshNetworkDelegate.swift
@@ -55,7 +55,7 @@ public protocol MeshNetworkDelegate: class {
                             sentFrom source: Address, to destination: Address)
     
     /// A callback called when an unsegmented message was sent to the
-    /// `transmitter`, or when all segments of a segmented message targetting
+    /// `transmitter`, or when all segments of a segmented message targeting
     /// a Unicast Address were acknowledged by the target Node.
     ///
     /// - parameters:
@@ -75,7 +75,7 @@ public protocol MeshNetworkDelegate: class {
     /// the `transmitter` was set to `nil`, or has thrown an exception from
     /// `send(data:ofType)`.
     ///
-    /// For segmented unacknowledged messages targetting a Unicast Address,
+    /// For segmented unacknowledged messages targeting a Unicast Address,
     /// besides that, it may also be called when sending timed out before all of
     /// the segments were acknowledged by the target Node, or when the target
     /// Node is busy and not able to proceed the message at the moment.
@@ -92,7 +92,7 @@ public protocol MeshNetworkDelegate: class {
     /// - `BearerError.bearerClosed` - when the `transmitter` object was net set.
     /// - `LowerTransportError.busy` - when the target Node is busy and can't
     ///   accept the message.
-    /// - `LowerTransportError.timeout` - when the segmented message targetting
+    /// - `LowerTransportError.timeout` - when the segmented message targeting
     ///   a Unicast Address was not acknowledgned before the `retransmissionLimit`
     ///   was reached (for unacknowledged messages only).
     /// - `AccessError.timeout` - when the response for an acknowledged message


### PR DESCRIPTION
This PR fixes the following issues:
1. When Proxy device supports only one address in Proxy Filter, it will add just the 0th Element's Unicast Address. It will also call a new `ProxyFilterDelegate.limitedProxyFilterDetected(maxSize:)` method so user can take an action.
2. It ensures that the device gets disconnected after it's provisioned before reconnecting to it in proxy mode. This ensures that the MTU request is resent by the iDevice. MTU may be different in those 2 modes and some devices start advertising with Node Identity immediately after provisioning is complete, also when they are still connected to the provisioner. The `NetworkConnection` was picking the advertisement and connecting to it in background when the `PBGattBearer` was still connected.
3. Several other issues found.