### PR TITLE
Importing Publish period resolution fixed

### DIFF
--- a/nRFMeshProvision/Classes/Mesh Model/Publish.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Publish.swift
@@ -359,30 +359,6 @@ public struct Publish: Codable {
                                                    debugDescription: "Retransmit interval must be in range 50-1600 ms in 50 ms steps.")
         }
     }
-    
-    /// This method tries to decode the publication period using the legacy schema,
-    /// where it was stored as number of milliseconds, instead of steps and resolution
-    /// separately.
-    ///
-    /// - parameter container: The decoding container to read from.
-    /// - returns: The Period object.
-    /// - throws: Data Corrupted Error when the decoded value is invalid.
-    private static func legacyDecodePeriod(from container: KeyedDecodingContainer<CodingKeys>) throws -> Period {
-        let period = try container.decode(Int.self, forKey: .period)
-        switch period {
-        case let period where period % 600000 == 0:
-            return Period(steps: UInt8(period / 600000), resolution: .tensOfMinutes)
-        case let period where period % 10000 == 0:
-            return Period(steps: UInt8(period / 10000), resolution: .tensOfSeconds)
-        case let period where period % 1000 == 0:
-            return Period(steps: UInt8(period / 1000), resolution: .seconds)
-        case let period where period % 100 == 0:
-            return Period(steps: UInt8(period / 100), resolution: .hundredsOfMilliseconds)
-        default:
-            throw DecodingError.dataCorruptedError(forKey: .period, in: container,
-                                                   debugDescription: "Unsupported period value: \(period).")
-        }
-    }
 }
 
 public extension Publish {


### PR DESCRIPTION
This PR fixes the second issue reported in #321.
nRF Mesh for Android in versions 3.0.1 and older was exporting the publish period resolution as a multiplication of resolution and steps. The PR implements a method that detects that and fixes imported value.