### PR TITLE
Shortcut buttons

### DIFF
--- a/Example/nRFMeshProvision.xcodeproj/project.pbxproj
+++ b/Example/nRFMeshProvision.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		528352B42284139F0097B949 /* ProxyProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528352B32284139F0097B949 /* ProxyProtocol.swift */; };
 		528352BC2285B6150097B949 /* OobSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528352BB2285B6150097B949 /* OobSelector.swift */; };
 		528445C924EEA765002168A1 /* HeartbeatSubscriptionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528445C824EEA765002168A1 /* HeartbeatSubscriptionCell.swift */; };
+		5288153D25125AB600484AF0 /* RootTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5288153C25125AB600484AF0 /* RootTabBarController.swift */; };
 		5288C20423704EF300321ED3 /* ConnectionModeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5288C20323704EF300321ED3 /* ConnectionModeCell.swift */; };
 		5288C2062370571100321ED3 /* ProxySelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5288C2052370571100321ED3 /* ProxySelectorViewController.swift */; };
 		5288C20823705C8D00321ED3 /* ProxyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5288C20723705C8D00321ED3 /* ProxyCell.swift */; };
@@ -230,6 +231,7 @@
 		528352B32284139F0097B949 /* ProxyProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyProtocol.swift; sourceTree = "<group>"; };
 		528352BB2285B6150097B949 /* OobSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OobSelector.swift; sourceTree = "<group>"; };
 		528445C824EEA765002168A1 /* HeartbeatSubscriptionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartbeatSubscriptionCell.swift; sourceTree = "<group>"; };
+		5288153C25125AB600484AF0 /* RootTabBarController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootTabBarController.swift; sourceTree = "<group>"; };
 		5288C20323704EF300321ED3 /* ConnectionModeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionModeCell.swift; sourceTree = "<group>"; };
 		5288C2052370571100321ED3 /* ProxySelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxySelectorViewController.swift; sourceTree = "<group>"; };
 		5288C20723705C8D00321ED3 /* ProxyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyCell.swift; sourceTree = "<group>"; };
@@ -491,6 +493,7 @@
 		52835253227AEC8C0097B949 /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				5288153C25125AB600484AF0 /* RootTabBarController.swift */,
 				529B756C223FE7F1008F1CE7 /* RootViewController.swift */,
 				523F776B22C6324A0030EA6A /* ProgressViewController.swift */,
 				5212152E231554190059FB3D /* ProgressCollectionViewController.swift */,
@@ -948,6 +951,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				529B764722522D37008F1CE7 /* UITableView+EmptyView.swift in Sources */,
+				5288153D25125AB600484AF0 /* RootTabBarController.swift in Sources */,
 				52CD0A55232FC11700A9A181 /* AddressCell.swift in Sources */,
 				52313FEE22EAFB090074325A /* SubscribeViewController.swift in Sources */,
 				5212152B23152A450059FB3D /* SectionView.swift in Sources */,

--- a/Example/nRFMeshProvision/UI/Base.lproj/Main.storyboard
+++ b/Example/nRFMeshProvision/UI/Base.lproj/Main.storyboard
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYb-mK-mH5">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.3" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYb-mK-mH5">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Tab Bar Controller-->
         <scene sceneID="zJB-dB-C0K">
             <objects>
-                <tabBarController title="Tab Bar Controller" id="BYb-mK-mH5" sceneMemberID="viewController">
+                <tabBarController title="Tab Bar Controller" id="BYb-mK-mH5" customClass="RootTabBarController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationItem key="navigationItem" id="uit-TO-OCn"/>
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="ig6-ap-aTu">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="49"/>
@@ -50,7 +50,7 @@
             </objects>
             <point key="canvasLocation" x="134" y="-65"/>
         </scene>
-        <!--ProxyFilter-->
+        <!--Proxy-->
         <scene sceneID="hTx-iH-lEi">
             <objects>
                 <viewControllerPlaceholder storyboardName="Proxy" id="z61-cg-pzs" sceneMemberID="viewController">
@@ -81,6 +81,7 @@
             <point key="canvasLocation" x="169" y="-256"/>
         </scene>
     </scenes>
+    <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
     <resources>
         <image name="tab_control_outline_black_24pt" width="24" height="24"/>
         <image name="tab_filter_outline_black_24pt" width="24" height="24"/>
@@ -88,5 +89,4 @@
         <image name="tab_network_outline_black_24pt" width="24" height="24"/>
         <image name="tab_settings_outline_black_24pt" width="24" height="24"/>
     </resources>
-    <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
 </document>

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelBindAppKeyViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelBindAppKeyViewController.swift
@@ -34,6 +34,8 @@ import nRFMeshProvision
 protocol BindAppKeyDelegate {
     /// This method is called when a new Application Key has been bound to the Model.
     func keyBound()
+    /// This method will present Node's Application Keys configuration screen.
+    func presentNodeApplicationKeys()
 }
 
 class ModelBindAppKeyViewController: ProgressViewController {
@@ -61,9 +63,15 @@ class ModelBindAppKeyViewController: ProgressViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        let presentNodeApplicationKeys = UIButtonAction(title: "Add key") { [weak self] in
+            self?.dismiss(animated: true) { [weak self] in
+                self?.delegate?.presentNodeApplicationKeys()
+            }
+        }
         tableView.setEmptyView(title: "No keys available",
                                message: "Add a new key to the node first.",
-                               messageImage: #imageLiteral(resourceName: "baseline-key"))
+                               messageImage: #imageLiteral(resourceName: "baseline-key"),
+                               action: presentNodeApplicationKeys)
         
         MeshNetworkManager.instance.delegate = self
         

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
@@ -799,6 +799,14 @@ extension ModelViewController: MeshNetworkDelegate {
 
 extension ModelViewController: BindAppKeyDelegate, PublicationDelegate,
                                SubscriptionDelegate, HeartbeatSubscriptionDelegate {
+                                   
+    func presentNodeApplicationKeys() {
+        if let configurationViewController = navigationController?.viewControllers
+                .first(where: { $0 is ConfigurationViewController }) {
+            navigationController?.popToViewController(configurationViewController, animated: true)
+            configurationViewController.performSegue(withIdentifier: "showAppKeys", sender: nil)
+        }
+    }
     
     func keyBound() {
         tableView.reloadSections(.bindings, with: .automatic)

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeAddAppKeyViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeAddAppKeyViewController.swift
@@ -65,9 +65,17 @@ class NodeAddAppKeyViewController: ProgressViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        let presentApplicationKeysSettings = UIButtonAction(title: "Settings") { [weak self] in
+            guard let self = self else { return }
+            let tabBarController = self.presentingViewController as? RootTabBarController
+            self.dismiss(animated: true) {
+                tabBarController?.presentApplicationKeysSettings()
+            }
+        }
         tableView.setEmptyView(title: "No keys available",
                                message: "Go to Settings to create a new key,\nor add a bound Network Key first.",
-                               messageImage: #imageLiteral(resourceName: "baseline-key"))
+                               messageImage: #imageLiteral(resourceName: "baseline-key"),
+                               action: presentApplicationKeysSettings)
         
         MeshNetworkManager.instance.delegate = self
         

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeAddNetworkKeyViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeAddNetworkKeyViewController.swift
@@ -65,9 +65,17 @@ class NodeAddNetworkKeyViewController: ProgressViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        let presentNetworkKeysSettings = UIButtonAction(title: "Settings") { [weak self] in
+            guard let self = self else { return }
+            let tabBarController = self.presentingViewController as? RootTabBarController
+            self.dismiss(animated: true) {
+                tabBarController?.presentNetworkKeysSettings()
+            }
+        }
         tableView.setEmptyView(title: "No keys available",
                                message: "Go to Settings to create a new key.",
-                               messageImage: #imageLiteral(resourceName: "baseline-key"))
+                               messageImage: #imageLiteral(resourceName: "baseline-key"),
+                               action: presentNetworkKeysSettings)
         
         MeshNetworkManager.instance.delegate = self
         

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeStoreSceneViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/NodeStoreSceneViewController.swift
@@ -80,9 +80,17 @@ class NodeStoreSceneViewController: ProgressViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        let presentScenesSettings = UIButtonAction(title: "Settings") { [weak self] in
+            guard let self = self else { return }
+            let tabBarController = self.presentingViewController as? RootTabBarController
+            self.dismiss(animated: true) {
+                tabBarController?.presentScenesSettings()
+            }
+        }
         tableView.setEmptyView(title: "No scenes",
                                message: "Go to Settings to create a new scene.",
-                               messageImage: #imageLiteral(resourceName: "baseline-scene"))
+                               messageImage: #imageLiteral(resourceName: "baseline-scene"),
+                               action: presentScenesSettings)
         
         MeshNetworkManager.instance.delegate = self
         

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SubscribeViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SubscribeViewController.swift
@@ -46,7 +46,11 @@ class SubscribeViewController: ProgressViewController {
         dismiss(animated: true)
     }
     @IBAction func doneTapped(_ sender: UIBarButtonItem) {
-        addSubscription()
+        guard let selectedIndexPath = selectedIndexPath else {
+            return
+        }
+        let group = groups[selectedIndexPath.row]
+        addSubscription(to: group)
     }
     
     // MARK: - Properties
@@ -59,9 +63,17 @@ class SubscribeViewController: ProgressViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        let presentGroups = UIButtonAction(title: "Groups") { [weak self] in
+            guard let self = self else { return }
+            let tabBarController = self.presentingViewController as? RootTabBarController
+            self.dismiss(animated: true) {
+                tabBarController?.presentGroups()
+            }
+        }
         tableView.setEmptyView(title: "No groups",
                                message: "Go to Groups to create a group.",
-                               messageImage: #imageLiteral(resourceName: "baseline-groups"))
+                               messageImage: #imageLiteral(resourceName: "baseline-groups"),
+                               action: presentGroups)
         
         MeshNetworkManager.instance.delegate = self
         
@@ -112,11 +124,7 @@ class SubscribeViewController: ProgressViewController {
 
 private extension SubscribeViewController {
     
-    func addSubscription() {
-        guard let selectedIndexPath = selectedIndexPath else {
-            return
-        }
-        let group = groups[selectedIndexPath.row]
+    func addSubscription(to group: Group) {
         guard let model = model,
               let node = model.parentElement?.parentNode else {
             return

--- a/Example/nRFMeshProvision/View Controllers/RootTabBarController.swift
+++ b/Example/nRFMeshProvision/View Controllers/RootTabBarController.swift
@@ -1,0 +1,125 @@
+//
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import UIKit
+
+class RootTabBarController: UITabBarController {
+    
+    func presentGroups() {
+        selectedIndex = .groupsTabIndex
+        if let rootViewController = selectedViewController as? RootViewController {
+            rootViewController.popToRootViewController(animated: true)
+        }
+    }
+    
+    func presentNetworkKeysSettings() {
+        selectedIndex = .settingsTabIndex
+        if let rootViewController = selectedViewController as? RootViewController {
+            guard let topViewController = rootViewController.topViewController else {
+                return
+            }
+            // If we are in Network Keys View Controller already?
+            if topViewController is NetworkKeysViewController {
+                return
+            }
+            // If we are in Settings?
+            if let settingsViewController = topViewController as? SettingsViewController {
+                // If so, present Net Keys.
+                settingsViewController.performSegue(withIdentifier: "networkKeys", sender: nil)
+            } else {
+                // Else, we need to navigate back to Settings and present Net Keys.
+                topViewController.navigationController?.popViewController(animated: false)
+                if let settingsViewController = topViewController as? SettingsViewController {
+                    settingsViewController.performSegue(withIdentifier: "networkKeys", sender: nil)
+                }
+            }
+        }
+    }
+    
+    func presentApplicationKeysSettings() {
+        selectedIndex = .settingsTabIndex
+        if let rootViewController = selectedViewController as? RootViewController {
+            guard let topViewController = rootViewController.topViewController else {
+                return
+            }
+            // If we are in Application Keys View Controller already?
+            if topViewController is AppKeysViewController {
+                return
+            }
+            // If we are in Settings?
+            if let settingsViewController = topViewController as? SettingsViewController {
+                // If so, present App Keys.
+                settingsViewController.performSegue(withIdentifier: "appKeys", sender: nil)
+            } else {
+                // Else, we need to navigate back to Settings and present App Keys.
+                topViewController.navigationController?.popViewController(animated: false)
+                if let settingsViewController = topViewController as? SettingsViewController {
+                    settingsViewController.performSegue(withIdentifier: "appKeys", sender: nil)
+                }
+            }
+        }
+    }
+    
+    func presentScenesSettings() {
+        selectedIndex = .settingsTabIndex
+        if let rootViewController = selectedViewController as? RootViewController {
+            guard let topViewController = rootViewController.topViewController else {
+                return
+            }
+            // If we are in Scenes View Controller already?
+            if topViewController is ScenesViewController {
+                return
+            }
+            // If we are in Settings?
+            if let settingsViewController = topViewController as? SettingsViewController {
+                // If so, present Scenes.
+                settingsViewController.performSegue(withIdentifier: "scenes", sender: nil)
+            } else {
+                // Else, we need to navigate back to Settings and present Scenes.
+                topViewController.navigationController?.popViewController(animated: false)
+                if let settingsViewController = topViewController as? SettingsViewController {
+                    settingsViewController.performSegue(withIdentifier: "scenes", sender: nil)
+                }
+            }
+        }
+    }
+
+}
+
+private extension Int {
+    
+    static let localNodeTabIndex = 0
+    static let networkTabIndex   = 1
+    static let groupsTabIndex    = 2
+    static let proxyTabIndex     = 3
+    static let settingsTabIndex  = 4
+    
+}


### PR DESCRIPTION
This PR adds shortcut buttons to the sample app. E.g., on the *Node -> Application Keys -> Add new* screen, if no Application Key was left to be added, the text was saying "Got to Settings to add new one". Now you can go there automatically by clicking a button. Simple, but handly.