### PR TITLE
Config Low Power PollTimeout messages supported

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -112,6 +112,8 @@
 		51DF58B92722EE2CB876F4859B449F54 /* ConfigModelSubscriptionVirtualAddressAdd.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04AB807F1DC543A41014F525360355B2 /* ConfigModelSubscriptionVirtualAddressAdd.swift */; };
 		51F397463EBD18BCD543C64FE1313C67 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E749F10DEF7618DE8B1B122A5D982D /* Model.swift */; };
 		5205603EB13F6ED8D95F47779C169397 /* ConfigNetworkTransmitStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E287AB63C5554D1EB6D838BE420837 /* ConfigNetworkTransmitStatus.swift */; };
+		5227730F25CADD76003777D6 /* ConfigLowPowerNodePollTimeoutGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5227730E25CADD76003777D6 /* ConfigLowPowerNodePollTimeoutGet.swift */; };
+		5227731525CADF35003777D6 /* ConfigLowPowerNodePollTimeoutStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5227731425CADF35003777D6 /* ConfigLowPowerNodePollTimeoutStatus.swift */; };
 		52A0041125BF267400A24C92 /* MeshNetwork+IvIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A0041025BF267400A24C92 /* MeshNetwork+IvIndex.swift */; };
 		52A0042525C1733100A24C92 /* ConfigKeyRefreshPhaseGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A0042425C1733100A24C92 /* ConfigKeyRefreshPhaseGet.swift */; };
 		52A0042B25C173C100A24C92 /* ConfigKeyRefreshPhaseSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A0042A25C173C100A24C92 /* ConfigKeyRefreshPhaseSet.swift */; };
@@ -500,6 +502,8 @@
 		5199F803DC73E0CF5E7C920FC16AF2BD /* GenericDeltaSetUnacknowledged.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericDeltaSetUnacknowledged.swift; sourceTree = "<group>"; };
 		51BBAA3978BFB1C9BAA0B3563DB01A48 /* Pods-nRFMeshProvision_Example-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-nRFMeshProvision_Example-Info.plist"; sourceTree = "<group>"; };
 		5208074594FCA179BDAEAC0AADD27CA0 /* GenericPowerLevelSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericPowerLevelSet.swift; sourceTree = "<group>"; };
+		5227730E25CADD76003777D6 /* ConfigLowPowerNodePollTimeoutGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigLowPowerNodePollTimeoutGet.swift; sourceTree = "<group>"; };
+		5227731425CADF35003777D6 /* ConfigLowPowerNodePollTimeoutStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigLowPowerNodePollTimeoutStatus.swift; sourceTree = "<group>"; };
 		52473EF190638F8B70BB7B106E956029 /* pem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = pem.h; path = ios/include/openssl/pem.h; sourceTree = "<group>"; };
 		52513CFCF2954BAD169F4ECFE23DE170 /* LightHSLDefaultSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightHSLDefaultSet.swift; sourceTree = "<group>"; };
 		52A0041025BF267400A24C92 /* MeshNetwork+IvIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MeshNetwork+IvIndex.swift"; sourceTree = "<group>"; };
@@ -1427,6 +1431,8 @@
 				0A7E82328457864B0DAB9CAA46497DA6 /* ConfigVendorModelAppList.swift */,
 				839C61F3F375511DD50402BF3B35FF40 /* ConfigVendorModelSubscriptionGet.swift */,
 				4206CFF9FC3541326741F16FEAB3F1B8 /* ConfigVendorModelSubscriptionList.swift */,
+				5227730E25CADD76003777D6 /* ConfigLowPowerNodePollTimeoutGet.swift */,
+				5227731425CADF35003777D6 /* ConfigLowPowerNodePollTimeoutStatus.swift */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
@@ -1947,6 +1953,7 @@
 				817E8B35DB7CF1871DA5565B31B990B0 /* MeshMessage.swift in Sources */,
 				BF6BD822A338173292A8A62FAE19AC07 /* MeshMessageError.swift in Sources */,
 				EAF4D8DC8415015245191402FCA08D37 /* MeshNetwork+Address.swift in Sources */,
+				5227730F25CADD76003777D6 /* ConfigLowPowerNodePollTimeoutGet.swift in Sources */,
 				34E0062FF1AF1F83CBA7D032DD9F852D /* MeshNetwork+Groups.swift in Sources */,
 				8C9090F5C44A9F968D989D9B906B7DC9 /* MeshNetwork+Keys.swift in Sources */,
 				A92F83E45085F2CCDFD1B15367E0E913 /* MeshNetwork+Nodes.swift in Sources */,
@@ -1999,6 +2006,7 @@
 				D46971EB3AADF187134AEAC3B4C9CE54 /* ProxyFilter.swift in Sources */,
 				F203C1E5A7C7591DE481B7D58D8E7B6D /* ProxyProtocolHandler.swift in Sources */,
 				CA16729B56C1539049596851F4D552C2 /* PublicKey.swift in Sources */,
+				5227731525CADF35003777D6 /* ConfigLowPowerNodePollTimeoutStatus.swift in Sources */,
 				B6095E20E053A6A518FCB10C1B2E1B4F /* Publish.swift in Sources */,
 				4A99A6B54792BC3FA00535A0AB61D693 /* RangeObject.swift in Sources */,
 				4C8C997874BDAC953889396869A0D5EF /* Ranges.swift in Sources */,

--- a/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationClientHandler.swift
+++ b/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationClientHandler.swift
@@ -61,6 +61,7 @@ internal class ConfigurationClientHandler: ModelDelegate {
             ConfigHeartbeatPublicationStatus.self,
             ConfigHeartbeatSubscriptionStatus.self,
             ConfigKeyRefreshPhaseStatus.self,
+            ConfigLowPowerNodePollTimeoutStatus.self,
         ]
         self.meshNetwork = meshNetwork
         self.messageTypes = types.toMap()
@@ -335,6 +336,10 @@ internal class ConfigurationClientHandler: ModelDelegate {
             }
             
         case is ConfigKeyRefreshPhaseStatus:
+            // Do nothing. The model does not need to be updated.
+            break
+            
+        case is ConfigLowPowerNodePollTimeoutStatus:
             // Do nothing. The model does not need to be updated.
             break
             

--- a/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationServerHandler.swift
+++ b/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationServerHandler.swift
@@ -83,6 +83,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
             ConfigHeartbeatSubscriptionSet.self,
             ConfigKeyRefreshPhaseGet.self,
             ConfigKeyRefreshPhaseSet.self,
+            ConfigLowPowerNodePollTimeoutGet.self,
         ]
         self.meshNetwork = meshNetwork
         self.messageTypes = types.toMap()
@@ -675,6 +676,11 @@ internal class ConfigurationServerHandler: ModelDelegate {
                      .forEach { $0.oldKey = nil }
             }
             return ConfigKeyRefreshPhaseStatus(reportPhaseOf: networkKey)
+        
+        case let request as ConfigLowPowerNodePollTimeoutGet:
+            // The library does not support Friend feature.
+            // The below code will reply with PollTimeout set to 0x000000.
+            return ConfigLowPowerNodePollTimeoutStatus(responseTo: request)
             
         default:
             fatalError("Message not handled: \(request)")

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigLowPowerNodePollTimeoutGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigLowPowerNodePollTimeoutGet.swift
@@ -1,0 +1,68 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// The Config Low Power Node PollTimeout Get is an acknowledged message
+/// used to get the current value of PollTimeout timer of the Low Power
+/// node within a Friend Node.
+/// The message is sent to a Friend Node that has claimed to be handling
+/// messages by sending ACKs On Behalf Of (OBO) the indicated Low Power
+/// Node. This message should only be sent to a Node that has the Friend
+/// feature supported and enabled.
+public struct ConfigLowPowerNodePollTimeoutGet: AcknowledgedConfigMessage {
+    public static let opCode: UInt32 = 0x802D
+    public static let responseType: StaticMeshMessage.Type = ConfigLowPowerNodePollTimeoutStatus.self
+    
+    public var parameters: Data? {
+        return Data() + lpnAddress
+    }
+    
+    /// The Unicast Address of the Low Power Node.
+    public let lpnAddress: Address
+    
+    /// Creates Config Low Power Node PollTimeout Get message.
+    ///
+    /// - parameter address: The primary Unicast Address of the Low Power Node.
+    public init?(from address: Address) {
+        guard address.isUnicast else {
+            return nil
+        }
+        self.lpnAddress = address
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 2 else {
+            return nil
+        }
+        lpnAddress = parameters.read()
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigLowPowerNodePollTimeoutStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigLowPowerNodePollTimeoutStatus.swift
@@ -83,6 +83,16 @@ public struct ConfigLowPowerNodePollTimeoutStatus: ConfigMessage {
         self.pollTimeout = pollTimeout
     }
     
+    /// Creates Config Low Power Node PollTimeout Status message
+    /// with the PollTimeout set to 0, indicating that the local
+    /// Node has no friend relationship with the given one.
+    ///
+    /// - parameter request: The request received.
+    public init(responseTo request: ConfigLowPowerNodePollTimeoutGet) {
+        self.lpnAddress = request.lpnAddress
+        self.pollTimeout = 0x000000
+    }
+    
     public init?(parameters: Data) {
         guard parameters.count == 5 else {
             return nil

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigLowPowerNodePollTimeoutStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigLowPowerNodePollTimeoutStatus.swift
@@ -1,0 +1,96 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// The Config Low Power Node PollTimeout Status is an unacknowledged message
+/// used to report the current value of the PollTimeout timer of the Low Power
+/// Node within a Friend Node.
+public struct ConfigLowPowerNodePollTimeoutStatus: ConfigMessage {
+    public static let opCode: UInt32 = 0x802E
+    public static let responseType: StaticMeshMessage.Type = ConfigLowPowerNodePollTimeoutStatus.self
+    
+    public var parameters: Data? {
+        // PollTimeout value is 24-bit value.
+        // As it is added in Little Endian as UInt32, the last byte must be dropped.
+        return (Data() + lpnAddress + pollTimeout).dropLast()
+    }
+    
+    /// The Unicast Address of the Low Power Node.
+    public let lpnAddress: Address
+    /// The PollTimeout timer value.
+    ///
+    /// This is 24-bit value, where:
+    /// - 0x000000 - The Node is no longer a Friend node of the Low Power Node
+    ///              identified by the LPNAddress.
+    /// - 0x000001 - 0x000009 - Prohibited.
+    /// - 0x00000A - 0x34BBFF - The PollTimeout timer value in units of 100 milliseconds,
+    ///                         which represents a range from 1 second to 3 days
+    ///                         23 hours 59 seconds 900 milliseconds.
+    /// - 0x34BC00 - 0xFFFFFF - Prohibited.
+    public let pollTimeout: UInt32
+    
+    /// The PollTimeout timer value in seconds, or `nil`.
+    public var pollTimeoutInterval: TimeInterval? {
+        if pollTimeout >= 0x00000A && pollTimeout <= 0x34BBFF {
+            return TimeInterval(pollTimeout) / 10
+        }
+        return nil
+    }
+    
+    /// Creates Config Low Power Node PollTimeout Status message.
+    ///
+    /// - parameters:
+    ///   - address: The primary Unicast Address of the Low Power Node.
+    ///   - pollTimeout: The current value of the PollTimeout timer of the
+    ///                  Low Power Node.
+    public init?(of address: Address, pollTimeout: UInt32) {
+        guard address.isUnicast else {
+            return nil
+        }
+        guard pollTimeout == 0x000000 ||
+             (pollTimeout >= 0x34BC00 && pollTimeout <= 0x34BBFF) else {
+            return nil
+        }
+        self.lpnAddress = address
+        self.pollTimeout = pollTimeout
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 5 else {
+            return nil
+        }
+        lpnAddress = parameters.read()
+        // Extend the parameters by 1 byte and read pollTimeout as UInt32.
+        // The parameters on Access Layer are encoded using Little Endian.
+        pollTimeout = (parameters + UInt8(0)).read(fromOffset: 2)
+    }
+    
+}


### PR DESCRIPTION
This PR adds library support for the following messages:
* Config Low Power PollTimeout Get
* Config Low Power PollTimeout Status

As the library does not support Friend feature, the server will always reply with PollTimeout set to 0.

> If the Friend feature is not supported or the Friend feature is supported and disabled, the current value of the PollTimeout List state for any Low Power node shall be set to 0x000000.