### PR TITLE
Fixed issue with TTL

### DIFF
--- a/nRFMeshProvision/Classes/Layers/Network Layer/NetworkLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/NetworkLayer.swift
@@ -160,7 +160,8 @@ internal class NetworkLayer {
         // Loopback interface.
         if shouldLoopback(networkPdu) {
             handle(incomingPdu: networkPdu.pdu, ofType: type)
-            
+            // Messages sent with TTL = 1 will only be sent locally.
+            guard ttl != 1 else { return }
             if isLocalUnicastAddress(networkPdu.destination) {
                 // No need to send messages targeting local Unicast Addresses.
                 return
@@ -168,6 +169,8 @@ internal class NetworkLayer {
             // If the message was sent locally, don't report Bearer closer error.
             try? transmitter.send(networkPdu.pdu, ofType: type)
         } else {
+            // Messages sent with TTL = 1 may only be sent locally.
+            guard ttl != 1 else { return }
             do {
                 try transmitter.send(networkPdu.pdu, ofType: type)
             } catch {

--- a/nRFMeshProvision/Classes/Mesh Model/MeshNetwork.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/MeshNetwork.swift
@@ -62,7 +62,7 @@ public class MeshNetwork: Codable {
     public internal(set) var applicationKeys: [ApplicationKey]
     /// An array of nodes in the network.
     public internal(set) var nodes: [Node]
-    /// An array of groups in teh network.
+    /// An array of groups in the network.
     public internal(set) var groups: [Group]
     
     /// The IV Index of the mesh network.

--- a/nRFMeshProvision/Classes/Mesh Model/Node.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Node.swift
@@ -436,9 +436,9 @@ public class Node: Codable {
         self.features = try container.decodeIfPresent(NodeFeatures.self, forKey: .features)
         self.secureNetworkBeacon = try container.decodeIfPresent(Bool.self, forKey: .secureNetworkBeacon)
         let ttl = try container.decodeIfPresent(UInt8.self, forKey: .ttl)
-        guard ttl != 1 && (ttl == nil || ttl! <= 127) else {
+        guard ttl == nil || ttl! <= 127 else {
             throw DecodingError.dataCorruptedError(forKey: .ttl, in: container,
-                                                   debugDescription: "Default TTL must be in range 0-127, except 1.")
+                                                   debugDescription: "Default TTL must be in range 0-127.")
         }
         self.ttl = ttl
         self.networkTransmit = try container.decodeIfPresent(NetworkTransmit.self, forKey: .networkTransmit)

--- a/nRFMeshProvision/Classes/Mesh Model/Publish.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Publish.swift
@@ -172,9 +172,9 @@ public struct Publish: Codable {
         self.address = publishAddressAsString
         self.index = try container.decode(KeyIndex.self, forKey: .index)
         let ttl = try container.decode(UInt8.self, forKey: .ttl)
-        guard ttl != 1 && (ttl <= 127 || ttl == 225) else {
+        guard ttl == 255 || ttl <= 127 else {
             throw DecodingError.dataCorruptedError(forKey: .ttl, in: container,
-                                                   debugDescription: "TTL must be in range 0, 2-127 or 255.")
+                                                   debugDescription: "TTL must be in range 0-127 or 255.")
         }
         self.ttl = ttl
         self.period = try container.decode(Int.self, forKey: .period)


### PR DESCRIPTION
This PR fixes an issue with TTL. In some places TTL = 1 was not allowed, but should be. Messages with TTL = 1 can be delivered to local models on given element.
The local Network Layer has been fixed not to send such messages out.