### PR TITLE
Key Refresh Procedure

### DIFF
--- a/Documentation/SETTING_UP_NETWORK.md
+++ b/Documentation/SETTING_UP_NETWORK.md
@@ -20,7 +20,7 @@ The provisioning process assigns a unique Unicast Address and a primary Network 
 
 The first thing you have to do to after provisioning is reading **Composition Data**. Do this by sending *Config Composition Data Get* message with page 0. Composition data contains the information about the Node, and Elements and Models on the new device. The status message will automatically be applied to the Node when received.
 
-The next step is to send other Network Keys, if needed, and Application Keys that this device needs to know. In theory, a key that has once been added can be deleted, but there is no guarantee that the Node will actually remove the key. The proper way of deleting the keys is by dong Key Refresh Procedure (not implemented yet in the library), which will distribute a new, updated key with the same index to all nodes but the one that we want to remove it from, and switch them to use the new key instead. The blacklisted device will not be able to understand messages anymore even if it hasn't deleted the key, as the key has now been replaced and is no longer is use.
+The next step is to send other Network Keys, if needed, and Application Keys that this device needs to know. In theory, a key that has once been added can be deleted, but there is no guarantee that the Node will actually remove the key. The proper way of deleting the keys is by doing [Key Refresh Procedure](https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/pull/314), which will distribute a new, updated key with the same index to all nodes except those that we want to remove from the subnetwork, and switch them to use the new key instead. The excluded device(s) will not be able to understand messages anymore even if it hasn't deleted the key, as the key has now been replaced and is no longer is use.
 
 To send a Network Key to a device use `ConfigNetKeyAdd` message and to send an Application Key - `ConfigAppKeyAdd` message.
 
@@ -41,6 +41,12 @@ To set a publication, use `ConfigModelPubilcationSet` or `ConfigModelPubilcation
 These messages may also be sent to local Models. For example, the Sample App contains 2 Elements, each with **Generic OnOff Client** and **Generic OnOff Server** that can be configured to send messages to each other.
 
 After subscribibg a local Model to a group or virtual address you have to add this address to the Proxy Filter.
+
+### Scenes
+
+Scenes may be used to restore a saved state of a device. Scene server models support two operations: storing and recalling a scene. To store a scene, first set the required device state. For example, turn the light on, set desider light color and brightness. Then send `SceneStore` message with a *scene number*. Upon calling `SceneRecall` message with the same *scene number*, the device will restore saved state.
+
+The library natively supports Scene Client model, so it may send `SceneStore`, `SceneRecall` or `SceneDelete` messages. The sample app, additionally, supports Scene Server and Scene Setup Server models, which can be used to test Scene Clients on other devices. Generic OnOff Server and Generic Level Server models on the two Elements on the phone will behave accordingly to received messages. Mind that, on contrary to Configuration Server and Configuration Client, Scene models need to be bound to an App Key (one or more) and will receive only message sent with that App Key.
 
 ### Proxy Filter
 

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -113,6 +113,9 @@
 		51F397463EBD18BCD543C64FE1313C67 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E749F10DEF7618DE8B1B122A5D982D /* Model.swift */; };
 		5205603EB13F6ED8D95F47779C169397 /* ConfigNetworkTransmitStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E287AB63C5554D1EB6D838BE420837 /* ConfigNetworkTransmitStatus.swift */; };
 		52A0041125BF267400A24C92 /* MeshNetwork+IvIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A0041025BF267400A24C92 /* MeshNetwork+IvIndex.swift */; };
+		52A0042525C1733100A24C92 /* ConfigKeyRefreshPhaseGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A0042425C1733100A24C92 /* ConfigKeyRefreshPhaseGet.swift */; };
+		52A0042B25C173C100A24C92 /* ConfigKeyRefreshPhaseSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A0042A25C173C100A24C92 /* ConfigKeyRefreshPhaseSet.swift */; };
+		52A0043125C177AB00A24C92 /* ConfigKeyRefreshPhaseStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A0043025C177AB00A24C92 /* ConfigKeyRefreshPhaseStatus.swift */; };
 		52E8FF9825BB5EE90087B2A6 /* UserDefaults+SeqAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E8FF9725BB5EE90087B2A6 /* UserDefaults+SeqAuth.swift */; };
 		539B7D307CE6DAD58135573C2BD34CF9 /* NetworkKey+MeshNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7FD4C6B9026F5AB76D7B586E2CF3AA /* NetworkKey+MeshNetwork.swift */; };
 		5591B4463258E51A0030AA284239437D /* KeySet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B4EFEACAC71F2189FC119255429A54 /* KeySet.swift */; };
@@ -500,6 +503,9 @@
 		52473EF190638F8B70BB7B106E956029 /* pem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = pem.h; path = ios/include/openssl/pem.h; sourceTree = "<group>"; };
 		52513CFCF2954BAD169F4ECFE23DE170 /* LightHSLDefaultSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightHSLDefaultSet.swift; sourceTree = "<group>"; };
 		52A0041025BF267400A24C92 /* MeshNetwork+IvIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MeshNetwork+IvIndex.swift"; sourceTree = "<group>"; };
+		52A0042425C1733100A24C92 /* ConfigKeyRefreshPhaseGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigKeyRefreshPhaseGet.swift; sourceTree = "<group>"; };
+		52A0042A25C173C100A24C92 /* ConfigKeyRefreshPhaseSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigKeyRefreshPhaseSet.swift; sourceTree = "<group>"; };
+		52A0043025C177AB00A24C92 /* ConfigKeyRefreshPhaseStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigKeyRefreshPhaseStatus.swift; sourceTree = "<group>"; };
 		52B112AB6B61A75C4468FE0B87BC2E08 /* GenericLevelStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericLevelStatus.swift; sourceTree = "<group>"; };
 		52E8FF9725BB5EE90087B2A6 /* UserDefaults+SeqAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+SeqAuth.swift"; sourceTree = "<group>"; };
 		54B5F2AC51F4BA0659354EDFEA843669 /* ConfigAppKeyList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigAppKeyList.swift; sourceTree = "<group>"; };
@@ -1381,6 +1387,9 @@
 				46E0E498EED20AA0B5A6DDB02929C169 /* ConfigHeartbeatSubscriptionGet.swift */,
 				07064A555756D10ED0063E60651DE416 /* ConfigHeartbeatSubscriptionSet.swift */,
 				849317365DD698109002490BB64BEB16 /* ConfigHeartbeatSubscriptionStatus.swift */,
+				52A0042425C1733100A24C92 /* ConfigKeyRefreshPhaseGet.swift */,
+				52A0042A25C173C100A24C92 /* ConfigKeyRefreshPhaseSet.swift */,
+				52A0043025C177AB00A24C92 /* ConfigKeyRefreshPhaseStatus.swift */,
 				76FDA63C6C6B7883B4D6F20D0D4B0BA7 /* ConfigModelAppBind.swift */,
 				F9962F39E0AEEBCA311C60572F3D80B6 /* ConfigModelAppStatus.swift */,
 				D740716793891C802038A10B5151A456 /* ConfigModelAppUnbind.swift */,
@@ -1841,6 +1850,7 @@
 				03BD6CC620C84A1C1E4C212CCCB5C3CD /* GenericOnOffStatus.swift in Sources */,
 				FB072C7A4F990A83D39E096BF890A97B /* GenericOnPowerUpGet.swift in Sources */,
 				DA5761FFD8DEAE04F3F5AC3B7D7FC4C5 /* GenericOnPowerUpSet.swift in Sources */,
+				52A0043125C177AB00A24C92 /* ConfigKeyRefreshPhaseStatus.swift in Sources */,
 				AB84FE344627AD4DB4FB839093573960 /* GenericOnPowerUpSetUnacknowledged.swift in Sources */,
 				73198CE63D2C8C6F1B150B98E53326A1 /* GenericOnPowerUpStatus.swift in Sources */,
 				E3AD1ED26A5417DC0DFBD5F546C62636 /* GenericPowerDefaultSet.swift in Sources */,
@@ -1984,6 +1994,7 @@
 				0E7745E058959B3EEA0065840452EB25 /* ProvisioningManager.swift in Sources */,
 				45E429D472AAA7AE58BEC272A83FA7CB /* ProvisioningPdu.swift in Sources */,
 				6C875993ABBFF73B5D953648EA094627 /* ProvisioningState.swift in Sources */,
+				52A0042B25C173C100A24C92 /* ConfigKeyRefreshPhaseSet.swift in Sources */,
 				7CE4CD148E29C16ADB7899B3F2C1376A /* ProxyConfigurationMessage.swift in Sources */,
 				D46971EB3AADF187134AEAC3B4C9CE54 /* ProxyFilter.swift in Sources */,
 				F203C1E5A7C7591DE481B7D58D8E7B6D /* ProxyProtocolHandler.swift in Sources */,
@@ -2006,6 +2017,7 @@
 				2B8704A8816EBF7B0D02FDBB32C5A2AC /* SceneRegisterStatus.swift in Sources */,
 				9B5197A14828BC76716DC8A7659B00D0 /* Scenes.swift in Sources */,
 				999F5C5004A2C84282C69697787B44CB /* SceneStatus.swift in Sources */,
+				52A0042525C1733100A24C92 /* ConfigKeyRefreshPhaseGet.swift in Sources */,
 				73E28AB21381519736E428EF67D766B5 /* SceneStore.swift in Sources */,
 				6607DEEC1A2767E7E4CBF65384AD9797 /* SceneStoreUnacknowledged.swift in Sources */,
 				A068C7489BA6439282CBB4422DA86B5C /* SecureNetworkBeacon.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ The library is compatible with version 1.0.1 of the Bluetooth Mesh Profile Speci
 
 This is the second version of the nRF Mesh Provision library for iOS. All  features are tested againt nRF Mesh SDK and Zephyr based mesh devices.
 
-> The first version of this library is no longer maintained. The application available on App Store will eventually be replaced with the new sample application.
+> The version 1.x and 2.x of this library are no longer maintained. Please migrate to 3.x to get new features and bug fixes. For changes and migration details see [#295](https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/pull/295).
 
 ## Sample app
 
 The sample application demonstrates how to use the library. It may also be used to configure your Mesh network. Use `pod try` to install and set up the sample app when using CocoaPods.
 The app and the library are released under BSD-3 license. Feel free to modify them as you want.
+
+The app is available on App Store: https://apps.apple.com/us/app/nrf-mesh/id1380726771
 
 ## Supported features
 
@@ -36,14 +38,15 @@ The app and the library are released under BSD-3 license. Feel free to modify th
 13. Generic OnOff and Vendor model have dedicated controls in sample app.
 14. Proxy Filter.
 15. IV Index update (handling updates received in Secure Network beacons).
-16. Hearbeats (both as client and server).
+16. Heartbeats (both as client and server).
 17. Scenes (both as client and server).
-18. Partial export (allows to export only part of the network, for example for a Guest)
+18. Partial export (allows to export only part of the network, for example for a Guest).
+19. [Key Refresh Procedure](https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/pull/314) (using *ConfigKeyRefreshPhaseSet* messages, not Secure Network beacon) 
 
 ## NOT (yet) supported features
 
 1. Many SIG defined models, except from supported ones.
-2. Key Refresh Procedure, IV Index update (initiation).
+2. IV Index update (initiation).
 3. Health server messages.
 4. Remote Provisioning.
 

--- a/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationClientHandler.swift
+++ b/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationClientHandler.swift
@@ -59,7 +59,8 @@ internal class ConfigurationClientHandler: ModelDelegate {
             ConfigNetworkTransmitStatus.self,
             ConfigNodeResetStatus.self,
             ConfigHeartbeatPublicationStatus.self,
-            ConfigHeartbeatSubscriptionStatus.self
+            ConfigHeartbeatSubscriptionStatus.self,
+            ConfigKeyRefreshPhaseStatus.self,
         ]
         self.meshNetwork = meshNetwork
         self.messageTypes = types.toMap()
@@ -332,6 +333,10 @@ internal class ConfigurationClientHandler: ModelDelegate {
                 // This may be set to nil.
                 node.heartbeatSubscription = HeartbeatSubscription(status)
             }
+            
+        case is ConfigKeyRefreshPhaseStatus:
+            // Do nothing. The model does not need to be updated.
+            break
             
         default:
             break

--- a/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationServerHandler.swift
+++ b/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationServerHandler.swift
@@ -113,7 +113,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
                                                      name: "Network Key \(keyIndex + 1)")
                 }
                 // Add the Network Key index to the local Node.
-                meshNetwork.localProvisioner?.node?.add(networkKeyWithIndex: keyIndex)
+                localNode.add(networkKeyWithIndex: keyIndex)
                 return ConfigNetKeyStatus(confirm: networkKey!)
             } catch {
                 return ConfigNetKeyStatus(responseTo: request, with: .unspecifiedError)
@@ -125,19 +125,38 @@ internal class ConfigurationServerHandler: ModelDelegate {
             guard let networkKey = meshNetwork.networkKeys[keyIndex] else {
                 return ConfigNetKeyStatus(responseTo: request, with: .invalidNetKeyIndex)
             }
-            // Update the key data (observer will set the `oldKey` automatically).
-            networkKey.key = request.key
-            // And mark the key in the local Node as updated.
-            meshNetwork.localProvisioner?.node?.update(networkKeyWithIndex: keyIndex)
+            // The Network Key can only be changed once if a single Key Refresh Procedure.
+            // Otherwise, return .keyIndexAlreadyStored.
+            guard networkKey.phase == .normalOperation ||
+                 (networkKey.phase == .distributingKeys && networkKey.key == request.key) else {
+                return ConfigNetKeyStatus(responseTo: request, with: .keyIndexAlreadyStored)
+            }
+            if networkKey.phase == .normalOperation {
+                // Update the key data (observer will set the `oldKey` automatically).
+                networkKey.key = request.key
+                // And mark the key in the local Node as updated.
+                localNode.update(networkKeyWithIndex: keyIndex)
+            }
             return ConfigNetKeyStatus(confirm: networkKey)
             
         case let request as ConfigNetKeyDelete:
             let keyIndex = request.networkKeyIndex
+            // When an element receives a Config NetKey Delete message that identifies a
+            // Network Key that is not in the Network Key List, it responds with Success,
+            // because the result of deleting the key that does not exist in the Network Key
+            // List will be the same as if the key was deleted from the List.
+            guard let _ = meshNetwork.networkKeys[keyIndex] else {
+                return ConfigNetKeyStatus(responseTo: request, with: .success)
+            }
+            // It is not possible to remove the last key.
+            guard meshNetwork.networkKeys.count > 1 else {
+                return ConfigNetKeyStatus(responseTo: request, with: .cannotRemove)
+            }
             // Force delete the key from the global configuration.
             try? meshNetwork.remove(networkKeyWithKeyIndex: keyIndex, force: true)
             // Remove the key also from the local Node. This will also remove all
             // Application Keys bound to it.
-            meshNetwork.localProvisioner?.node?.remove(networkKeyWithIndex: keyIndex)
+            localNode.remove(networkKeyWithIndex: keyIndex)
             return ConfigNetKeyStatus(responseTo: request, with: .success)
                     
         case is ConfigNetKeyGet:
@@ -166,7 +185,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
                     applicationKey!.boundNetworkKeyIndex = networkKey.index
                 }
                 // Add the Network Key index to the local Node.
-                meshNetwork.localProvisioner?.node?.add(applicationKeyWithIndex: keyIndex)
+                localNode.add(applicationKeyWithIndex: keyIndex)
                 return ConfigAppKeyStatus(confirm: applicationKey!)
             } catch {
                 return ConfigAppKeyStatus(responseTo: request, with: .unspecifiedError)
@@ -186,23 +205,47 @@ internal class ConfigurationServerHandler: ModelDelegate {
             guard applicationKey.isBound(to: networkKey) else {
                 return ConfigAppKeyStatus(responseTo: request, with: .invalidBinding)
             }
-            // Update the key data (observer will set the `oldKey` automatically).
-            applicationKey.key = request.key
-            // And mark the key in the local Node as updated.
-            meshNetwork.localProvisioner?.node?.update(applicationKeyWithIndex: keyIndex)
+            // Updating Application Key is only possible during Key Refresh Procedure
+            // for the bound Network Key. Otherwise, return .cannotUpdate.
+            guard case .distributingKeys = networkKey.phase else {
+                return ConfigAppKeyStatus(responseTo: request, with: .cannotUpdate)
+            }
+            // The key cannot be changed multiple times in a single Key Refresh Procedure.
+            // Otherwise, return .keyIndexAlreadyStored.
+            guard applicationKey.oldKey == nil || applicationKey.key == request.key else {
+                return ConfigAppKeyStatus(responseTo: request, with: .keyIndexAlreadyStored)
+            }
+            if applicationKey.oldKey == nil {
+                // Update the key data (observer will set the `oldKey` automatically).
+                applicationKey.key = request.key
+                // And mark the key in the local Node as updated.
+                localNode.update(applicationKeyWithIndex: keyIndex)
+            }
             return ConfigAppKeyStatus(confirm: applicationKey)
             
         case let request as ConfigAppKeyDelete:
             // If the Network Key does not exist, return .invalidNetKeyIndex.
-            guard let _ = meshNetwork.networkKeys[request.networkKeyIndex] else {
+            guard let networkKey = meshNetwork.networkKeys[request.networkKeyIndex] else {
                 return ConfigAppKeyStatus(responseTo: request, with: .invalidNetKeyIndex)
             }
             let keyIndex = request.applicationKeyIndex
+            // When an element receives a Config AppKey Delete message that identifies
+            // an Application Key that is not in the Application Key List, it responds
+            // with Success, because the result of deleting the key that does not exist
+            // in the Application Key List will be the same as if the key was deleted
+            // from the AppKey List.
+            guard let applicationKey = meshNetwork.applicationKeys[keyIndex] else {
+                return ConfigAppKeyStatus(responseTo: request, with: .success)
+            }
+            // Check if the binding is correct. Otherwise, reutnr .invalidBinding.
+            guard applicationKey.isBound(to: networkKey) else {
+                return ConfigAppKeyStatus(responseTo: request, with: .invalidBinding)
+            }
             // Force delete the key from the global configuration.
             try? meshNetwork.remove(applicationKeyWithKeyIndex: keyIndex, force: true)
             // Remove the key also from the local Node. This will also remove all
             // Application Keys bound to it.
-            meshNetwork.localProvisioner?.node?.remove(applicationKeyWithIndex: keyIndex)
+            localNode.remove(applicationKeyWithIndex: keyIndex)
             return ConfigAppKeyStatus(responseTo: request, with: .success)
                 
         case let request as ConfigAppKeyGet:

--- a/nRFMeshProvision/Classes/Layers/Network Layer/SecureNetworkBeacon.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/SecureNetworkBeacon.swift
@@ -36,6 +36,9 @@ internal struct SecureNetworkBeacon: BeaconPdu {
     
     /// The Network Key related to this Secure Network beacon.
     let networkKey: NetworkKey
+    /// A flag indicating whether the Secure Network beacon has been
+    /// secured using the new Network Key during Key Refresh Procedure.
+    let validForKeyRefreshProcedure: Bool
     /// Key Refresh flag value.
     ///
     /// When this flag is active, the Node shall set the Key Refresh
@@ -52,8 +55,9 @@ internal struct SecureNetworkBeacon: BeaconPdu {
     
     /// Creates Secure Network beacon PDU object from received PDU.
     ///
-    /// - parameter pdu: The data received from mesh network.
-    /// - parameter networkKey: The Network Key to validate the beacon.
+    /// - parameters:
+    ///   - pdu: The data received from mesh network.
+    ///   - networkKey: The Network Key to validate the beacon.
     /// - returns: The beacon object, or `nil` if the data are invalid.
     init?(decode pdu: Data, usingNetworkKey networkKey: NetworkKey) {
         self.pdu = pdu
@@ -67,6 +71,8 @@ internal struct SecureNetworkBeacon: BeaconPdu {
         ivIndex = IvIndex(index: index, updateActive: updateActive)
         
         // Authenticate beacon using given Network Key.
+        // During Key Refresh Procedure when in Phase 1 (key distribution) the
+        // Secure Network beacon may be decoded using the old Network Key.
         let helper = OpenSSLHelper()
         if networkId == networkKey.networkId {
             let authenticationValue = helper.calculateCMAC(pdu.subdata(in: 1..<14), andKey: networkKey.keys.beaconKey)!
@@ -74,12 +80,14 @@ internal struct SecureNetworkBeacon: BeaconPdu {
                 return nil
             }
             self.networkKey = networkKey
-        } else if let oldNetworkId = networkKey.oldNetworkId, networkId == oldNetworkId {
+            self.validForKeyRefreshProcedure = networkKey.oldKey != nil
+        } else if case .distributingKeys = networkKey.phase, networkId == networkKey.oldNetworkId {
             let authenticationValue = helper.calculateCMAC(pdu.subdata(in: 1..<14), andKey: networkKey.oldKeys!.beaconKey)!
             guard authenticationValue.subdata(in: 0..<8) == pdu.subdata(in: 14..<22) else {
                 return nil
             }
             self.networkKey = networkKey
+            self.validForKeyRefreshProcedure = false
         } else {
             return nil
         }
@@ -125,9 +133,9 @@ internal extension SecureNetworkBeacon {
         // The new index must not be greater than the current one + 42,
         // unless this rule is disabled.
         guard (ivIndex.index > target.index &&
-            (ivRecoveryOver42Allowed || ivIndex.index <= target.index + 42)
+                (ivRecoveryOver42Allowed || ivIndex.index <= target.index + 42)
               ) ||
-            (ivIndex.index == target.index &&
+              (ivIndex.index == target.index &&
                 (target.updateActive || !ivIndex.updateActive)
               ) else {
             return false
@@ -179,16 +187,16 @@ internal extension SecureNetworkBeacon {
     /// This method goes over all Network Keys in the mesh network and tries
     /// to parse the beacon.
     ///
-    /// - parameter pdu:         The received PDU.
-    /// - parameter meshNetwork: The mesh network for which the PDU should be decoded.
+    /// - parameters:
+    ///   - pdu:         The received PDU.
+    ///   - meshNetwork: The mesh network for which the PDU should be decoded.
     /// - returns: The beacon object.
     static func decode(_ pdu: Data, for meshNetwork: MeshNetwork) -> SecureNetworkBeacon? {
-        guard pdu.count > 1 else {
+        guard pdu.count > 1, let beaconType = BeaconType(rawValue: pdu[0]) else {
             return nil
         }
-        let beaconType = BeaconType(rawValue: pdu[0])
         switch beaconType {
-        case .some(.secureNetwork):
+        case .secureNetwork:
             for networkKey in meshNetwork.networkKeys {
                 if let beacon = SecureNetworkBeacon(decode: pdu, usingNetworkKey: networkKey) {
                     return beacon

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigKeyRefreshPhaseGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigKeyRefreshPhaseGet.swift
@@ -1,0 +1,54 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct ConfigKeyRefreshPhaseGet: AcknowledgedConfigMessage, ConfigNetKeyMessage {
+    public static let opCode: UInt32 = 0x8015
+    public static let responseType: StaticMeshMessage.Type = ConfigKeyRefreshPhaseStatus.self
+    
+    public var parameters: Data? {
+        return encodeNetKeyIndex()
+    }
+    
+    public let networkKeyIndex: KeyIndex
+    
+    public init(networkKey: NetworkKey) {
+        self.networkKeyIndex = networkKey.index
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 2 else {
+            return nil
+        }
+        networkKeyIndex = ConfigAppKeyGet.decodeNetKeyIndex(from: parameters, at: 0)
+    }
+}
+

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigKeyRefreshPhaseSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigKeyRefreshPhaseSet.swift
@@ -1,0 +1,62 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct ConfigKeyRefreshPhaseSet: AcknowledgedConfigMessage, ConfigNetKeyMessage {
+    public static let opCode: UInt32 = 0x8016
+    public static let responseType: StaticMeshMessage.Type = ConfigKeyRefreshPhaseStatus.self
+    
+    public var parameters: Data? {
+        return encodeNetKeyIndex() + transition.rawValue
+    }
+    
+    public let networkKeyIndex: KeyIndex
+    /// New Key Refresh Phase Transition.
+    public let transition: KeyRefreshPhaseTransition
+    
+    public init(networkKey: NetworkKey, transition: KeyRefreshPhaseTransition) {
+        self.networkKeyIndex = networkKey.index
+        self.transition = transition
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 3 else {
+            return nil
+        }
+        networkKeyIndex = ConfigKeyRefreshPhaseSet.decodeNetKeyIndex(from: parameters, at: 0)
+        guard let t = KeyRefreshPhaseTransition(rawValue: parameters[2]) else {
+            return nil
+        }
+        transition = t
+    }
+    
+}
+

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigKeyRefreshPhaseStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigKeyRefreshPhaseStatus.swift
@@ -1,0 +1,80 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct ConfigKeyRefreshPhaseStatus: ConfigNetKeyMessage, ConfigStatusMessage {
+    public static let opCode: UInt32 = 0x8017
+    
+    public var parameters: Data? {
+        return Data([status.rawValue]) + encodeNetKeyIndex() + UInt8(phase.rawValue)
+    }
+    
+    public let networkKeyIndex: KeyIndex
+    public let status: ConfigMessageStatus
+    public let phase: KeyRefreshPhase
+    
+    /// Creates Config Key Refresh Phase Status message with given
+    /// error status.
+    ///
+    /// For successful responses use init(reportPhaseOf:).
+    ///
+    /// - parameters:
+    ///   - request: The request received.
+    ///   - error: The error status.
+    public init(responseTo request: ConfigNetKeyMessage, error: ConfigMessageStatus) {
+        self.networkKeyIndex = request.networkKeyIndex
+        self.status = error
+        self.phase = .normalOperation // = 0x00
+    }
+    
+    public init(reportPhaseOf networkKey: NetworkKey) {
+        self.networkKeyIndex = networkKey.index
+        self.status = .success
+        self.phase = networkKey.phase
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 4 else {
+            return nil
+        }
+        guard let status = ConfigMessageStatus(rawValue: parameters[0]) else {
+            return nil
+        }
+        self.status = status
+        networkKeyIndex = ConfigKeyRefreshPhaseSet.decodeNetKeyIndex(from: parameters, at: 1)
+        guard let phase = KeyRefreshPhase(rawValue: Int(parameters[3])) else {
+            return nil
+        }
+        self.phase = phase
+    }
+    
+}
+

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigKeyRefreshPhaseStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigKeyRefreshPhaseStatus.swift
@@ -49,7 +49,7 @@ public struct ConfigKeyRefreshPhaseStatus: ConfigNetKeyMessage, ConfigStatusMess
     /// - parameters:
     ///   - request: The request received.
     ///   - error: The error status.
-    public init(responseTo request: ConfigNetKeyMessage, error: ConfigMessageStatus) {
+    public init(responseTo request: ConfigNetKeyMessage, with error: ConfigMessageStatus) {
         self.networkKeyIndex = request.networkKeyIndex
         self.status = error
         self.phase = .normalOperation // = 0x00

--- a/nRFMeshProvision/Classes/Mesh Model/KeyRefreshPhase.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/KeyRefreshPhase.swift
@@ -57,6 +57,18 @@ public enum KeyRefreshPhase: Int, Codable {
     }
 }
 
+/// The type represeting Key Refresh phase transition.
+public enum KeyRefreshPhaseTransition: UInt8 {
+    /// The Node will start encoding messages using the new keys,
+    /// but will continue to decode using the old and new keys.
+    /// The Node will only accept beacons secured using the new
+    /// Network Key.
+    case finalize      = 2
+    /// The old keys will be revoked and the Node will go back to
+    /// Normal Operation state for the given Network Key.
+    case revokeOldKeys = 3
+}
+
 extension KeyRefreshPhase: CustomDebugStringConvertible {
     
     public var debugDescription: String {
@@ -64,6 +76,17 @@ extension KeyRefreshPhase: CustomDebugStringConvertible {
         case .normalOperation:  return "Normal operation"
         case .distributingKeys: return "Distributing keys"
         case .finalizing:       return "Finalizing"
+        }
+    }
+    
+}
+
+extension KeyRefreshPhaseTransition: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        switch self {
+        case .finalize:      return "Finalize"
+        case .revokeOldKeys: return "Revoke old keys"
         }
     }
     

--- a/nRFMeshProvision/Classes/Mesh Model/NetworkKey.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/NetworkKey.swift
@@ -118,8 +118,8 @@ public class NetworkKey: Key, Codable {
     internal private(set) var oldNid: UInt8?
     /// Returns the key set that should be used for encrypting outgoing packets.
     internal var transmitKeys: NetworkKeyDerivaties {
-        if case .distributingKeys = phase {
-            return oldKeys!
+        if case .distributingKeys = phase, let oldKeys = oldKeys {
+            return oldKeys
         }
         return keys
     }


### PR DESCRIPTION
This PR implements the Key Refresh Procedure.

Basic workflow is complete. There is no UI for this feature in the Sample app, but required messages are supported in the library. To update a Network Key and optionally bound Application Keys do the following:

1. Initially, assume number of devices in the network, including the phone acting as Provisioner.
2. All Nodes know Primary Network Key with 2 bound Application Keys.
3. One of the devices was disposed, and to make it the proper way, all other devices need to update the Network Key to a different one, so the disposed one can no longer send or receive messages. The disposed device will be excluded from the Key Refresh Procedure.
4. Mark the required device "Excluded" (former Blacklisted).
https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/blob/bc05b9af80b4a678e91f873943c8f89894c08f47/nRFMeshProvision/Classes/Mesh%20Model/Node.swift#L207-L210
5. Generate a new 16-byte key.
5. Send `ConfigNetKeyUpdate` message to all non-excluded Nodes, including the local Node (phone). This step will distribute the new key to all Nodes. They will all go to Phase 1 of Key Refresh Procedure, also called Key Distribution.
6. In that phase they will continue to send messages using the old key, but will decode messages secured using the old or the new Network Key.
7. You may optionally send `ConfigAppKeyUpdate` to the same set of Nodes to update the Application Key(s). Mind, that updating Application Keys is only possible if the bound Network Key is in Phase 1.
8. When all Nodes, including low-power Nodes received the new Network Key (and optionally Application Key) (which may take some time if low-power Nodes turn on rarely), send `ConfigKeyRefreshPhaseSet` with `transition` set to `.finalize` to the same set of Nodes. This will transition them to Phase 2 of Key Refresh Procedure, also called "Finalizing". In that phase they will start encrypting message using the new keys, and continue to receive messages (other than Secure Network beacons) using both old or new keys.
   > Note: Sending Secure Network beacon is currently not supported and may be added in the future releases. 
9. When all Nodes are in Phase 2, the old keys can be revoked. Do this by sending `ConfigKeyRefreshPhaseSet` with `transition` set to `.revokeOldKeys` to all Nodes. This will make them forget the old keys and transition to the Phase 0 (Normal Operation).

Remember, that all messages in the iOS version of nRF Mesh library must be sent also to the local Node.