### PR TITLE
Sequence number related improvements

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		51DF58B92722EE2CB876F4859B449F54 /* ConfigModelSubscriptionVirtualAddressAdd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04AB807F1DC543A41014F525360355B2 /* ConfigModelSubscriptionVirtualAddressAdd.swift */; };
 		51F397463EBD18BCD543C64FE1313C67 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E749F10DEF7618DE8B1B122A5D982D /* Model.swift */; };
 		5205603EB13F6ED8D95F47779C169397 /* ConfigNetworkTransmitStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E287AB63C5554D1EB6D838BE420837 /* ConfigNetworkTransmitStatus.swift */; };
+		52E8FF9825BB5EE90087B2A6 /* UserDefaults+SeqAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E8FF9725BB5EE90087B2A6 /* UserDefaults+SeqAuth.swift */; };
 		539B7D307CE6DAD58135573C2BD34CF9 /* NetworkKey+MeshNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7FD4C6B9026F5AB76D7B586E2CF3AA /* NetworkKey+MeshNetwork.swift */; };
 		5591B4463258E51A0030AA284239437D /* KeySet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B4EFEACAC71F2189FC119255429A54 /* KeySet.swift */; };
 		5622C14B59036EBF6FDC69CF7BD7C09E /* LightCTLStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E2C3EA1ED307F08BF0FC773A8C1616 /* LightCTLStatus.swift */; };
@@ -498,6 +499,7 @@
 		52473EF190638F8B70BB7B106E956029 /* pem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = pem.h; path = ios/include/openssl/pem.h; sourceTree = "<group>"; };
 		52513CFCF2954BAD169F4ECFE23DE170 /* LightHSLDefaultSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightHSLDefaultSet.swift; sourceTree = "<group>"; };
 		52B112AB6B61A75C4468FE0B87BC2E08 /* GenericLevelStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericLevelStatus.swift; sourceTree = "<group>"; };
+		52E8FF9725BB5EE90087B2A6 /* UserDefaults+SeqAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+SeqAuth.swift"; sourceTree = "<group>"; };
 		54B5F2AC51F4BA0659354EDFEA843669 /* ConfigAppKeyList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigAppKeyList.swift; sourceTree = "<group>"; };
 		54C79392C23E6C6C80BADBB1128D2385 /* MeshNetwork+Address.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MeshNetwork+Address.swift"; sourceTree = "<group>"; };
 		55E4A9034F3927884CB305A3BD8CACA3 /* ControlMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ControlMessage.swift; sourceTree = "<group>"; };
@@ -946,6 +948,7 @@
 				3BDD5855AC3D43A856F2CEF487F54C9F /* KeyedDecodingContainer+Legacy.swift */,
 				D6583A2A54196CCEE62C0AA2D79064F6 /* OptionSet+Data.swift */,
 				C19F131008A699E10B6178902CED5BFE /* UUID+Hex.swift */,
+				52E8FF9725BB5EE90087B2A6 /* UserDefaults+SeqAuth.swift */,
 			);
 			name = "Type Extensions";
 			path = "nRFMeshProvision/Classes/Type Extensions";
@@ -1723,6 +1726,7 @@
 				6952A0203AA6D28B8C02529B0FC7B6CE /* ApplicationKey.swift in Sources */,
 				7156772C5A4A92D7D75B5EC0A6B0B0B1 /* ApplicationKeys.swift in Sources */,
 				6D2FDE31101DDA0D9D8CFDB5658BFE34 /* BackgroundTimer.swift in Sources */,
+				52E8FF9825BB5EE90087B2A6 /* UserDefaults+SeqAuth.swift in Sources */,
 				3E07C8DB8D1819C260D20103C5CE484E /* BaseGattProxyBearer.swift in Sources */,
 				D98B12DD646C8443EC4FA07E3FEDAD6F /* Beacon.swift in Sources */,
 				FE1EADD583209378FDA194D9CCD6F0B6 /* BeaconPdu.swift in Sources */,

--- a/Example/Tests/FastSending.swift
+++ b/Example/Tests/FastSending.swift
@@ -363,9 +363,8 @@ class FastSending: XCTestCase, MeshNetworkDelegate {
             }
             if let network = manager.meshNetwork,
                let defaults = UserDefaults(suiteName: network.uuid.uuidString) {
-                defaults.removeObject(forKey: "S0001") // Remove sender's Sequence number
-                defaults.removeObject(forKey: "P0001") // Remove receivers's previous Sequence number
-                defaults.removeObject(forKey: "0001")  // Remove receivers's Sequence number
+                defaults.removeSequenceNumber(for: Address(0001))
+                defaults.removeSeqAuthValues(of: Address(0001))
             }
         } catch {
             print(error)

--- a/Example/Tests/ManagingProvisioners.swift
+++ b/Example/Tests/ManagingProvisioners.swift
@@ -50,7 +50,7 @@ class ManagingProvisioners: XCTestCase {
         XCTAssertNoThrow(try meshNetwork.add(node: Node(name: "Node 4", unicastAddress: 65, elements: 5)))
         XCTAssertNoThrow(try meshNetwork.add(node: Node(name: "Node 5", unicastAddress: 73, elements: 5)))
         
-        let provisioner = Provisioner(name: "New provisioner",
+        let provisioner = Provisioner(name: "Main provisioner",
                                       allocatedUnicastRange: [
                                         AddressRange(8...38),
                                         AddressRange(50...80)
@@ -67,9 +67,26 @@ class ManagingProvisioners: XCTestCase {
         XCTAssertEqual(meshNetwork.nodes[6].unicastAddress, 11)
         XCTAssertEqual(meshNetwork.nodes[6].lastUnicastAddress, 11)
         
-        meshNetwork.remove(provisioner: provisioner)
-        XCTAssertEqual(meshNetwork.provisioners.count, 0)
-        XCTAssertEqual(meshNetwork.nodes.count, 6)
+        // This will throw, as it's not possible to remove the last Provisioner object.
+        XCTAssertThrowsError(try meshNetwork.remove(provisioner: provisioner))
+        XCTAssertEqual(meshNetwork.provisioners.count, 1)
+        XCTAssertEqual(meshNetwork.nodes.count, 7)
+
+        let otherProvisioner = Provisioner(name: "New provisioner",
+                                           allocatedUnicastRange: [
+                                            AddressRange(100...200)
+                                           ],
+                                           allocatedGroupRange: [],
+                                           allocatedSceneRange: [])
+        XCTAssertNoThrow(try meshNetwork.add(provisioner: otherProvisioner))
+        XCTAssertEqual(meshNetwork.provisioners.count, 2)
+        XCTAssertEqual(meshNetwork.nodes.count, 8)
+        XCTAssertEqual(meshNetwork.nodes[7].unicastAddress, 100)
+        XCTAssertEqual(meshNetwork.nodes[7].lastUnicastAddress, 100)
+        
+        XCTAssertNoThrow(try meshNetwork.remove(provisioner: otherProvisioner))
+        XCTAssertEqual(meshNetwork.provisioners.count, 1)
+        XCTAssertEqual(meshNetwork.nodes.count, 7)
     }
     
     func testAddProvisioner_missingRanges() {

--- a/nRFMeshProvision/Classes/Mesh Model/MeshNetwork.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/MeshNetwork.swift
@@ -467,13 +467,15 @@ extension MeshNetwork {
             node.meshNetwork = nil
             timestamp = Date()
             
+            // The stored SeqAuth value cannot be removed, as that could
+            // lead to accepting repeated messages.
+            /*
             // Forget the last sequence number for the device.
             let meshUuid = self.uuid
-            if let defauts = UserDefaults(suiteName: meshUuid.uuidString) {
-                for element in node.elements {
-                    defauts.removeObject(forKey: element.unicastAddress.hex)
-                }
+            if let defaults = UserDefaults(suiteName: meshUuid.uuidString) {
+                defaults.removeSeqAuthValues(of: node)
             }
+            */
         }
     }
     

--- a/nRFMeshProvision/Classes/Mesh Model/MeshNetwork.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/MeshNetwork.swift
@@ -507,8 +507,7 @@ extension MeshNetwork {
     /// If the mesh network already contains a Scene with the same number,
     /// this method throws an error.
     ///
-    /// - parameters
-    ///   - scene: The Scene to be added.
+    /// - parameter scene: The Scene to be added.
     func add(scene: Scene) {
         scene.meshNetwork = self
         scenes.append(scene)

--- a/nRFMeshProvision/Classes/Type Extensions/UserDefaults+SeqAuth.swift
+++ b/nRFMeshProvision/Classes/Type Extensions/UserDefaults+SeqAuth.swift
@@ -1,0 +1,136 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+// This extension contains helper methods for handling Sequence Numbers
+// of outgoing messages from the local Node. Each message must contain
+// a unique 24-bit Sequence Number, which together with 32-bit IV Index
+// ensure that replay attacks are not possible.
+internal extension UserDefaults {
+    
+    /// Returns the next SEQ number to be used to send a message from
+    /// the given Unicast Address.
+    ///
+    /// Each time this method is called returned value is incremented by 1.
+    ///
+    /// Size of SEQ is 24 bits.
+    ///
+    /// - parameter source: The Unicast Address of local Element.
+    /// - returns: The next SEQ number to be used.
+    func nextSequenceNumber(for source: Address) -> UInt32 {
+        // Get the current sequence number source address.
+        let sequence = UInt32(integer(forKey: "S\(source.hex)"))
+        // As the sequnce number was just used, it has to be incremented.
+        set(sequence + 1, forKey: "S\(source.hex)")
+        return sequence
+    }
+    
+    /// Resets the SEQ associated with all Elements of the given Node to 0.
+    ///
+    /// This method should be called when the IV Index is incremented and SEQ
+    /// number should be reset.
+    ///
+    /// - parameter node: The local Node.
+    func resetSequenceNumbers(of node: Node) {
+        node.elements.forEach { element in
+            set(0, forKey: "S\(element.unicastAddress.hex)")
+        }
+    }
+    
+}
+
+// This extension contains helper methods for handling SeqAuth values
+// of received messages. The local Node must remember the last SeqAuth value
+// received from all Nodes it is communicating with and discard messeges
+// having lower or equal SeqAuth value, as potential replies.
+internal extension UserDefaults {
+    
+    /// Returns the last SeqAuth value stored for the given source address, or nil,
+    /// if no message has ever been received from that address.
+    ///
+    /// The SeqAuth value ensures uniqueness of each message. Each message from
+    /// the same source address must be sent with unique value of SeqAuth.
+    ///
+    /// - parameter source: The source Unicast Address.
+    /// - returns: The 32+24 bit SeqAuth value, or nil.
+    func lastSeqAuthValue(for source: Address) -> UInt64? {
+        return (object(forKey: source.hex) as? NSNumber)?.uint64Value
+    }
+    
+    /// Stores the last received SeqAuth value in User Defaults.
+    ///
+    /// - parameters:
+    ///   - value: The SeqAuth value of received message.
+    ///   - source: The source Unicast Address.
+    func storeLastSeqAuthValue(_ value: UInt64, for source: Address) {
+        set(NSNumber(value: value), forKey: source.hex)
+    }
+    
+    /// Returns the previousl last SeqAuth value for the given source address, or nil,
+    /// if no more than 1 message has ever been received from that address.
+    ///
+    /// - parameter source: The source Unicast Address.
+    /// - returns: The 32+24 bit SeqAuth value, or nil.
+    func previousSeqAuthValue(for source: Address) -> UInt64? {
+        return (object(forKey: "P\(source.hex)") as? NSNumber)?.uint64Value
+    }
+    
+    /// Stores the previously received SeqAuth value in User Defaults.
+    ///
+    /// - parameters:
+    ///   - value: The previously received SeqAuth value.
+    ///   - source: The source Unicast Address.
+    func storePreviousSeqAuthValue(_ value: UInt64, for source: Address) {
+        set(NSNumber(value: value), forKey: "P\(source.hex)")
+    }
+    
+    /// Removes all known SeqAuth values associated with any of the Elements
+    /// of the given remote Node.
+    ///
+    /// - parameter node: The remote Node.
+    func removeSeqAuthValues(of node: Node) {
+        node.elements.forEach { element in
+            removeSeqAuthValues(of: element)
+        }
+    }
+    
+    /// Removes last known SeqAuth value associated with the address of the
+    /// given Element of remote Node.
+    ///
+    /// - parameter element: The removed Element.
+    func removeSeqAuthValues(of element: Element) {
+        // Remove the last and previous values of SeqAuth associated
+        // with the address of the given Element.
+        removeObject(forKey: element.unicastAddress.hex)
+        removeObject(forKey: "P\(element.unicastAddress.hex)")
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Type Extensions/UserDefaults+SeqAuth.swift
+++ b/nRFMeshProvision/Classes/Type Extensions/UserDefaults+SeqAuth.swift
@@ -65,6 +65,13 @@ internal extension UserDefaults {
         }
     }
     
+    /// Removes the SEQ number associated with the given address.
+    ///
+    /// - parameter source: The address to be forgotten.
+    func removeSequenceNumber(for source: Address) {
+        removeObject(forKey: "S\(source.hex)")
+    }
+    
 }
 
 // This extension contains helper methods for handling SeqAuth values
@@ -118,19 +125,17 @@ internal extension UserDefaults {
     /// - parameter node: The remote Node.
     func removeSeqAuthValues(of node: Node) {
         node.elements.forEach { element in
-            removeSeqAuthValues(of: element)
+            removeSeqAuthValues(of: element.unicastAddress)
         }
     }
     
-    /// Removes last known SeqAuth value associated with the address of the
-    /// given Element of remote Node.
+    /// Removes last known SeqAuth value associated with the givem address
+    /// of a remote Node.
     ///
-    /// - parameter element: The removed Element.
-    func removeSeqAuthValues(of element: Element) {
-        // Remove the last and previous values of SeqAuth associated
-        // with the address of the given Element.
-        removeObject(forKey: element.unicastAddress.hex)
-        removeObject(forKey: "P\(element.unicastAddress.hex)")
+    /// - parameter source: The forgotten Address.
+    func removeSeqAuthValues(of source: Address) {
+        removeObject(forKey: source.hex)
+        removeObject(forKey: "P\(source.hex)")
     }
     
 }


### PR DESCRIPTION
This PR moves all code related to storing Sequence Number (for outgoing messages) and SeqAuth (for incoming messages) to a single place.
It also fixes a potential bug, when the SeqAuth was forgotten (removed) when a Node was removed. That could allow older messages to be replied and the lib would accept them. Now SeqAuth values of remote Nodes are never deleted.