### PR TITLE
Version 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Changelog
+- **2.2.1**:
+    - API related to "compatible models" removed, as the client and server models do not need to have model IDs differing by 1 (#225).
+    
 - **2.2.0**:
     - Scene messages added.
     - Lightness, CTL and HSL messages added.

--- a/Example/Pods/Target Support Files/nRFMeshProvision/nRFMeshProvision-Info.plist
+++ b/Example/Pods/Target Support Files/nRFMeshProvision/nRFMeshProvision-Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>en</string>
-  <key>CFBundleExecutable</key>
-  <string>${EXECUTABLE_NAME}</string>
-  <key>CFBundleIdentifier</key>
-  <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundleName</key>
-  <string>${PRODUCT_NAME}</string>
-  <key>CFBundlePackageType</key>
-  <string>FMWK</string>
-  <key>CFBundleShortVersionString</key>
-  <string>2.2.0</string>
-  <key>CFBundleSignature</key>
-  <string>????</string>
-  <key>CFBundleVersion</key>
-  <string>${CURRENT_PROJECT_VERSION}</string>
-  <key>NSPrincipalClass</key>
-  <string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.2.1</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${CURRENT_PROJECT_VERSION}</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Example/nRFMeshProvision.xcodeproj/project.pbxproj
+++ b/Example/nRFMeshProvision.xcodeproj/project.pbxproj
@@ -1179,7 +1179,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				LINK_WITH_STANDARD_LIBRARIES = YES;
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				MODULE_NAME = ExampleApp;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -1213,7 +1213,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				LINK_WITH_STANDARD_LIBRARIES = YES;
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.2.1;
 				MODULE_NAME = ExampleApp;
 				OTHER_LDFLAGS = (
 					"$(inherited)",

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
@@ -292,14 +292,14 @@ class ModelViewController: ProgressViewController {
                 let thisNode = thisElement.parentNode!
                 let otherNodes = network.nodes.filter { $0 != thisNode }
                 let elementsWithCompatibleModels = otherNodes.flatMap {
-                    $0.elements.filter({ $0.contains(modelCompatibleWith: self.model, boundTo: applicationKey)})
+                    $0.elements.filter({ $0.contains(modelBoundTo: applicationKey)})
                 }
                 let compatibleModels = elementsWithCompatibleModels.flatMap {
-                    $0.models.filter({ $0.isCompatible(to: self.model) && $0.boundApplicationKeys.contains(applicationKey) })
+                    $0.models.filter({ $0.isBoundTo(applicationKey) })
                 }
                 let boundKeyUsedByOtherNodes = compatibleModels.contains {
-                        $0.publish?.publicationAddress.address == thisElement.unicastAddress &&
-                            $0.publish?.index == applicationKey.index
+                    $0.publish?.publicationAddress.address == thisElement.unicastAddress &&
+                    $0.publish?.index == applicationKey.index
                 }
                 
                 if boundKeyUsedInPublication || boundKeyUsedByOtherNodes {

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationDestinationsViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationDestinationsViewController.swift
@@ -46,9 +46,7 @@ class SetPublicationDestinationsViewController: UITableViewController {
     var selectedApplicationKey: ApplicationKey?
     var selectedDestination: MeshAddress?
     
-    /// List of Elements containing a compatible Model. For example,
-    /// for Generic On/Off Server this list will contain all Elements
-    /// with Genetic On/Off Client.
+    /// List of Elements containing Model bound to selected Application Key.
     private var compatibleElements: [Element]!
     private let specialGroups: [(title: String, address: Address)] = [
         ("All Proxies", Address.allProxies),
@@ -212,10 +210,10 @@ private extension SetPublicationDestinationsViewController {
         rows.append(indexPath)
         selectedKeyIndexPath = indexPath
         
-        // The list of Elements contains Elements with compatible models, that are bound
+        // The list of Elements contains Elements with models, that are bound
         // to the selected key. Changing the key will cause the Elements list to reload.
         // If an Element was selected, it may happen that it also is bound to the
-        // new key, or not. We have either to update the selected index path, or
+        // new key, or not. We either have to update the selected index path, or
         // clear the selection.
         var selectedElementIndex: UInt8?
         if !initial, let indexPath = selectedIndexPath, indexPath.isElementsSection {
@@ -226,7 +224,7 @@ private extension SetPublicationDestinationsViewController {
         let meshNetwork = MeshNetworkManager.instance.meshNetwork!
         compatibleElements = meshNetwork.nodes
             .flatMap({ $0.elements })
-            .filter({ $0.contains(modelCompatibleWith: model, boundTo: key) })
+            .filter({ $0.contains(modelBoundTo: key) })
         
         if let selectedElementIndex = selectedElementIndex {
             if let newRow = compatibleElements.firstIndex(where: { $0.index == selectedElementIndex }) {

--- a/nRFMeshProvision.podspec
+++ b/nRFMeshProvision.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'nRFMeshProvision'
-  s.version          = '2.2.0'
+  s.version          = '2.2.1'
   s.summary          = 'A Bluetooth Mesh library'
   s.description      = <<-DESC
   nRF Mesh is a Bluetooth Mesh compliant library that has many features such as provisioning, configuration and control of Bluetooth Mesh compliant nodes.

--- a/nRFMeshProvision/Classes/Mesh API/Element+Models.swift
+++ b/nRFMeshProvision/Classes/Mesh API/Element+Models.swift
@@ -92,18 +92,14 @@ public extension Element {
         return models.contains(model)
     }
     
-    /// Returns `true` if the Element contains a Model compatible
-    /// with given one. Compatible Models make a pair of Client - Server.
+    /// Returns `true` if the Element contains a Model bound to the
+    /// given Application Key.
     ///
-    /// For example, a compatible Model to Generic On/Off Server is
-    /// Generic On/Off Client, and vice versa.
-    ///
-    /// - parameter model:          The Model, which pair is required.
     /// - parameter applicationKey: The Application Key which the Model
     ///                             must be bound to.
     /// - returns: `True`, if the Element has the matching Model.
-    func contains(modelCompatibleWith model: Model, boundTo applicationKey: ApplicationKey) -> Bool {
-        return models.contains { $0.isCompatible(to: model) && $0.bind.contains(applicationKey.index) }
+    func contains(modelBoundTo applicationKey: ApplicationKey) -> Bool {
+        return models.contains { $0.bind.contains(applicationKey.index) }
     }
     
     /// Returns whether the Element contains any Models that are

--- a/nRFMeshProvision/Classes/Mesh API/Model+Keys.swift
+++ b/nRFMeshProvision/Classes/Mesh API/Model+Keys.swift
@@ -49,4 +49,5 @@ public extension Model {
     func isBoundTo(_ applicationKey: ApplicationKey) -> Bool {
         return bind.contains(applicationKey.index)
     }
+    
 }

--- a/nRFMeshProvision/Classes/Mesh API/Models.swift
+++ b/nRFMeshProvision/Classes/Mesh API/Models.swift
@@ -32,20 +32,6 @@ import Foundation
 
 public extension Model {
     
-    /// Returns whether the given Model is compatible with the one.
-    ///
-    /// A compatible Models create a Client-Server pair. I.e., the
-    /// Generic On/Off Client is compatible to Generic On/Off Server,
-    /// and vice versa. The rule is that the Server Model has an even
-    /// Model ID and the Client Model has Model ID greater by 1.
-    ///
-    /// - parameter model: The Model to compare to.
-    /// - returns: `True`, if the Models are compatible, `false` otherwise.
-    func isCompatible(to model: Model) -> Bool {
-        let compatibleModelId = (modelId % 2 == 0) ? modelId + 1 : modelId - 1
-        return model.modelId == compatibleModelId
-    }
-    
     /// Returns whether the Model is subscribed to the given Group.
     ///
     /// This method may also return `true` if the Group is not known


### PR DESCRIPTION
Bugs fixed:
- The API related to "compatible models" has been removed as it was incorrect. The server and client model IDs do not have to differ by 1. Even the Bluetooth Mesh Model 1.0.1 spec defines some models differently, for example:
![](https://user-images.githubusercontent.com/6576580/69943908-49b73b00-14e6-11ea-86d8-cc065fbd195a.png)
This was reported in #225.