### PR TITLE
Shortcut buttons, part 2

### DIFF
--- a/Example/nRFMeshProvision/View Controllers/Settings/AppKeysViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Settings/AppKeysViewController.swift
@@ -51,9 +51,27 @@ class AppKeysViewController: UITableViewController, Editable {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        let generate = UIButtonAction(title: "Generate") {
+            self.presentTextAlert(title: "Generate keys",
+                                  message: "Specify number of application keys to generate (max 5):",
+                                  placeHolder: "E.g. 3", type: .numberRequired,
+                                  cancelHandler: nil) { value in
+                guard let network = MeshNetworkManager.instance.meshNetwork,
+                      let number = Int(value), number > 0 else {
+                    return
+                }
+                for i in 0..<min(number, 5) {
+                    let key = Data.random128BitKey()
+                    _ = try? network.add(applicationKey: key, name: "App Key \(i + 1)")
+                }
+                self.tableView.reloadData()
+                self.hideEmptyView()
+            }
+        }
         tableView.setEmptyView(title: "No keys",
                                message: "Click + to add a new key.",
-                               messageImage: #imageLiteral(resourceName: "baseline-key"))
+                               messageImage: #imageLiteral(resourceName: "baseline-key"),
+                               action: generate)
         
         let hasAppKeys = MeshNetworkManager.instance.meshNetwork?.applicationKeys.count ?? 0 > 0
         if !hasAppKeys {

--- a/Example/nRFMeshProvision/View Controllers/Settings/ScenesViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Settings/ScenesViewController.swift
@@ -35,9 +35,29 @@ class ScenesViewController: UITableViewController, Editable {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        let generate = UIButtonAction(title: "Generate") {
+            self.presentTextAlert(title: "Generate scenes",
+                                  message: "Specify number of scenes to generate (max 20):",
+                                  placeHolder: "E.g. 3", type: .numberRequired,
+                                  cancelHandler: nil) { value in
+                guard let network = MeshNetworkManager.instance.meshNetwork,
+                      let number = Int(value), number > 0 else {
+                    return
+                }
+                for _ in 0..<min(number, 20) {
+                    guard let scene = network.nextAvailableScene() else {
+                        break
+                    }
+                    try? network.add(scene: scene, name: "Scene \(scene)")
+                }
+                self.tableView.reloadData()
+                self.hideEmptyView()
+            }
+        }
         tableView.setEmptyView(title: "No scenes",
                                message: "Click + to add a new scene.",
-                               messageImage: #imageLiteral(resourceName: "baseline-scene"))
+                               messageImage: #imageLiteral(resourceName: "baseline-scene"),
+                               action: generate)
         
         let hasScenes = MeshNetworkManager.instance.meshNetwork?.scenes.count ?? 0 > 0
         if !hasScenes {

--- a/nRFMeshProvision/Classes/Mesh API/MeshNetwork+Address.swift
+++ b/nRFMeshProvision/Classes/Mesh API/MeshNetwork+Address.swift
@@ -73,6 +73,24 @@ public extension MeshNetwork {
                                            elementsUsing: provisioner)
     }
     
+    /// Returns the next available Unicast Address from the local Provisioner's range
+    /// that can be assigned to a new node with given number of elements.
+    /// The 0'th element is identified by the node's Unicast Address.
+    /// Each following element is identified by a subsequent Unicast Address.
+    ///
+    /// - parameters:
+    ///   - offset: Minimum Unicast Address to be assigned.
+    ///   - elementsCount: The number of Node's elements. Each element will be
+    ///                    identified by a subsequent Unicast Address.
+    /// - returns: The next available Unicast Address that can be assigned to a node,
+    ///            or `nil`, if there are no more available addresses in the allocated range.
+    func nextAvailableUnicastAddress(startingFrom offset: Address = Address.minUnicastAddress,
+                                     forElementsCount elementsCount: UInt8) -> Address? {
+        return localProvisioner.map {
+            nextAvailableUnicastAddress(startingFrom: offset, for: elementsCount, elementsUsing: $0)
+        } ?? nil
+    }
+    
     /// Returns the next available Unicast Address from the Provisioner's range
     /// that can be assigned to a new node with given number of elements.
     /// The 0'th element is identified by the node's Unicast Address.
@@ -192,6 +210,15 @@ public extension MeshNetwork {
         }
         // No address was found :(
         return nil
+    }
+    
+    /// Returns the next available Group Address from the local Provisioner's range
+    /// that can be assigned to a new Group.
+    ///
+    /// - returns: The next available Group Address that can be assigned to a new Group,
+    ///            or `nil`, if there are no more available addresses in the allocated range.
+    func nextAvailableGroupAddress() -> Address? {
+        return localProvisioner.map { nextAvailableGroupAddress(for: $0) } ?? nil
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh API/MeshNetwork+Keys.swift
+++ b/nRFMeshProvision/Classes/Mesh API/MeshNetwork+Keys.swift
@@ -65,6 +65,7 @@ public extension MeshNetwork {
     ///           there isn't any Network Key to bind the new key to
     ///           or the assigned Key Index is out of range.
     /// - seeAlso: `nextAvailableApplicationKeyIndex`
+    @discardableResult
     func add(applicationKey: Data, withIndex index: KeyIndex? = nil, name: String) throws -> ApplicationKey {
         guard applicationKey.count == 16 else {
             throw MeshNetworkError.invalidKey
@@ -138,6 +139,7 @@ public extension MeshNetwork {
     /// - throws: This method throws an error if the key is not 128-bit long
     ///           or the assigned Key Index is out of range.
     /// - seeAlso: `nextAvailableNetworkKeyIndex`
+    @discardableResult
     func add(networkKey: Data, withIndex index: KeyIndex? = nil, name: String) throws -> NetworkKey {
         guard networkKey.count == 16 else {
             throw MeshNetworkError.invalidKey

--- a/nRFMeshProvision/Classes/Mesh API/MeshNetwork+Scenes.swift
+++ b/nRFMeshProvision/Classes/Mesh API/MeshNetwork+Scenes.swift
@@ -122,4 +122,13 @@ public extension MeshNetwork {
         return nil
     }
     
+    /// Returns the next available Scene number from the local Provisioner's range
+    /// that can be assigned to a new Scene.
+    ///
+    /// - returns: The next available Scene number that can be assigned to a new Scene,
+    ///            or `nil`, if there are no more available numbers in the allocated range.
+    func nextAvailableScene() -> SceneNumber? {
+        return localProvisioner.map { nextAvailableScene(for: $0) } ?? nil
+    }
+    
 }


### PR DESCRIPTION
This PR adds 2 additional shortcut buttons that can be used to generate App keys and Scenes automatically. When pressed, users can specify number of items to be generated.