### PR TITLE
Sensors

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -144,6 +144,8 @@
 		5215995525DFBA5200F602FA /* SensorSettingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215995425DFBA5200F602FA /* SensorSettingStatus.swift */; };
 		5215995B25DFD2D800F602FA /* SensorSettingSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215995A25DFD2D800F602FA /* SensorSettingSetUnacknowledged.swift */; };
 		5215996125DFD44800F602FA /* SensorSettingSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215996025DFD44800F602FA /* SensorSettingSet.swift */; };
+		5215996725DFD4E900F602FA /* SensorCadenceSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215996625DFD4E900F602FA /* SensorCadenceSetUnacknowledged.swift */; };
+		5215996D25DFD61400F602FA /* SensorCadenceSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215996C25DFD61400F602FA /* SensorCadenceSet.swift */; };
 		523C6B1F33DB2E96993439A057BDF4D8 /* ConfigAppKeyAdd.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ED7E9A1A76137851290A8E7D4B828 /* ConfigAppKeyAdd.swift */; };
 		52DE3A9E25D5640900268D7D /* SensorDescriptorGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */; };
 		52DE3AA425D5649400268D7D /* SensorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3AA325D5649400268D7D /* SensorMessage.swift */; };
@@ -600,6 +602,8 @@
 		5215995425DFBA5200F602FA /* SensorSettingStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSettingStatus.swift; sourceTree = "<group>"; };
 		5215995A25DFD2D800F602FA /* SensorSettingSetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSettingSetUnacknowledged.swift; sourceTree = "<group>"; };
 		5215996025DFD44800F602FA /* SensorSettingSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSettingSet.swift; sourceTree = "<group>"; };
+		5215996625DFD4E900F602FA /* SensorCadenceSetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorCadenceSetUnacknowledged.swift; sourceTree = "<group>"; };
+		5215996C25DFD61400F602FA /* SensorCadenceSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorCadenceSet.swift; sourceTree = "<group>"; };
 		52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SensorDescriptorGet.swift; sourceTree = "<group>"; };
 		52DE3AA325D5649400268D7D /* SensorMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorMessage.swift; sourceTree = "<group>"; };
 		52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorDescriptorStatus.swift; sourceTree = "<group>"; };
@@ -1127,6 +1131,8 @@
 				52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */,
 				52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */,
 				5215992425DA99CD00F602FA /* SensorCadenceGet.swift */,
+				5215996C25DFD61400F602FA /* SensorCadenceSet.swift */,
+				5215996625DFD4E900F602FA /* SensorCadenceSetUnacknowledged.swift */,
 				5215992A25DA9B7C00F602FA /* SensorCadenceStatus.swift */,
 				5215994025DE96A700F602FA /* SensorSettingsGet.swift */,
 				5215994825DE96EB00F602FA /* SensorSettingsStatus.swift */,
@@ -1999,6 +2005,7 @@
 				DD0B02FF82BC3F52F6E4872D75192BF4 /* ConfigCompositionDataStatus.swift in Sources */,
 				BFEC502D3C41E506A4FEE85624CE5E38 /* ConfigDefaultTtlGet.swift in Sources */,
 				FD66294191AFAD8D8F482325D05E090D /* ConfigDefaultTtlSet.swift in Sources */,
+				5215996D25DFD61400F602FA /* SensorCadenceSet.swift in Sources */,
 				D32007EE9E25652BC27DDFDEB5DF56A4 /* ConfigDefaultTtlStatus.swift in Sources */,
 				7105EE8BFE0FAAB20076BD5E3BABB568 /* ConfigFriendGet.swift in Sources */,
 				31300FD03036D8DABE2F70D96E78FEDC /* ConfigFriendSet.swift in Sources */,
@@ -2140,6 +2147,7 @@
 				99A1DB5121226C7D4345FCE6241FE17B /* LightCTLTemperatureSet.swift in Sources */,
 				F28F78FB0744144D3D935DA7709805B7 /* LightCTLTemperatureSetUnacknowledged.swift in Sources */,
 				27E3E127D5AFB97ACFF5017C77A14C0E /* LightCTLTemperatureStatus.swift in Sources */,
+				5215996725DFD4E900F602FA /* SensorCadenceSetUnacknowledged.swift in Sources */,
 				65B3D4B60D0B054CC2795DDDDCFC25DA /* LightHSLDefaultGet.swift in Sources */,
 				BB8BEC2CB24707D1308436B034305DDB /* LightHSLDefaultSet.swift in Sources */,
 				6FB894C6BE86D074F0B9F801C49D4C3E /* LightHSLDefaultSetUnacknowledged.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -148,6 +148,10 @@
 		5215996D25DFD61400F602FA /* SensorCadenceSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215996C25DFD61400F602FA /* SensorCadenceSet.swift */; };
 		5215997725DFE3A100F602FA /* SensorGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215997625DFE3A100F602FA /* SensorGet.swift */; };
 		5215997D25DFE56300F602FA /* SensorStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215997C25DFE56300F602FA /* SensorStatus.swift */; };
+		5215998725E8E74C00F602FA /* SensorColumnGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215998625E8E74C00F602FA /* SensorColumnGet.swift */; };
+		5215998D25E8E85100F602FA /* SensorColumnStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215998C25E8E85100F602FA /* SensorColumnStatus.swift */; };
+		5215999325E8EC8F00F602FA /* SensorSeriesGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215999225E8EC8F00F602FA /* SensorSeriesGet.swift */; };
+		5215999925E8EDA800F602FA /* SensorSeriesStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215999825E8EDA800F602FA /* SensorSeriesStatus.swift */; };
 		523C6B1F33DB2E96993439A057BDF4D8 /* ConfigAppKeyAdd.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ED7E9A1A76137851290A8E7D4B828 /* ConfigAppKeyAdd.swift */; };
 		52DE3A9E25D5640900268D7D /* SensorDescriptorGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */; };
 		52DE3AA425D5649400268D7D /* SensorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3AA325D5649400268D7D /* SensorMessage.swift */; };
@@ -608,6 +612,10 @@
 		5215996C25DFD61400F602FA /* SensorCadenceSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorCadenceSet.swift; sourceTree = "<group>"; };
 		5215997625DFE3A100F602FA /* SensorGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorGet.swift; sourceTree = "<group>"; };
 		5215997C25DFE56300F602FA /* SensorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorStatus.swift; sourceTree = "<group>"; };
+		5215998625E8E74C00F602FA /* SensorColumnGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorColumnGet.swift; sourceTree = "<group>"; };
+		5215998C25E8E85100F602FA /* SensorColumnStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorColumnStatus.swift; sourceTree = "<group>"; };
+		5215999225E8EC8F00F602FA /* SensorSeriesGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSeriesGet.swift; sourceTree = "<group>"; };
+		5215999825E8EDA800F602FA /* SensorSeriesStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSeriesStatus.swift; sourceTree = "<group>"; };
 		52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SensorDescriptorGet.swift; sourceTree = "<group>"; };
 		52DE3AA325D5649400268D7D /* SensorMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorMessage.swift; sourceTree = "<group>"; };
 		52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorDescriptorStatus.swift; sourceTree = "<group>"; };
@@ -1146,6 +1154,10 @@
 				5215995425DFBA5200F602FA /* SensorSettingStatus.swift */,
 				5215997625DFE3A100F602FA /* SensorGet.swift */,
 				5215997C25DFE56300F602FA /* SensorStatus.swift */,
+				5215998625E8E74C00F602FA /* SensorColumnGet.swift */,
+				5215998C25E8E85100F602FA /* SensorColumnStatus.swift */,
+				5215999225E8EC8F00F602FA /* SensorSeriesGet.swift */,
+				5215999825E8EDA800F602FA /* SensorSeriesStatus.swift */,
 			);
 			path = Sensors;
 			sourceTree = "<group>";
@@ -1978,6 +1990,7 @@
 				98A00DE31C5EB5755992F9C4A1A51540 /* AccessError.swift in Sources */,
 				A27FFC722DB3B1FC2F750BE053D6945B /* AccessLayer.swift in Sources */,
 				7AE8C7BE4F001012CB6A31DA86BED193 /* AccessMessage.swift in Sources */,
+				5215998D25E8E85100F602FA /* SensorColumnStatus.swift in Sources */,
 				DDA1D2EECB0EAD1A9C7CD3686AB18C8B /* AccessPdu.swift in Sources */,
 				CF125A3824D47922B77B432D3FD84120 /* AddAddressesToFilter.swift in Sources */,
 				F9248E93149C3FC50AF451649D69BD76 /* Address.swift in Sources */,
@@ -2180,6 +2193,7 @@
 				DF34413B3E26F1CE8C163D421A5D150E /* LightHSLTargetGet.swift in Sources */,
 				BEA3977905525C9BEFA2742C7395F65B /* LightHSLTargetStatus.swift in Sources */,
 				EB5F31060C22DEED763E25770BB0FD15 /* LightLightnessDefaultGet.swift in Sources */,
+				5215999325E8EC8F00F602FA /* SensorSeriesGet.swift in Sources */,
 				E9C07D36EF99C54022E52EA2E8E2800A /* LightLightnessDefaultSet.swift in Sources */,
 				B0631254516BB821ABD87674AA001CD9 /* LightLightnessDefaultSetUnacknowledged.swift in Sources */,
 				561D6EBBC0C06FAE63B50A2AEC353311 /* LightLightnessDefaultStatus.swift in Sources */,
@@ -2241,6 +2255,7 @@
 				6A37EB9E6D6D408AF027679529C6DB5A /* Node+Address.swift in Sources */,
 				29CB61A8AC54E225F98C04A49B965349 /* Node+Elements.swift in Sources */,
 				47DC6C225774AF8E91B163DAF64BC3BA /* Node+Keys.swift in Sources */,
+				5215999925E8EDA800F602FA /* SensorSeriesStatus.swift in Sources */,
 				BBF37D56C318D5E2A3AD820D55970D27 /* Node+Provisioner.swift in Sources */,
 				A1A1A3018449FD88B6715F5D994CE2BA /* Node+Scenes.swift in Sources */,
 				5215994F25DFB8E800F602FA /* SensorSettingGet.swift in Sources */,
@@ -2303,6 +2318,7 @@
 				E5DADCCFCA9EE5FF4664C00D54C39CAA /* UpperTransportPdu.swift in Sources */,
 				92D58AE55790BD5913D9B219646C3FD1 /* UserDefaults+SeqAuth.swift in Sources */,
 				52DE3AA425D5649400268D7D /* SensorMessage.swift in Sources */,
+				5215998725E8E74C00F602FA /* SensorColumnGet.swift in Sources */,
 				18BF0F783B88F11F18D2583C8C8EAA87 /* UUID+Hex.swift in Sources */,
 				3DA44FB727F740F61B5A549DBF1F8F41 /* VendorMessage.swift in Sources */,
 			);

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -140,6 +140,10 @@
 		5215993125DE70BC00F602FA /* DeviceProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215993025DE70BC00F602FA /* DeviceProperty.swift */; };
 		5215994125DE96A700F602FA /* SensorSettingsGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215994025DE96A700F602FA /* SensorSettingsGet.swift */; };
 		5215994925DE96EB00F602FA /* SensorSettingsStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215994825DE96EB00F602FA /* SensorSettingsStatus.swift */; };
+		5215994F25DFB8E800F602FA /* SensorSettingGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215994E25DFB8E800F602FA /* SensorSettingGet.swift */; };
+		5215995525DFBA5200F602FA /* SensorSettingStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215995425DFBA5200F602FA /* SensorSettingStatus.swift */; };
+		5215995B25DFD2D800F602FA /* SensorSettingSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215995A25DFD2D800F602FA /* SensorSettingSetUnacknowledged.swift */; };
+		5215996125DFD44800F602FA /* SensorSettingSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215996025DFD44800F602FA /* SensorSettingSet.swift */; };
 		523C6B1F33DB2E96993439A057BDF4D8 /* ConfigAppKeyAdd.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ED7E9A1A76137851290A8E7D4B828 /* ConfigAppKeyAdd.swift */; };
 		52DE3A9E25D5640900268D7D /* SensorDescriptorGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */; };
 		52DE3AA425D5649400268D7D /* SensorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3AA325D5649400268D7D /* SensorMessage.swift */; };
@@ -592,6 +596,10 @@
 		5215993025DE70BC00F602FA /* DeviceProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceProperty.swift; sourceTree = "<group>"; };
 		5215994025DE96A700F602FA /* SensorSettingsGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSettingsGet.swift; sourceTree = "<group>"; };
 		5215994825DE96EB00F602FA /* SensorSettingsStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSettingsStatus.swift; sourceTree = "<group>"; };
+		5215994E25DFB8E800F602FA /* SensorSettingGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSettingGet.swift; sourceTree = "<group>"; };
+		5215995425DFBA5200F602FA /* SensorSettingStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSettingStatus.swift; sourceTree = "<group>"; };
+		5215995A25DFD2D800F602FA /* SensorSettingSetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSettingSetUnacknowledged.swift; sourceTree = "<group>"; };
+		5215996025DFD44800F602FA /* SensorSettingSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSettingSet.swift; sourceTree = "<group>"; };
 		52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SensorDescriptorGet.swift; sourceTree = "<group>"; };
 		52DE3AA325D5649400268D7D /* SensorMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorMessage.swift; sourceTree = "<group>"; };
 		52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorDescriptorStatus.swift; sourceTree = "<group>"; };
@@ -1122,6 +1130,10 @@
 				5215992A25DA9B7C00F602FA /* SensorCadenceStatus.swift */,
 				5215994025DE96A700F602FA /* SensorSettingsGet.swift */,
 				5215994825DE96EB00F602FA /* SensorSettingsStatus.swift */,
+				5215994E25DFB8E800F602FA /* SensorSettingGet.swift */,
+				5215996025DFD44800F602FA /* SensorSettingSet.swift */,
+				5215995A25DFD2D800F602FA /* SensorSettingSetUnacknowledged.swift */,
+				5215995425DFBA5200F602FA /* SensorSettingStatus.swift */,
 			);
 			path = Sensors;
 			sourceTree = "<group>";
@@ -2146,6 +2158,7 @@
 				DEE86FC955EFAA1B7F0665670B3E757F /* LightHSLSaturationSetUnacknowledged.swift in Sources */,
 				48A62F13CA72FD5ECF55D807501D679E /* LightHSLSaturationStatus.swift in Sources */,
 				F953E6BA48BFB85B0C42877AB70FB592 /* LightHSLSet.swift in Sources */,
+				5215996125DFD44800F602FA /* SensorSettingSet.swift in Sources */,
 				819DC8256A89524D9CAC1F4ED3B3CBAB /* LightHSLSetUnackowledged.swift in Sources */,
 				7B725D69D0FD04CA637A5E48A4B1BB7D /* LightHSLStatus.swift in Sources */,
 				DF34413B3E26F1CE8C163D421A5D150E /* LightHSLTargetGet.swift in Sources */,
@@ -2154,6 +2167,7 @@
 				E9C07D36EF99C54022E52EA2E8E2800A /* LightLightnessDefaultSet.swift in Sources */,
 				B0631254516BB821ABD87674AA001CD9 /* LightLightnessDefaultSetUnacknowledged.swift in Sources */,
 				561D6EBBC0C06FAE63B50A2AEC353311 /* LightLightnessDefaultStatus.swift in Sources */,
+				5215995B25DFD2D800F602FA /* SensorSettingSetUnacknowledged.swift in Sources */,
 				E440419447C210C4ECB029D8929E9227 /* LightLightnessGet.swift in Sources */,
 				388F695C32D5BE7E6789DBF275ACCD1E /* LightLightnessLastGet.swift in Sources */,
 				C150DF9D61051FD8F3237217FF9AB561 /* LightLightnessLastStatus.swift in Sources */,
@@ -2213,6 +2227,7 @@
 				47DC6C225774AF8E91B163DAF64BC3BA /* Node+Keys.swift in Sources */,
 				BBF37D56C318D5E2A3AD820D55970D27 /* Node+Provisioner.swift in Sources */,
 				A1A1A3018449FD88B6715F5D994CE2BA /* Node+Scenes.swift in Sources */,
+				5215994F25DFB8E800F602FA /* SensorSettingGet.swift in Sources */,
 				1C78ADADA3BA88528FF131A612CFE469 /* Node.swift in Sources */,
 				C24016BF65126810C30128D72E970552 /* NodeFeatures.swift in Sources */,
 				23B432F6947E9309177AA280DCC3AED7 /* nRFMeshProvision-dummy.m in Sources */,
@@ -2266,6 +2281,7 @@
 				19A5DD8043D0A928C9DE4EB017B2F2E1 /* TransitionTime.swift in Sources */,
 				655AE1E9664A5F7DD28EED421204BAEA /* UnknownMessage.swift in Sources */,
 				86B729303B82A13D9FC10526A85CBD11 /* UnprovisionedDevice.swift in Sources */,
+				5215995525DFBA5200F602FA /* SensorSettingStatus.swift in Sources */,
 				213E79650FD83191444A654DA9C46188 /* UnprovisionedDeviceBeacon.swift in Sources */,
 				21EA09D153579FEF3A0931D2D87702DC /* UpperTransportLayer.swift in Sources */,
 				E5DADCCFCA9EE5FF4664C00D54C39CAA /* UpperTransportPdu.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -138,6 +138,8 @@
 		5215992525DA99CD00F602FA /* SensorCadenceGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215992425DA99CD00F602FA /* SensorCadenceGet.swift */; };
 		5215992B25DA9B7C00F602FA /* SensorCadenceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215992A25DA9B7C00F602FA /* SensorCadenceStatus.swift */; };
 		5215993125DE70BC00F602FA /* DeviceProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215993025DE70BC00F602FA /* DeviceProperty.swift */; };
+		5215994125DE96A700F602FA /* SensorSettingsGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215994025DE96A700F602FA /* SensorSettingsGet.swift */; };
+		5215994925DE96EB00F602FA /* SensorSettingsStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215994825DE96EB00F602FA /* SensorSettingsStatus.swift */; };
 		523C6B1F33DB2E96993439A057BDF4D8 /* ConfigAppKeyAdd.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ED7E9A1A76137851290A8E7D4B828 /* ConfigAppKeyAdd.swift */; };
 		52DE3A9E25D5640900268D7D /* SensorDescriptorGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */; };
 		52DE3AA425D5649400268D7D /* SensorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3AA325D5649400268D7D /* SensorMessage.swift */; };
@@ -588,6 +590,8 @@
 		5215992425DA99CD00F602FA /* SensorCadenceGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorCadenceGet.swift; sourceTree = "<group>"; };
 		5215992A25DA9B7C00F602FA /* SensorCadenceStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorCadenceStatus.swift; sourceTree = "<group>"; };
 		5215993025DE70BC00F602FA /* DeviceProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceProperty.swift; sourceTree = "<group>"; };
+		5215994025DE96A700F602FA /* SensorSettingsGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSettingsGet.swift; sourceTree = "<group>"; };
+		5215994825DE96EB00F602FA /* SensorSettingsStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSettingsStatus.swift; sourceTree = "<group>"; };
 		52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SensorDescriptorGet.swift; sourceTree = "<group>"; };
 		52DE3AA325D5649400268D7D /* SensorMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorMessage.swift; sourceTree = "<group>"; };
 		52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorDescriptorStatus.swift; sourceTree = "<group>"; };
@@ -1116,6 +1120,8 @@
 				52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */,
 				5215992425DA99CD00F602FA /* SensorCadenceGet.swift */,
 				5215992A25DA9B7C00F602FA /* SensorCadenceStatus.swift */,
+				5215994025DE96A700F602FA /* SensorSettingsGet.swift */,
+				5215994825DE96EB00F602FA /* SensorSettingsStatus.swift */,
 			);
 			path = Sensors;
 			sourceTree = "<group>";
@@ -2055,6 +2061,7 @@
 				A85AD97788323F6980E69F855FD375C6 /* GattBearerDelegate.swift in Sources */,
 				4E2B1128D4B69C183F9D8CFAD53E0352 /* GattBearerError.swift in Sources */,
 				ED4A457E11C9172F50CAD9A829DD9982 /* GenericBatteryGet.swift in Sources */,
+				5215994925DE96EB00F602FA /* SensorSettingsStatus.swift in Sources */,
 				715BF39B0C141A786D6FA5A1581068B7 /* GenericBatteryStatus.swift in Sources */,
 				13E06DB209DF660D73D04526E3661564 /* GenericDefaultTransitionTimeGet.swift in Sources */,
 				5FFFE4BBD45A8E56D142E36863880FC3 /* GenericDefaultTransitionTimeSet.swift in Sources */,
@@ -2178,6 +2185,7 @@
 				491F99B9328D6AE6583CB0B2478342BC /* MeshNetwork+Nodes.swift in Sources */,
 				A9CBBAED5EF08321C9A7D2D6CFDE3362 /* MeshNetwork+Provisioner.swift in Sources */,
 				52DE3AAA25D6A2CA00268D7D /* SensorDescriptorStatus.swift in Sources */,
+				5215994125DE96A700F602FA /* SensorSettingsGet.swift in Sources */,
 				23A99A060C5888E472138226C21E7DCA /* MeshNetwork+Ranges.swift in Sources */,
 				5C7FA345C4F4A3C7A5753E27F29A2F96 /* MeshNetwork+Scenes.swift in Sources */,
 				C71AF6E6373A791020F1C2A86891370E /* MeshNetwork.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -146,6 +146,8 @@
 		5215996125DFD44800F602FA /* SensorSettingSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215996025DFD44800F602FA /* SensorSettingSet.swift */; };
 		5215996725DFD4E900F602FA /* SensorCadenceSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215996625DFD4E900F602FA /* SensorCadenceSetUnacknowledged.swift */; };
 		5215996D25DFD61400F602FA /* SensorCadenceSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215996C25DFD61400F602FA /* SensorCadenceSet.swift */; };
+		5215997725DFE3A100F602FA /* SensorGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215997625DFE3A100F602FA /* SensorGet.swift */; };
+		5215997D25DFE56300F602FA /* SensorStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215997C25DFE56300F602FA /* SensorStatus.swift */; };
 		523C6B1F33DB2E96993439A057BDF4D8 /* ConfigAppKeyAdd.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ED7E9A1A76137851290A8E7D4B828 /* ConfigAppKeyAdd.swift */; };
 		52DE3A9E25D5640900268D7D /* SensorDescriptorGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */; };
 		52DE3AA425D5649400268D7D /* SensorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3AA325D5649400268D7D /* SensorMessage.swift */; };
@@ -604,6 +606,8 @@
 		5215996025DFD44800F602FA /* SensorSettingSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSettingSet.swift; sourceTree = "<group>"; };
 		5215996625DFD4E900F602FA /* SensorCadenceSetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorCadenceSetUnacknowledged.swift; sourceTree = "<group>"; };
 		5215996C25DFD61400F602FA /* SensorCadenceSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorCadenceSet.swift; sourceTree = "<group>"; };
+		5215997625DFE3A100F602FA /* SensorGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorGet.swift; sourceTree = "<group>"; };
+		5215997C25DFE56300F602FA /* SensorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorStatus.swift; sourceTree = "<group>"; };
 		52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SensorDescriptorGet.swift; sourceTree = "<group>"; };
 		52DE3AA325D5649400268D7D /* SensorMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorMessage.swift; sourceTree = "<group>"; };
 		52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorDescriptorStatus.swift; sourceTree = "<group>"; };
@@ -1140,6 +1144,8 @@
 				5215996025DFD44800F602FA /* SensorSettingSet.swift */,
 				5215995A25DFD2D800F602FA /* SensorSettingSetUnacknowledged.swift */,
 				5215995425DFBA5200F602FA /* SensorSettingStatus.swift */,
+				5215997625DFE3A100F602FA /* SensorGet.swift */,
+				5215997C25DFE56300F602FA /* SensorStatus.swift */,
 			);
 			path = Sensors;
 			sourceTree = "<group>";
@@ -2014,6 +2020,7 @@
 				E93DE2BE52864CDBCC4FFAA35D3A4C62 /* ConfigGATTProxySet.swift in Sources */,
 				EE64C3628F97E7B8EA7F4641B0710F7A /* ConfigGATTProxyStatus.swift in Sources */,
 				E80FE6A7999C5E97C536C8653BE27436 /* ConfigHeartbeatPublicationGet.swift in Sources */,
+				5215997725DFE3A100F602FA /* SensorGet.swift in Sources */,
 				DF80134B5A11603DD6C4298483CA6C40 /* ConfigHeartbeatPublicationSet.swift in Sources */,
 				BC275BA1B61602362E50F60898C5CC87 /* ConfigHeartbeatPublicationStatus.swift in Sources */,
 				99F1EE9FA57FE8934A89E30456282776 /* ConfigHeartbeatSubscriptionGet.swift in Sources */,
@@ -2155,6 +2162,7 @@
 				9177F8D65A43973BED1D09A7F277ACB1 /* LightHSLGet.swift in Sources */,
 				B137530D805670B32E29958A801E9570 /* LightHSLHueGet.swift in Sources */,
 				607DAF8CF8D0E3B8FB2D1AF2A227F080 /* LightHSLHueSet.swift in Sources */,
+				5215997D25DFE56300F602FA /* SensorStatus.swift in Sources */,
 				5E0EF4E83830EBD8E00DF0C63A401ADD /* LightHSLHueSetUnacknowledged.swift in Sources */,
 				9CD977A21F5C81A123893262E84D5988 /* LightHSLHueStatus.swift in Sources */,
 				6F94E386932B9DABE49C0B47FC345A1F /* LightHSLRangeGet.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -135,7 +135,13 @@
 		4FA255D265621A76C42167EB5BAA3811 /* GenericLevelSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12B1362ABB8AF89E7C5F1F4BD352E094 /* GenericLevelSetUnacknowledged.swift */; };
 		4FE3E75FEF292E403FB8D13B64906F41 /* SHA3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 434F5E7450DADC05E75995EA79284AF8 /* SHA3.swift */; };
 		51213504F55CD20C4E3F03E4911059B2 /* ECB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643A88054A4FDB58A6101472ADA8B721 /* ECB.swift */; };
+		5215992525DA99CD00F602FA /* SensorCadenceGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215992425DA99CD00F602FA /* SensorCadenceGet.swift */; };
+		5215992B25DA9B7C00F602FA /* SensorCadenceStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215992A25DA9B7C00F602FA /* SensorCadenceStatus.swift */; };
+		5215993125DE70BC00F602FA /* DeviceProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215993025DE70BC00F602FA /* DeviceProperty.swift */; };
 		523C6B1F33DB2E96993439A057BDF4D8 /* ConfigAppKeyAdd.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ED7E9A1A76137851290A8E7D4B828 /* ConfigAppKeyAdd.swift */; };
+		52DE3A9E25D5640900268D7D /* SensorDescriptorGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */; };
+		52DE3AA425D5649400268D7D /* SensorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3AA325D5649400268D7D /* SensorMessage.swift */; };
+		52DE3AAA25D6A2CA00268D7D /* SensorDescriptorStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */; };
 		5419D23A75236616FD9003BFEAB0A196 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C21C8E900A0E68E2325ECFEC2E7B92 /* Digest.swift */; };
 		543740C6C31D3637343F37FA099E11BD /* AEADChaCha20Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30CC9F96E86F25A65521BCC123D5014 /* AEADChaCha20Poly1305.swift */; };
 		54CA4CC2D9DDD32F559FEFE36DB31914 /* NoPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC17DD2135B8E43A2EBE41EE0F6DDB19 /* NoPadding.swift */; };
@@ -503,7 +509,7 @@
 		24EC78F1692CE788901B9F2C60E79ED1 /* LightCTLDefaultStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightCTLDefaultStatus.swift; sourceTree = "<group>"; };
 		26C5F36638F91B47AF71E709DFC40669 /* Key.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Key.swift; sourceTree = "<group>"; };
 		279D789664CC436C3F4D4A21CBC5CCD1 /* UInt64+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt64+Extension.swift"; path = "Sources/CryptoSwift/UInt64+Extension.swift"; sourceTree = "<group>"; };
-		27DEA8C693FDB8927FC5D6F5EF714930 /* SceneStoreUnacknowledged.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneStoreUnacknowledged.swift; sourceTree = "<group>"; };
+		27DEA8C693FDB8927FC5D6F5EF714930 /* SceneStoreUnacknowledged.swift */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneStoreUnacknowledged.swift; sourceTree = "<group>"; };
 		283A6E25ABA315359A802BBBB4390288 /* ConfigNetworkTransmitSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigNetworkTransmitSet.swift; sourceTree = "<group>"; };
 		28A6344F02F9B61FE6A28745533BF75F /* UInt32+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UInt32+Extension.swift"; path = "Sources/CryptoSwift/UInt32+Extension.swift"; sourceTree = "<group>"; };
 		28C7C7B3242CA745C28C0ABCFED614D8 /* ClosedRange.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClosedRange.swift; sourceTree = "<group>"; };
@@ -515,8 +521,8 @@
 		2B7633252BEF6DC6B39C28821917F5A8 /* IvIndex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IvIndex.swift; sourceTree = "<group>"; };
 		2B93E2D7F149DB2C366055BEEDB66A66 /* ConfigModelPublicationVirtualAddressSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigModelPublicationVirtualAddressSet.swift; sourceTree = "<group>"; };
 		2C14C06AB4607CC125AFC5656016997E /* ConfigAppKeyList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigAppKeyList.swift; sourceTree = "<group>"; };
-		2C1637BBCADF930540CD740A57A7D516 /* SceneRecall.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneRecall.swift; sourceTree = "<group>"; };
-		2C65D73CCDA224902B0BC1B7174424EE /* SceneRegisterStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneRegisterStatus.swift; sourceTree = "<group>"; };
+		2C1637BBCADF930540CD740A57A7D516 /* SceneRecall.swift */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneRecall.swift; sourceTree = "<group>"; };
+		2C65D73CCDA224902B0BC1B7174424EE /* SceneRegisterStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneRegisterStatus.swift; sourceTree = "<group>"; };
 		2CA58286CB52FE4799BDB7CFD525D84C /* MeshLoggerDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MeshLoggerDelegate.swift; sourceTree = "<group>"; };
 		2CABA57E99AF45E1AECFCEA02E08C7A4 /* PBGattBearer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PBGattBearer.swift; sourceTree = "<group>"; };
 		2D6BCC1E5E70E1A45D22FB142D7E829D /* PublicKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PublicKey.swift; sourceTree = "<group>"; };
@@ -579,6 +585,12 @@
 		4EB8A376EB18FE8DA60ABC32DFA535EF /* Data.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		4F65B787817450BEAC96EBA741561A63 /* LowerTransportError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LowerTransportError.swift; sourceTree = "<group>"; };
 		52084737DEB046D97BB00FBE5F20B82D /* MeshState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MeshState.swift; sourceTree = "<group>"; };
+		5215992425DA99CD00F602FA /* SensorCadenceGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorCadenceGet.swift; sourceTree = "<group>"; };
+		5215992A25DA9B7C00F602FA /* SensorCadenceStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorCadenceStatus.swift; sourceTree = "<group>"; };
+		5215993025DE70BC00F602FA /* DeviceProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceProperty.swift; sourceTree = "<group>"; };
+		52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SensorDescriptorGet.swift; sourceTree = "<group>"; };
+		52DE3AA325D5649400268D7D /* SensorMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorMessage.swift; sourceTree = "<group>"; };
+		52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorDescriptorStatus.swift; sourceTree = "<group>"; };
 		531B9F2EF263CE4EA7065194384BE25F /* MeshStateManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MeshStateManager.swift; sourceTree = "<group>"; };
 		538806EF44671C282F414D17398F37EA /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		544BD2258E957BEB4A4E579D0107AF32 /* Provisioner+Node.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Provisioner+Node.swift"; sourceTree = "<group>"; };
@@ -640,7 +652,7 @@
 		777BC8CEF53516FF5AD98E30C2E24977 /* UnknownMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UnknownMessage.swift; sourceTree = "<group>"; };
 		7835F1DD59380ED95A8BA1F1171ADD5E /* GenericOnPowerUpSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericOnPowerUpSet.swift; sourceTree = "<group>"; };
 		7864C635FB1327C8EFCB4A311C201DC7 /* MeshNetworkManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MeshNetworkManager.swift; path = nRFMeshProvision/Classes/MeshNetworkManager.swift; sourceTree = "<group>"; };
-		7944FACD4E313437B3A88907FCD5DE68 /* SceneDeleteUnacknowledged.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneDeleteUnacknowledged.swift; sourceTree = "<group>"; };
+		7944FACD4E313437B3A88907FCD5DE68 /* SceneDeleteUnacknowledged.swift */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneDeleteUnacknowledged.swift; sourceTree = "<group>"; };
 		79564C40077AEB1DB1E0763FCCE5185A /* GenericOnOffGet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericOnOffGet.swift; sourceTree = "<group>"; };
 		79D146A7496F5732D2CA4017BDB21B63 /* Node+Address.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Node+Address.swift"; sourceTree = "<group>"; };
 		7B13D00AD5032722E2DA831A0E470221 /* ConfigModelSubscriptionVirtualAddressAdd.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigModelSubscriptionVirtualAddressAdd.swift; sourceTree = "<group>"; };
@@ -705,7 +717,7 @@
 		99F0DE343C5900845DA05BC37FAC82E5 /* FilterStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FilterStatus.swift; sourceTree = "<group>"; };
 		9AEB012E6EC185485B22AE30D8A07F0A /* GenericPowerLevelSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericPowerLevelSet.swift; sourceTree = "<group>"; };
 		9B75FAE6885CC2FB549E2DB112228BB4 /* Pods-nRFMeshProvision_Tests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-nRFMeshProvision_Tests-Info.plist"; sourceTree = "<group>"; };
-		9C094E599DC4B9257DB01B099C9D92B6 /* SceneStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneStatus.swift; sourceTree = "<group>"; };
+		9C094E599DC4B9257DB01B099C9D92B6 /* SceneStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneStatus.swift; sourceTree = "<group>"; };
 		9CA8F8CC284F53E034E56B19D2EABA85 /* LightHSLSetUnackowledged.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightHSLSetUnackowledged.swift; sourceTree = "<group>"; };
 		9D16351BA202AEF3960D964B7A2FC51E /* LightLightnessRangeStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightLightnessRangeStatus.swift; sourceTree = "<group>"; };
 		9D3C73A04846CB47FB0F7E6533996E68 /* LightHSLHueStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightHSLHueStatus.swift; sourceTree = "<group>"; };
@@ -719,7 +731,7 @@
 		A1FD9EFFF210FDE10629A511B1957F98 /* CryptoSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "CryptoSwift-umbrella.h"; sourceTree = "<group>"; };
 		A310E0C60D9BE281F07B1E43E190065C /* GenericPowerLastStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericPowerLastStatus.swift; sourceTree = "<group>"; };
 		A311D77D81FE1F5349A806E59B9AE092 /* Scene.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Scene.swift; sourceTree = "<group>"; };
-		A34F3B863AA0756D755A4E80386787AA /* SceneStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneStore.swift; sourceTree = "<group>"; };
+		A34F3B863AA0756D755A4E80386787AA /* SceneStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneStore.swift; sourceTree = "<group>"; };
 		A3B03D1D0A6470D0D7FC7269BA25068E /* AES+Foundation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AES+Foundation.swift"; path = "Sources/CryptoSwift/Foundation/AES+Foundation.swift"; sourceTree = "<group>"; };
 		A421192576A8E503AE97BBA464BDB881 /* Pods-nRFMeshProvision_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-nRFMeshProvision_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		A5FC765AE940CEDCEE9D2CFA66331EA3 /* OptionSet+Data.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "OptionSet+Data.swift"; sourceTree = "<group>"; };
@@ -751,7 +763,7 @@
 		B5E2B6D8204EAA1400D236CD6A50AF43 /* Address.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Address.swift; sourceTree = "<group>"; };
 		B681335B81957A049873C2D7435F1ED6 /* GattBearerDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GattBearerDelegate.swift; sourceTree = "<group>"; };
 		B6A4B750CD0512CF43F4771040C75677 /* GenericLevelSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericLevelSet.swift; sourceTree = "<group>"; };
-		B6A4C754FE7F4DD81A6659FE2060114A /* SceneRegisterGet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneRegisterGet.swift; sourceTree = "<group>"; };
+		B6A4C754FE7F4DD81A6659FE2060114A /* SceneRegisterGet.swift */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneRegisterGet.swift; sourceTree = "<group>"; };
 		B6D4773D76A7168631B479638794872E /* LightCTLGet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightCTLGet.swift; sourceTree = "<group>"; };
 		B7710B4FB8FF484D1B19E19EF1893125 /* Generics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Generics.swift; path = Sources/CryptoSwift/Generics.swift; sourceTree = "<group>"; };
 		B7D63D5372DE43F425AB81AAEE906535 /* GenericBatteryStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericBatteryStatus.swift; sourceTree = "<group>"; };
@@ -769,14 +781,14 @@
 		C00ED4E395D689600DB67B37CE4096C5 /* GenericPowerRangeStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericPowerRangeStatus.swift; sourceTree = "<group>"; };
 		C184F8C183B5800FB936B6D079F66B1F /* Pods-nRFMeshProvision_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-nRFMeshProvision_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		C30CC9F96E86F25A65521BCC123D5014 /* AEADChaCha20Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEADChaCha20Poly1305.swift; path = Sources/CryptoSwift/AEAD/AEADChaCha20Poly1305.swift; sourceTree = "<group>"; };
-		C31699E373407774BDB78BE99C602127 /* SceneRecallUnacknowledged.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneRecallUnacknowledged.swift; sourceTree = "<group>"; };
+		C31699E373407774BDB78BE99C602127 /* SceneRecallUnacknowledged.swift */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneRecallUnacknowledged.swift; sourceTree = "<group>"; };
 		C5B0746FD8D7FA9F1B29CD76F1B22E4E /* LightCTLDefaultSetUnacknowledged.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightCTLDefaultSetUnacknowledged.swift; sourceTree = "<group>"; };
 		C6625596D92D53C80B85E66FDDB1E060 /* Collection+Extension.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Collection+Extension.swift"; path = "Sources/CryptoSwift/Collection+Extension.swift"; sourceTree = "<group>"; };
 		C70E3B1B769D9314CFE3C3C9CB846A3B /* LightHSLSaturationSetUnacknowledged.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightHSLSaturationSetUnacknowledged.swift; sourceTree = "<group>"; };
 		C7234FD2AA9C4FF86407994212554BB7 /* LightHSLRangeGet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightHSLRangeGet.swift; sourceTree = "<group>"; };
 		C76D8435DEA308F0A11BCEB773C87B96 /* BlockModeOptions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockModeOptions.swift; path = Sources/CryptoSwift/BlockMode/BlockModeOptions.swift; sourceTree = "<group>"; };
 		C7FB66B64BF69DB84A9EB0B9F9743992 /* Int+Hex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Int+Hex.swift"; sourceTree = "<group>"; };
-		C8053B756CCA4A3B0E83D25871A53028 /* SceneGet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneGet.swift; sourceTree = "<group>"; };
+		C8053B756CCA4A3B0E83D25871A53028 /* SceneGet.swift */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneGet.swift; sourceTree = "<group>"; };
 		C86C992475272AAE65364AD37C8832D8 /* CBC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CBC.swift; path = Sources/CryptoSwift/BlockMode/CBC.swift; sourceTree = "<group>"; };
 		CABBCBFB8207CAF6F05B980964B75993 /* BlockEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BlockEncryptor.swift; path = Sources/CryptoSwift/BlockEncryptor.swift; sourceTree = "<group>"; };
 		CAE5A48AAD5094E64BC06ACC5E80B27F /* StreamEncryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StreamEncryptor.swift; path = Sources/CryptoSwift/StreamEncryptor.swift; sourceTree = "<group>"; };
@@ -867,7 +879,7 @@
 		FBD0F2C216F862FA00F732873CD2F4DD /* LightHSLSaturationSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightHSLSaturationSet.swift; sourceTree = "<group>"; };
 		FC01F5DE571A85F45B4FD53095F78BBE /* Storage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Storage.swift; path = nRFMeshProvision/Classes/Storage.swift; sourceTree = "<group>"; };
 		FC06DADE90DF0FC1A3411D92B38C9BB2 /* ConfigSIGModelSubscriptionList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigSIGModelSubscriptionList.swift; sourceTree = "<group>"; };
-		FC2B4880DD4BC5353F1373AC1DBD575F /* SceneDelete.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneDelete.swift; sourceTree = "<group>"; };
+		FC2B4880DD4BC5353F1373AC1DBD575F /* SceneDelete.swift */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneDelete.swift; sourceTree = "<group>"; };
 		FDC424460CDE7579385B7FA31CF02197 /* LightCTLTemperatureRangeSetUnacknowledged.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightCTLTemperatureRangeSetUnacknowledged.swift; sourceTree = "<group>"; };
 		FDD9C50B778C15FB416FB0CD97B0A8F6 /* ConfigAppKeyDelete.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigAppKeyDelete.swift; sourceTree = "<group>"; };
 		FECC5F42DFA6578EDAAF7856876C65B5 /* KeyRefreshPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KeyRefreshPhase.swift; sourceTree = "<group>"; };
@@ -1095,6 +1107,17 @@
 			);
 			name = "Support Files";
 			path = "Example/Pods/Target Support Files/nRFMeshProvision";
+			sourceTree = "<group>";
+		};
+		52DE3A9325D563BF00268D7D /* Sensors */ = {
+			isa = PBXGroup;
+			children = (
+				52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */,
+				52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */,
+				5215992425DA99CD00F602FA /* SensorCadenceGet.swift */,
+				5215992A25DA9B7C00F602FA /* SensorCadenceStatus.swift */,
+			);
+			path = Sensors;
 			sourceTree = "<group>";
 		};
 		578452D2E740E91742655AC8F1636D1F /* iOS */ = {
@@ -1332,10 +1355,12 @@
 		7CA1E1EC135D3778786E090DE76291C7 /* Mesh Messages */ = {
 			isa = PBXGroup;
 			children = (
+				5215993025DE70BC00F602FA /* DeviceProperty.swift */,
 				DAC7D8C779300D2702FE0DA5E7F45573 /* ConfigMessage.swift */,
 				F9DBD80605BF0B6D9CD247A11B98C853 /* GenericMessage.swift */,
 				F7BE07A8B977F0B1E777A574E71A97BA /* MeshMessage.swift */,
 				F5BA8C719898DC3B38100C9AAD8119B4 /* MeshMessageError.swift */,
+				52DE3AA325D5649400268D7D /* SensorMessage.swift */,
 				777BC8CEF53516FF5AD98E30C2E24977 /* UnknownMessage.swift */,
 				D7A04757CC2ED4012DF4B7CCED05DC86 /* VendorMessage.swift */,
 				A5407D3004105A0D45D822F19F489891 /* Foundation */,
@@ -1343,6 +1368,7 @@
 				BADBA6BD04939DC867D95EFB89FD2F05 /* Lighting */,
 				6D01510E6447A28D39F2036DA8CDB3EB /* Proxy Configuration */,
 				328B0B94718E15EC8BF4D872D1F6346A /* Time and Scenes */,
+				52DE3A9325D563BF00268D7D /* Sensors */,
 			);
 			name = "Mesh Messages";
 			path = "nRFMeshProvision/Classes/Mesh Messages";
@@ -1927,6 +1953,7 @@
 				F9248E93149C3FC50AF451649D69BD76 /* Address.swift in Sources */,
 				A4D85CB50CF5205A26F643F66B409412 /* AddressRange.swift in Sources */,
 				EDB849C95E31074BC2FDBD2877B2D229 /* Algorithm.swift in Sources */,
+				5215992525DA99CD00F602FA /* SensorCadenceGet.swift in Sources */,
 				25DE3326A8476A0DD321AAA990C98938 /* ApplicationKey+MeshNetwork.swift in Sources */,
 				C439AFBBD5F3E84BD5C2132FB27BE53C /* ApplicationKey+NetworkKey.swift in Sources */,
 				17683E5A4D5E2AFB5579259B668B4783 /* ApplicationKey.swift in Sources */,
@@ -2050,6 +2077,7 @@
 				783B4600D0619E3C51F213F67F1A950C /* GenericOnPowerUpSet.swift in Sources */,
 				7469FCDFDC5330AAC0A4C0952E01AAD0 /* GenericOnPowerUpSetUnacknowledged.swift in Sources */,
 				92A0EB8D35B90C98C15D58D177EC6803 /* GenericOnPowerUpStatus.swift in Sources */,
+				5215992B25DA9B7C00F602FA /* SensorCadenceStatus.swift in Sources */,
 				C39C7C5295C2BC5DA31C185F7A87B1D9 /* GenericPowerDefaultSet.swift in Sources */,
 				31ACB4B4F7385BF1465A9B2FFE8F3922 /* GenericPowerDefaultSetUnacknowledged.swift in Sources */,
 				EBAD47E8DB455AF7A01283652D0E42E3 /* GenericPowerDefaultStatus.swift in Sources */,
@@ -2149,6 +2177,7 @@
 				F5A0E86B8175C1D7F6DA5F9EF9AAAFB8 /* MeshNetwork+Keys.swift in Sources */,
 				491F99B9328D6AE6583CB0B2478342BC /* MeshNetwork+Nodes.swift in Sources */,
 				A9CBBAED5EF08321C9A7D2D6CFDE3362 /* MeshNetwork+Provisioner.swift in Sources */,
+				52DE3AAA25D6A2CA00268D7D /* SensorDescriptorStatus.swift in Sources */,
 				23A99A060C5888E472138226C21E7DCA /* MeshNetwork+Ranges.swift in Sources */,
 				5C7FA345C4F4A3C7A5753E27F29A2F96 /* MeshNetwork+Scenes.swift in Sources */,
 				C71AF6E6373A791020F1C2A86891370E /* MeshNetwork.swift in Sources */,
@@ -2197,6 +2226,7 @@
 				F47A7C38A7526D429BEC4773D75B8D71 /* PublicKey.swift in Sources */,
 				79E13E28012A3C058FFB485303EEDEDD /* Publish.swift in Sources */,
 				04DB928D0B9CDAC59D68C44B8B9C1B0A /* RangeObject.swift in Sources */,
+				52DE3A9E25D5640900268D7D /* SensorDescriptorGet.swift in Sources */,
 				4DF689E80F237AB0CBDE4E49A160F61F /* Ranges.swift in Sources */,
 				01E124862C05C8FA75CA3BE4211038D8 /* RemoveAddressesFromFilter.swift in Sources */,
 				FEB181CDA68C5CB186AC20A8631EB510 /* Scene+Nodes.swift in Sources */,
@@ -2207,6 +2237,7 @@
 				FD52DAD16DFA59D01A863F4AA1550481 /* SceneGet.swift in Sources */,
 				70FD7369E7AAF84DE2EF8AF9900E6D9A /* SceneNumber.swift in Sources */,
 				C89A9DB641A25D0BBBA38434F52AFA64 /* SceneRange.swift in Sources */,
+				5215993125DE70BC00F602FA /* DeviceProperty.swift in Sources */,
 				FA8F20AED3626FBEE85067F539C8E70D /* SceneRecall.swift in Sources */,
 				7CCD67CADDED5B0A7A6AD827B9A39538 /* SceneRecallUnacknowledged.swift in Sources */,
 				DE556FB495AD82B29E37C0809E7D6D7F /* SceneRegisterGet.swift in Sources */,
@@ -2231,6 +2262,7 @@
 				21EA09D153579FEF3A0931D2D87702DC /* UpperTransportLayer.swift in Sources */,
 				E5DADCCFCA9EE5FF4664C00D54C39CAA /* UpperTransportPdu.swift in Sources */,
 				92D58AE55790BD5913D9B219646C3FD1 /* UserDefaults+SeqAuth.swift in Sources */,
+				52DE3AA425D5649400268D7D /* SensorMessage.swift in Sources */,
 				18BF0F783B88F11F18D2583C8C8EAA87 /* UUID+Hex.swift in Sources */,
 				3DA44FB727F740F61B5A549DBF1F8F41 /* VendorMessage.swift in Sources */,
 			);

--- a/Example/Tests/DeviceProperties.swift
+++ b/Example/Tests/DeviceProperties.swift
@@ -1,0 +1,241 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import XCTest
+@testable import nRFMeshProvision
+
+class DeviceProperties: XCTestCase {
+
+    func testPercentage8() throws {
+        let samples: [(Data, Decimal?, Data)] = [
+            (Data([0]),   0.0,   Data([0])),         // min
+            (Data([1]),   0.5,   Data([1])),        // basic
+            (Data([100]), 50.0,  Data([100])),     // middle
+            (Data([200]), 100.0, Data([200])),    // max
+            (Data([201]), 100.0, Data([200])),   // trundated
+            (Data([0xFF]), nil,  Data([0xFF])), // unknown
+        ]
+        
+        for (sample, result, encoded) in samples {
+            let characteristic = DeviceProperty.motionSensed.read(from: sample, at: 0, length: 1)
+            switch characteristic {
+            case .percentage8(let percent):
+                XCTAssertEqual(percent, result, "Failed to parse \(sample.hex) into \(String(describing: result))")
+            default:
+                XCTFail("Failed to parse \(sample.hex) into .percentage8")
+            }
+            
+            let test = DevicePropertyCharacteristic.percentage8(result)
+            XCTAssertEqual(test, characteristic)
+            XCTAssertEqual(characteristic.data, encoded, "\(characteristic.data.hex) != \(encoded.hex)")
+        }
+    }
+    
+    func testTemperature8() throws {
+        let samples: [(Data, Decimal?, Data)] = [
+            (Data([0x80]), -64.0, Data([0x80])),     // min
+            (Data([0]),    0.0,   Data([0])),       // basic
+            (Data([1]),    0.5,   Data([1])),      // middle
+            (Data([126]),  63.0,  Data([126])),   // max
+            (Data([0x7F]), nil,   Data([0x7F])), // unknown
+        ]
+        
+        for (sample, result, encoded) in samples {
+            let characteristic = DeviceProperty.desiredAmbientTemperature.read(from: sample, at: 0, length: 1)
+            switch characteristic {
+            case .temperature8(let temp):
+                XCTAssertEqual(temp, result, "Failed to parse \(sample.hex) into \(String(describing: result))")
+            default:
+                XCTFail("Failed to parse \(sample.hex) into .temperature8")
+            }
+            
+            let test = DevicePropertyCharacteristic.temperature8(result)
+            XCTAssertEqual(test, characteristic)
+            XCTAssertEqual(characteristic.data, encoded, "\(characteristic.data.hex) != \(encoded.hex)")
+        }
+    }
+    
+    func testPerceivedLightness() throws {
+        let samples: [(Data, UInt16, Data)] = [
+            (Data([0x00, 0x00]), 0x0000, Data([0x00, 0x00])),    // min
+            (Data([0x01, 0x00]), 0x0001, Data([0x01, 0x00])),   // basic
+            (Data([0xCD, 0xAB]), 0xABCD, Data([0xCD, 0xAB])),  // middle
+            (Data([0xFF, 0xFF]), 0xFFFF, Data([0xFF, 0xFF])), // max
+        ]
+        
+        for (sample, result, encoded) in samples {
+            let characteristic = DeviceProperty.lightControlLightnessOn.read(from: sample, at: 0, length: 2)
+            switch characteristic {
+            case .perceivedLightness(let value):
+                XCTAssertEqual(value, result, "Failed to parse \(sample.hex) into \(String(describing: result))")
+            default:
+                XCTFail("Failed to parse \(sample.hex) into .perceivedLightness")
+            }
+            
+            let test = DevicePropertyCharacteristic.perceivedLightness(result)
+            XCTAssertEqual(test, characteristic)
+            XCTAssertEqual(characteristic.data, encoded, "\(characteristic.data.hex) != \(encoded.hex)")
+        }
+    }
+    
+    func testCount16() throws {
+        let samples: [(Data, UInt16?, Data)] = [
+            (Data([0x00, 0x00]), 0x0000, Data([0x00, 0x00])),     // min
+            (Data([0x01, 0x00]), 0x0001, Data([0x01, 0x00])),    // basic
+            (Data([0xCD, 0xAB]), 0xABCD, Data([0xCD, 0xAB])),   // middle
+            (Data([0xFE, 0xFF]), 0xFFFE, Data([0xFE, 0xFF])),  // max
+            (Data([0xFF, 0xFF]), nil,    Data([0xFF, 0xFF])), // unknown
+        ]
+        
+        for (sample, result, encoded) in samples {
+            let characteristic = DeviceProperty.peopleCount.read(from: sample, at: 0, length: 2)
+            switch characteristic {
+            case .count16(let count):
+                XCTAssertEqual(count, result, "Failed to parse \(sample.hex) into \(String(describing: result))")
+            default:
+                XCTFail("Failed to parse \(sample.hex) into .count16")
+            }
+            
+            let test = DevicePropertyCharacteristic.count16(result)
+            XCTAssertEqual(test, characteristic)
+            XCTAssertEqual(characteristic.data, encoded, "\(characteristic.data.hex) != \(encoded.hex)")
+        }
+    }
+    
+    func testHumidity() throws {
+        let samples: [(Data, Decimal?, Data)] = [
+            (Data([0x00, 0x00]), 0.0,   Data([0x00, 0x00])),      // min
+            (Data([0x01, 0x00]), 0.01,  Data([0x01, 0x00])),     // basic
+            (Data([0xD2, 0x04]), 12.34, Data([0xD2, 0x04])),    // middle
+            (Data([0x10, 0x27]), 100.0, Data([0x10, 0x27])),   // max
+            (Data([0x11, 0x27]), 100.0, Data([0x10, 0x27])),  // trucated
+            (Data([0xFF, 0xFF]), nil,   Data([0xFF, 0xFF])), // unknown
+        ]
+        
+        for (sample, result, encoded) in samples {
+            let characteristic = DeviceProperty.presentIndoorRelativeHumidity.read(from: sample, at: 0, length: 2)
+            switch characteristic {
+            case .humidity(let percent):
+                XCTAssertEqual(percent, result, "Failed to parse \(sample.hex) into \(String(describing: result))")
+            default:
+                XCTFail("Failed to parse \(sample.hex) into .humidity")
+            }
+            
+            let test = DevicePropertyCharacteristic.humidity(result)
+            XCTAssertEqual(test, characteristic)
+            XCTAssertEqual(characteristic.data, encoded, "\(characteristic.data.hex) != \(encoded.hex)")
+        }
+    }
+    
+    func testTemperature() throws {
+        let samples: [(Data, Decimal?, Data)] = [
+            (Data([0x4D, 0x95]), Decimal(string: "-273.15"), Data([0x4D, 0x95])),      // min
+            (Data([0x01, 0x00]), Decimal(string:    "0.01"), Data([0x01, 0x00])),     // basic
+            (Data([0xD2, 0x04]), Decimal(string:   "12.34"), Data([0xD2, 0x04])),    // middle
+            (Data([0xFF, 0x7F]), Decimal(string:  "327.67"), Data([0xFF, 0x7F])),   // max
+            (Data([0xD0, 0x8A]), Decimal(string: "-273.15"), Data([0x4D, 0x95])),  // trucated
+            (Data([0x00, 0x80]), nil,                        Data([0x00, 0x80])), // unknown
+        ]
+        
+        for (sample, result, encoded) in samples {
+            let characteristic = DeviceProperty.precisePresentAmbientTemperature.read(from: sample, at: 0, length: 2)
+            switch characteristic {
+            case .temperature(let temp):
+                XCTAssertEqual(temp, result, "Failed to parse \(sample.hex) into \(String(describing: result))")
+            default:
+                XCTFail("Failed to parse \(sample.hex) into .temperature")
+            }
+            
+            let test = DevicePropertyCharacteristic.temperature(result)
+            XCTAssertEqual(test, characteristic)
+            XCTAssertEqual(characteristic.data, encoded, "\(characteristic.data.hex) != \(encoded.hex)")
+        }
+    }
+    
+    func testCoefficient() throws {
+        let samples: [(Data, Float, Data)] = [
+            (Data([0xA4, 0x70, 0x45, 0x41]), 12.34,      Data([0xA4, 0x70, 0x45, 0x41])),       // basic
+            (Data([0x17, 0xB7, 0xD1, 0xB8]), -0.0001,    Data([0x17, 0xB7, 0xD1, 0xB8])),      // negative
+            (Data([0x00, 0x00, 0x00, 0x00]),  0.00,      Data([0x00, 0x00, 0x00, 0x00])),     // zero
+            (Data([0x00, 0x00, 0x00, 0x80]), -.zero,     Data([0x00, 0x00, 0x00, 0x80])),    // negative zero
+            (Data([0x00, 0x00, 0x80, 0x7F]),  .infinity, Data([0x00, 0x00, 0x80, 0x7F])),   // positive infinity
+            (Data([0x00, 0x00, 0x80, 0xFF]), -.infinity, Data([0x00, 0x00, 0x80, 0xFF])),  // negative infinity
+            (Data([0xFF, 0xFF, 0xFF, 0x7F]),  .nan,      Data([0xFF, 0xFF, 0xFF, 0x7F])), // NaN
+        ]
+        
+        for (sample, result, encoded) in samples {
+            let characteristic = DeviceProperty.sensorGain.read(from: sample, at: 0, length: 4)
+            switch characteristic {
+            case .coefficient(let value):
+                if value.isNaN {
+                    XCTAssertTrue(result.isNaN, "Result is not NaN")
+                } else {
+                    XCTAssertEqual(value, result, "Failed to parse \(sample.hex) into \(String(describing: result))")
+                }
+            default:
+                XCTFail("Failed to parse \(sample.hex) into .coefficient")
+            }
+            
+            let test = DevicePropertyCharacteristic.coefficient(result)
+            if result.isNaN, case .coefficient(let value) = test {
+                XCTAssert(value.isNaN)
+            } else {
+                XCTAssertEqual(test, characteristic)
+            }
+            XCTAssertEqual(characteristic.data, encoded, "\(characteristic.data.hex) != \(encoded.hex)")
+        }
+    }
+    
+    func testDateUTC() throws {
+        let dayInSeconds: TimeInterval = 86400.0
+        let samples: [(Data, Date?, Data)] = [
+            (Data([0x01, 0x00, 0x00]), Date(timeIntervalSince1970: 0x000001 * dayInSeconds), Data([0x01, 0x00, 0x00])),     // min
+            (Data([0x0F, 0x00, 0x00]), Date(timeIntervalSince1970: 0x00000F * dayInSeconds), Data([0x0F, 0x00, 0x00])),    // basic
+            (Data([0x56, 0x34, 0x12]), Date(timeIntervalSince1970: 0x123456 * dayInSeconds), Data([0x56, 0x34, 0x12])),   // middle
+            (Data([0xFF, 0xFF, 0xFF]), Date(timeIntervalSince1970: 0xFFFFFF * dayInSeconds), Data([0xFF, 0xFF, 0xFF])),  // max
+            (Data([0x00, 0x00, 0x00]), nil,                                                  Data([0x00, 0x00, 0x00])), // unknown
+        ]
+        
+        for (sample, result, encoded) in samples {
+            let characteristic = DeviceProperty.deviceDateOfManufacture.read(from: sample, at: 0, length: 3)
+            switch characteristic {
+            case .dateUTC(let date):
+                XCTAssertEqual(date, result, "Failed to parse \(sample.hex) into \(String(describing: result))")
+            default:
+                XCTFail("Failed to parse \(sample.hex) into .dateUTC")
+            }
+            
+            let test = DevicePropertyCharacteristic.dateUTC(result)
+            XCTAssertEqual(test, characteristic)
+            XCTAssertEqual(characteristic.data, encoded, "\(characteristic.data.hex) != \(encoded.hex)")
+        }
+    }
+
+}

--- a/Example/nRFMeshProvision.xcodeproj/project.pbxproj
+++ b/Example/nRFMeshProvision.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		5212152D231545D40059FB3D /* ModelGroupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5212152C231545D40059FB3D /* ModelGroupCell.swift */; };
 		5212152F231554190059FB3D /* ProgressCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5212152E231554190059FB3D /* ProgressCollectionViewController.swift */; };
 		521215312316C36B0059FB3D /* GenericLevelGroupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521215302316C36B0059FB3D /* GenericLevelGroupCell.swift */; };
+		5215998325E6703C00F602FA /* DeviceProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215998225E6703C00F602FA /* DeviceProperties.swift */; };
 		5217D2E0250F522A004FDE79 /* GenericDefaultTransitionTimeServerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5217D2DF250F522A004FDE79 /* GenericDefaultTransitionTimeServerDelegate.swift */; };
 		5217D2E2250F7639004FDE79 /* GenericDefaultTransitionTimeClientDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5217D2E1250F7639004FDE79 /* GenericDefaultTransitionTimeClientDelegate.swift */; };
 		5217D2E5250F90D8004FDE79 /* GenericDefaultTransitionTimeViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5217D2E3250F90D8004FDE79 /* GenericDefaultTransitionTimeViewCell.swift */; };
@@ -180,6 +181,7 @@
 		5212152C231545D40059FB3D /* ModelGroupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelGroupCell.swift; sourceTree = "<group>"; };
 		5212152E231554190059FB3D /* ProgressCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressCollectionViewController.swift; sourceTree = "<group>"; };
 		521215302316C36B0059FB3D /* GenericLevelGroupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericLevelGroupCell.swift; sourceTree = "<group>"; };
+		5215998225E6703C00F602FA /* DeviceProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceProperties.swift; sourceTree = "<group>"; };
 		5217D2DF250F522A004FDE79 /* GenericDefaultTransitionTimeServerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericDefaultTransitionTimeServerDelegate.swift; sourceTree = "<group>"; };
 		5217D2E1250F7639004FDE79 /* GenericDefaultTransitionTimeClientDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericDefaultTransitionTimeClientDelegate.swift; sourceTree = "<group>"; };
 		5217D2E3250F90D8004FDE79 /* GenericDefaultTransitionTimeViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericDefaultTransitionTimeViewCell.swift; sourceTree = "<group>"; };
@@ -741,6 +743,7 @@
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 				5231400122EEF7940074325A /* CreatingMeshNetwork.swift */,
 				524A8FD925D281A200ABEFB7 /* CryptoTest.swift */,
+				5215998225E6703C00F602FA /* DeviceProperties.swift */,
 				529522B5251B850700158AE0 /* Exporting.swift */,
 				52D2707D2511F850002F51F3 /* FastSending.swift */,
 				529B75AA2248E276008F1CE7 /* SceneRanges.swift */,
@@ -1116,6 +1119,7 @@
 				5231400022EEE1770074325A /* AssigningGroupAddresses.swift in Sources */,
 				52BC6F4A2452C4FB00EBEEA4 /* SecureNetworkBeacons.swift in Sources */,
 				52568D4B22DDFAC700B7B236 /* Groups.swift in Sources */,
+				5215998325E6703C00F602FA /* DeviceProperties.swift in Sources */,
 				52B492DB25C8A32E0096E75D /* KeyRefreshProcedure.swift in Sources */,
 				52F6AD6C22B78F3000F0D7DF /* CompositionData.swift in Sources */,
 				523F777022C64FD20030EA6A /* ConfigMessages.swift in Sources */,

--- a/Example/nRFMeshProvision.xcodeproj/project.pbxproj
+++ b/Example/nRFMeshProvision.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		52CD0A622330DCFF00A9A181 /* CustomAddressCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CD0A612330DCFF00A9A181 /* CustomAddressCell.swift */; };
 		52D2707E2511F850002F51F3 /* FastSending.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52D2707D2511F850002F51F3 /* FastSending.swift */; };
 		52DA9D7224F6765C0051795B /* UInt16+Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DA9D7124F6765C0051795B /* UInt16+Time.swift */; };
+		52DE3ABA25DA871800268D7D /* SensorClientDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3AB925DA871800268D7D /* SensorClientDelegate.swift */; };
 		52DF5D8A228DA78A00C297C1 /* ConfigurationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DF5D89228DA78A00C297C1 /* ConfigurationViewController.swift */; };
 		52DF5D8C228DAA0500C297C1 /* NodeViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DF5D8B228DAA0500C297C1 /* NodeViewCell.swift */; };
 		52DF5D8F229691BD00C297C1 /* NetworkConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DF5D8E229691BD00C297C1 /* NetworkConnection.swift */; };
@@ -294,6 +295,7 @@
 		52CD0A612330DCFF00A9A181 /* CustomAddressCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAddressCell.swift; sourceTree = "<group>"; };
 		52D2707D2511F850002F51F3 /* FastSending.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FastSending.swift; sourceTree = "<group>"; };
 		52DA9D7124F6765C0051795B /* UInt16+Time.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UInt16+Time.swift"; path = "Utils/UInt16+Time.swift"; sourceTree = "<group>"; };
+		52DE3AB925DA871800268D7D /* SensorClientDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorClientDelegate.swift; sourceTree = "<group>"; };
 		52DF5D89228DA78A00C297C1 /* ConfigurationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationViewController.swift; sourceTree = "<group>"; };
 		52DF5D8B228DAA0500C297C1 /* NodeViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeViewCell.swift; sourceTree = "<group>"; };
 		52DF5D8E229691BD00C297C1 /* NetworkConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnection.swift; sourceTree = "<group>"; };
@@ -655,6 +657,7 @@
 				52DF5D8E229691BD00C297C1 /* NetworkConnection.swift */,
 				5211EAD4250777E100089FF2 /* SceneServerDelegate.swift */,
 				5211EADA25090DB000089FF2 /* SceneSetupServerDelegate.swift */,
+				52DE3AB925DA871800268D7D /* SensorClientDelegate.swift */,
 				5217D2E1250F7639004FDE79 /* GenericDefaultTransitionTimeClientDelegate.swift */,
 				5217D2DF250F522A004FDE79 /* GenericDefaultTransitionTimeServerDelegate.swift */,
 				52E54CDC23438B2E00478F05 /* GenericOnOffClientDelegate.swift */,
@@ -988,6 +991,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				52DE3ABA25DA871800268D7D /* SensorClientDelegate.swift in Sources */,
 				529B764722522D37008F1CE7 /* UITableView+EmptyView.swift in Sources */,
 				5288153D25125AB600484AF0 /* RootTabBarController.swift in Sources */,
 				52CD0A55232FC11700A9A181 /* AddressCell.swift in Sources */,

--- a/Example/nRFMeshProvision/AppDelegate.swift
+++ b/Example/nRFMeshProvision/AppDelegate.swift
@@ -108,6 +108,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // Scene Server and Scene Setup Server models (client is added automatically):
             Model(sigModelId: .sceneServerModelId, delegate: sceneServer),
             Model(sigModelId: .sceneSetupServerModelId, delegate: sceneSetupServer),
+            // Sensor Client model:
+            Model(sigModelId: .sensorClientModelId, delegate: SensorClientDelegate()),
             // Generic Default Transition Time Server model:
             Model(sigModelId: .genericDefaultTransitionTimeServerModelId,
                   delegate: defaultTransitionTimeServerDelegate),

--- a/Example/nRFMeshProvision/Mesh Network/SensorClientDelegate.swift
+++ b/Example/nRFMeshProvision/Mesh Network/SensorClientDelegate.swift
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, Nordic Semiconductor
+* Copyright (c) 2021, Nordic Semiconductor
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification,
@@ -31,30 +31,47 @@
 import Foundation
 import nRFMeshProvision
 
-extension UInt16 {
+class SensorClientDelegate: ModelDelegate {
     
-    // Bluetooth SIG Models
-    static let configurationServerModelId: UInt16 = 0x0000
-    static let configurationClientModelId: UInt16 = 0x0001
+    let messageTypes: [UInt32 : MeshMessage.Type]
+    let isSubscriptionSupported: Bool = true
     
-    static let genericOnOffServerModelId: UInt16 = 0x1000
-    static let genericOnOffClientModelId: UInt16 = 0x1001
-    static let genericLevelServerModelId: UInt16 = 0x1002
-    static let genericLevelClientModelId: UInt16 = 0x1003
+    // TODO: Implement Sensor Client publications.
+    let publicationMessageComposer: MessageComposer? = nil
     
-    static let genericDefaultTransitionTimeServerModelId: UInt16 = 0x1004
-    static let genericDefaultTransitionTimeClientModelId: UInt16 = 0x1005
+    init() {
+        let types: [SensorMessage.Type] = [
+            SensorDescriptorStatus.self,
+            SensorCadenceStatus.self
+        ]
+        messageTypes = types.toMap()
+    }
     
-    static let sceneServerModelId: UInt16 = 0x1203
-    static let sceneSetupServerModelId: UInt16 = 0x1204
-    static let sceneClientModelId: UInt16 = 0x1205
+    func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage, from source: Address, sentTo destination: MeshAddress) throws -> MeshMessage {
+        switch request {
+            // No acknowledged message supported by this Model.
+        default:
+            fatalError("Message not supported: \(request)")
+        }
+    }
     
-    static let sensorServerModelId: UInt16 = 0x1100
-    static let sensorServerSetupModelId: UInt16 = 0x1101
-    static let sensorClientModelId: UInt16 = 0x1102
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+               from source: Address, sentTo destination: MeshAddress) {
+        handle(message, sentFrom: source)
+    }
     
-    // Supported vendor models
-    static let simpleOnOffModelId: UInt16 = 0x0001
-    static let nordicSemiconductorCompanyId: UInt16 = 0x0059
+    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+               toAcknowledgedMessage request: AcknowledgedMeshMessage,
+               from source: Address) {
+        handle(response, sentFrom: source)
+    }
+    
+}
+
+private extension SensorClientDelegate {
+    
+    func handle(_ message: MeshMessage, sentFrom source: Address) {
+        
+    }
     
 }

--- a/Example/nRFMeshProvision/Mesh Network/SensorClientDelegate.swift
+++ b/Example/nRFMeshProvision/Mesh Network/SensorClientDelegate.swift
@@ -45,6 +45,7 @@ class SensorClientDelegate: ModelDelegate {
             SensorCadenceStatus.self,
             SensorSettingsStatus.self,
             SensorSettingStatus.self,
+            SensorStatus.self,
         ]
         messageTypes = types.toMap()
     }

--- a/nRFMeshProvision/Classes/Mesh Messages/DeviceProperty.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/DeviceProperty.swift
@@ -1203,34 +1203,42 @@ extension DevicePropertyCharacteristic: CustomDebugStringConvertible {
         case .bool(let value):
             return value ? "True" : "False"
             
-        // UInt8?:
+        // Decimal:
+        case .pressure(let pressure):
+            let float = NSDecimalNumber(decimal: pressure).floatValue
+            return String(format: "%.1f°C", max(0, min(Float(UInt32.max / 10), float)))
+            
+        // Decimal?:
         case .percentage8(let percent):
             guard let percent = percent else {
                 return DevicePropertyCharacteristic.unknown
             }
-            return percent.description // String(format: "%.1f%%", max(0.0, min(100.0, percent)))
-            
-        // Float?:
+            let float = NSDecimalNumber(decimal: percent).floatValue
+            return String(format: "%.1f%%", max(0.0, min(100.0, float)))
         case .temperature8(let temp):
             guard let temp = temp else {
                 return DevicePropertyCharacteristic.unknown
             }
-            return temp.description // String(format: "%.1f°C", max(-64.0, min(63.0, temp)))
+            let float = NSDecimalNumber(decimal: temp).floatValue
+            return String(format: "%.1f°C", max(-64.0, min(63.0, float)))
         case .humidity(let percent):
             guard let percent = percent else {
                 return DevicePropertyCharacteristic.unknown
             }
-            return percent.description // String(format: "%.2f%%", max(0.0, min(100.0, percent)))
+            let float = NSDecimalNumber(decimal: percent).floatValue
+            return String(format: "%.2f%%", max(0.0, min(100.0, float)))
         case .illuminance(let millilux):
             guard let millilux = millilux else {
                 return DevicePropertyCharacteristic.unknown
             }
-            return millilux.description // String(format: "%.2f lux", millilux)
+            let float = NSDecimalNumber(decimal: millilux).floatValue
+            return String(format: "%.2f lux", float)
         case .temperature(let temp):
             guard let temp = temp else {
                 return DevicePropertyCharacteristic.unknown
             }
-            return temp.description // String(format: "%.2f°C", max(-273.15, min(327.67, temp)))
+            let float = NSDecimalNumber(decimal: temp).floatValue
+            return String(format: "%.2f°C", max(-273.15, min(327.67, float)))
             
         // UInt16:
         case .perceivedLightness(let count):
@@ -1258,16 +1266,12 @@ extension DevicePropertyCharacteristic: CustomDebugStringConvertible {
             guard let numberOfHours = numberOfHours else {
                 return DevicePropertyCharacteristic.unknown
             }
-            return "\(numberOfHours) hours"
+            return "\(min(numberOfHours, 0xFFFFFE)) hours"
         case .timeMillisecond24(let numberOfMilliseconds):
             guard let numberOfMilliseconds = numberOfMilliseconds else {
                 return DevicePropertyCharacteristic.unknown
             }
-            return "\(numberOfMilliseconds) ms"
-            
-        // UInt32:
-        case .pressure(let pressure):
-            return pressure.description
+            return "\(min(numberOfMilliseconds, 0xFFFFFE)) ms"
             
         // UInt32?:
         case .timeSecond32(let numberOfSeconds):

--- a/nRFMeshProvision/Classes/Mesh Messages/DeviceProperty.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/DeviceProperty.swift
@@ -30,6 +30,8 @@
 
 import Foundation
 
+// MARK: - DeviceProperty
+
 /// The device property.
 ///
 /// - note: Each property has a corresponding `DevicePropertyCharacteristic`.
@@ -589,6 +591,193 @@ public enum DeviceProperty {
     }
 }
 
+extension DeviceProperty: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        switch self {
+        case .averageAmbientTemperatureInAPeriodOfDay: return "Average Ambient Temperature In A Period Of Day"
+        case .averageInputCurrent: return "Average Input Current"
+        case .averageInputVoltage: return "Average Input Voltage"
+        case .averageOutputCurrent: return "Average Output Current"
+        case .averageOutputVoltage: return "Average Output Voltage"
+        case .centerBeamIntensityAtFullPower: return "Center Beam Intensity At Full Power"
+        case .chromaticityTolerance: return "Chromaticity T olerance"
+        case .colorRenderingIndexR9: return "Color Rendering Index R9"
+        case .colorRenderingIndexRa: return "Color Rendering Index Ra"
+        case .deviceAppearance: return "Device Appearance"
+        case .deviceCountryOfOrigin: return "Device Country Of Origin"
+        case .deviceDateOfManufacture: return "Device Date Of Manufacture"
+        case .deviceEnergyUseSinceTurnOn: return "Device Energy Use Since Turn On"
+        case .deviceFirmwareRevision: return "Device Firmware Revision"
+        case .deviceGlobalTradeItemNumber: return "Device Global Trade Item Number"
+        case .deviceHardwareRevision: return "Device Hardware Revision"
+        case .deviceManufacturerName: return "Device Manufacturer Name"
+        case .deviceModelNumber: return "Device Model Number"
+        case .deviceOperatingTemperatureRangeSpecification: return "Device Operating Temperature Range Specification"
+        case .deviceOperatingTemperatureStatisticalValues: return "Device Operating Temperature Statistical Values"
+        case .deviceOverTemperatureEventStatistics: return "Device Over Temperature Event Statistics"
+        case .devicePowerRangeSpecification: return "Device Power Range Specification"
+        case .deviceRuntimeSinceTurnOn: return "Device Runtime Since Turn On"
+        case .deviceRuntimeWarranty: return "Device Runtime Warranty"
+        case .deviceSerialNumber: return "Device Serial Number"
+        case .deviceSoftwareRevision: return "Device Software Revision"
+        case .deviceUnderTemperatureEventStatistics: return "Device Under Temperature Event Statistics"
+        case .indoorAmbientTemperatureStatisticalValues: return "Indoor Ambient Temperature Statistical Values"
+        case .initialCIE1931ChromaticityCoordinates: return "Initial CIE 1931 Chromaticity Coordinates"
+        case .initialCorrelatedColorTemperature: return "Initial Correlated Color Temperature"
+        case .initialLuminousFlux: return "Initial Luminous Flux"
+        case .initialPlanckianDistance: return "Initial Planckian Distance"
+        case .inputCurrentRangeSpecification: return "Input Current Range Specification"
+        case .inputCurrentStatistics: return "Input Current Statistics"
+        case .inputOverCurrentEventStatistics: return "Input Over Current Event Statistics"
+        case .inputOverRippleVoltageEventStatistics: return "Input Over Ripple Voltage Event Statistics"
+        case .inputOverVoltageEventStatistics: return "Input Over Voltage Event Statistics"
+        case .inputUnderCurrentEventStatistics: return "Input Under Current Event Statistics"
+        case .inputUnderVoltageEventStatistics: return "Input Under Voltage Event Statistics"
+        case .inputVoltageRangeSpecification: return "Input Voltage Range Specification"
+        case .inputVoltageRippleSpecification: return "Input Voltage Ripple Specification"
+        case .inputVoltageStatistics: return "Input Voltage Statistics"
+        case .lightControlAmbientLuxLevelOn: return "Light Control Ambient LuxLevel On"
+        case .lightControlAmbientLuxLevelProlong: return "Light Control Ambient LuxLevel Prolong"
+        case .lightControlAmbientLuxLevelStandby: return "Light Control Ambient LuxLevel Standby"
+        case .lightControlLightnessOn: return "Light Control Lightness On"
+        case .lightControlLightnessProlong: return "Light Control Lightness Prolong"
+        case .lightControlLightnessStandby: return "Light Control Lightness Standby"
+        case .lightControlRegulatorAccuracy: return "Light Control Regulator Accuracy"
+        case .lightControlRegulatorKid: return "Light Control Regulator Kid"
+        case .lightControlRegulatorKiu: return "Light Control Regulator Kiu"
+        case .lightControlRegulatorKpd: return "Light Control Regulator Kpd"
+        case .lightControlRegulatorKpu: return "Light Control Regulator Kpu"
+        case .lightControlTimeFade: return "Light Control Time Fade"
+        case .lightControlTimeFadeOn: return "Light Control Time Fade On"
+        case .lightControlTimeFadeStandbyAuto: return "Light Control Time Fade Standby Auto"
+        case .lightControlTimeFadeStandbyManual: return "Light Control Time Fade Standby Manual"
+        case .lightControlTimeOccupancyDelay: return "Light Control Time Occupancy Delay"
+        case .lightControlTimeProlong: return "Light Control Time Prolong"
+        case .lightControlTimeRunOn: return "Light Control Time Run On"
+        case .lumenMaintenanceFactor: return "Lumen Maintenance Factor"
+        case .luminousEfficacy: return "Luminous Efficacy"
+        case .luminousEnergySinceTurnOn: return "Luminous Energy Since Turn On"
+        case .luminousExposure: return "Luminous Exposure"
+        case .luminousFluxRange: return "Luminous Flux Range"
+        case .motionSensed: return "Motion Sensed"
+        case .motionThreshold: return "Motion Threshold"
+        case .openCircuitEventStatistics: return "Open Circuit Event Statistics"
+        case .outdoorStatisticalValues: return "Outdoor Statistical Values"
+        case .outputCurrentRange: return "Output Current Range"
+        case .outputCurrentStatistics: return "Output Current Statistics"
+        case .outputRippleVoltageSpecification: return "Output Ripple Voltage Specification"
+        case .outputVoltageRange: return "Output Voltage Range"
+        case .outputVoltageStatistics: return "Output Voltage Statistics"
+        case .overOutputRippleVoltageEventStatistics: return "Over Output Ripple Voltage Event Statistics"
+        case .peopleCount: return "People Count"
+        case .presenceDetected: return "Presence Detected"
+        case .presentAmbientLightLevel: return "Present Ambient Light Level"
+        case .presentAmbientTemperature: return "Present Ambient Temperature"
+        case .presentCIE1931ChromaticityCoordinates: return "Present CIE 1931 Chromaticity Coordinates"
+        case .presentCorrelatedColorTemperature: return "Present Correlated Color Temperature"
+        case .presentDeviceInputPower: return "Present Device Input Power"
+        case .presentDeviceOperatingEfficiency: return "Present Device Operating Efficiency"
+        case .presentDeviceOperatingTemperature: return "Present Device Operating Temperature"
+        case .presentIlluminance: return "Present Illuminance"
+        case .presentIndoorAmbientTemperature: return "Present Indoor Ambient Temperature"
+        case .presentInputCurrent: return "Present Input Current"
+        case .presentInputRippleVoltage: return "Present Input Ripple Voltage"
+        case .presentInputVoltage: return "Present Input Voltage"
+        case .presentLuminousFlux: return "Present Luminous Flux"
+        case .presentOutdoorAmbientTemperature: return "Present Outdoor Ambient Temperature"
+        case .presentOutputCurrent: return "Present Output Current"
+        case .presentOutputVoltage: return "Present Output Voltage"
+        case .presentPlanckianDistance: return "Present Planckian Distance"
+        case .presentRelativeOutputRippleVoltage: return "Present Relative Output Ripple Voltage"
+        case .relativeDeviceEnergyUseInAPeriodOfDay: return "Relative Device Energy Use In A Period Of Day"
+        case .relativeDeviceRuntimeInAGenericLevelRange: return "Relative Device Runtime In A Generic Level Range"
+        case .relativeExposureTimeInAnIlluminanceRange: return "Relative Exposure Time In An Illuminance Range"
+        case .relativeRuntimeInACorrelatedColorTemperatureRange: return "Relative Runtime In A Correlated Color Temperature Range"
+        case .relativeRuntimeInADeviceOperatingTemperatureRange: return "Relative Runtime In A Device Operating Temperature Range"
+        case .relativeRuntimeInAnInputCurrentRange: return "Relative Runtime In An Input Current Range"
+        case .relativeRuntimeInAnInputVoltageRange: return "Relative Runtime In An Input Voltage Range"
+        case .shortCircuitEventStatistics: return "Short Circuit Event Statistics"
+        case .timeSinceMotionSensed: return "Time Since Motion Sensed"
+        case .timeSincePresenceDetected: return "Time Since Presence Detected"
+        case .totalDeviceEnergyUse: return "Total Device Energy Use"
+        case .totalDeviceOffOnCycles: return "Total Device Off On Cycles"
+        case .totalDevicePowerOnCycles: return "Total Device Power On Cycles"
+        case .totalDevicePowerOnTime: return "Total Device Power On Time"
+        case .totalDeviceRuntime: return "Total Device Runtime"
+        case .totalLightExposureTime: return "Total Light Exposure Time"
+        case .totalLuminousEnergy: return "Total Luminous Energy"
+        case .desiredAmbientTemperature: return "Desired Ambient Temperature"
+        case .preciseTotalDeviceEnergyUse: return "Precise Total Device Energy Use"
+        case .powerFactor: return "Power Factor"
+        case .sensorGain: return "Sensor Gain"
+        case .precisePresentAmbientTemperature: return "Precise Present Ambient Temperature"
+        case .presentAmbientRelativeHumidity: return "Present Ambient Relative Humidity"
+        case .presentAmbientCarbonDioxideConcentration: return "Present Ambient Carbon Dioxide Concentration"
+        case .presentAmbientVolatileOrganicCompoundsConcentration: return "Present Ambient Volatile Organic Compounds Concentration"
+        case .presentAmbientNoise: return "Present Ambient Noise"
+        case .activeEnergyLoadside: return "Active Energy Loadside"
+        case .activePowerLoadside: return "Active Power Loadside"
+        case .airPressure: return "Air Pressure"
+        case .apparentEnergy: return "Apparent Energy"
+        case .apparentPower: return "Apparent Power"
+        case .apparentWindDirection: return "Apparent Wind Direction"
+        case .apparentWindSpeed: return "Apparent Wind Speed"
+        case .dewPoint: return "Dew Point"
+        case .externalSupplyVoltage: return "External Supply Voltage"
+        case .externalSupplyVoltageFrequency: return "External Supply Voltage Frequency"
+        case .gustFactor: return "Gust Factor"
+        case .heatIndex: return "Heat Index"
+        case .lightDistribution: return "Light Distribution"
+        case .lightSourceCurrent: return "Light Source Current"
+        case .lightSourceOnTimeNotResettable: return "Light Source On Time Not Resettable"
+        case .lightSourceOnTimeResettable: return "Light Source On Time Resettable"
+        case .lightSourceOpenCircuitStatistics: return "Light Source Open Circuit Statistics"
+        case .lightSourceOverallFailuresStatistics: return "Light Source Overall Failures Statistics"
+        case .lightSourceShortCircuitStatistics: return "Light Source Short Circuit Statistics"
+        case .lightSourceStartCounterResettable: return "Light Source Start Counter Resettable"
+        case .lightSourceTemperature: return "Light Source Temperature"
+        case .lightSourceThermalDeratingStatistics: return "Light Source Thermal Derating Statistics"
+        case .lightSourceThermalShutdownStatistics: return "Light Source Thermal Shutdown Statistics"
+        case .lightSourceTotalPowerOnCycles: return "Light Source Total Power On Cycles"
+        case .lightSourceVoltage: return "Light Source Voltage"
+        case .luminaireColor: return "Luminaire Color"
+        case .luminaireIdentificationNumber: return "Luminaire Identification Number"
+        case .luminaireManufacturerGTIN: return "Luminaire Manufacturer GTIN"
+        case .luminaireNominalInputPower: return "Luminaire Nominal Input Power"
+        case .luminaireNominalMaximumACMainsVoltage: return "Luminaire Nominal Maximum AC Mains Voltage"
+        case .luminaireNominalMinimumACMainsVoltage: return "Luminaire Nominal Minimum AC Mains Voltage"
+        case .luminairePowerAtMinimumDimLevel: return "Luminaire Power At Minimum Dim Level"
+        case .luminaireTimeOfManufacture: return "Luminaire Time Of Manufacture"
+        case .magneticDeclination: return "Magnetic Declination"
+        case .magneticFluxDensity2D: return "Magnetic Flux Density - 2D"
+        case .magneticFluxDensity3D: return "Magnetic Flux Density - 3D"
+        case .nominalLightOutput: return "Nominal Light Output"
+        case .overallFailureCondition: return "Overall Failure Condition"
+        case .pollenConcentration: return "Pollen Concentration"
+        case .presentIndoorRelativeHumidity: return "Present Indoor Relative Humidity"
+        case .presentOutdoorRelativeHumidity: return "Present Outdoor Relative Humidity"
+        case .pressure: return "Pressure"
+        case .rainfall: return "Rainfall"
+        case .ratedMedianUsefulLifeOfLuminaire: return "Rated Median Useful Life Of Luminaire"
+        case .ratedMedianUsefulLightSourceStarts: return "Rated Median Useful Light Source Starts"
+        case .referenceTemperature: return "Reference Temperature"
+        case .totalDeviceStarts: return "Total Device Starts"
+        case .trueWindDirection: return "True Wind Direction"
+        case .trueWindSpeed: return "True Wind Speed"
+        case .uVIndex: return "UV Index"
+        case .windChill: return "Wind Chill"
+        case .lightSourceType: return "Light Source Type"
+        case .luminaireIdentificationString: return "Luminaire Identification String"
+        case .outputPowerLimitation: return "Output Power Limitation"
+        case .thermalDerating: return "Thermal Derating"
+        case .outputCurrentPercent: return "Output Current Percent"
+        case .unknown(let id): return "Unknown (Property ID: \(id))"
+        }
+    }
+    
+}
+
 internal extension DeviceProperty {
     
     /// Lenght of the characteristic value in bytes.
@@ -854,6 +1043,8 @@ internal extension DeviceProperty {
     
 }
 
+// MARK: - DevicePropertyCharacteristic
+
 /// A representation of a property characteristic.
 public enum DevicePropertyCharacteristic: Equatable {
     /// True or false.
@@ -1003,6 +1194,7 @@ internal extension DevicePropertyCharacteristic {
 }
 
 extension DevicePropertyCharacteristic: CustomDebugStringConvertible {
+    /// Text printed when the characteristic value is unknown.
     private static let unknown = "Value is not known"
     
     public var debugDescription: String {
@@ -1114,192 +1306,7 @@ extension DevicePropertyCharacteristic: CustomDebugStringConvertible {
     
 }
 
-extension DeviceProperty: CustomDebugStringConvertible {
-    
-    public var debugDescription: String {
-        switch self {
-        case .averageAmbientTemperatureInAPeriodOfDay: return "Average Ambient Temperature In A Period Of Day"
-        case .averageInputCurrent: return "Average Input Current"
-        case .averageInputVoltage: return "Average Input Voltage"
-        case .averageOutputCurrent: return "Average Output Current"
-        case .averageOutputVoltage: return "Average Output Voltage"
-        case .centerBeamIntensityAtFullPower: return "Center Beam Intensity At Full Power"
-        case .chromaticityTolerance: return "Chromaticity T olerance"
-        case .colorRenderingIndexR9: return "Color Rendering Index R9"
-        case .colorRenderingIndexRa: return "Color Rendering Index Ra"
-        case .deviceAppearance: return "Device Appearance"
-        case .deviceCountryOfOrigin: return "Device Country Of Origin"
-        case .deviceDateOfManufacture: return "Device Date Of Manufacture"
-        case .deviceEnergyUseSinceTurnOn: return "Device Energy Use Since Turn On"
-        case .deviceFirmwareRevision: return "Device Firmware Revision"
-        case .deviceGlobalTradeItemNumber: return "Device Global Trade Item Number"
-        case .deviceHardwareRevision: return "Device Hardware Revision"
-        case .deviceManufacturerName: return "Device Manufacturer Name"
-        case .deviceModelNumber: return "Device Model Number"
-        case .deviceOperatingTemperatureRangeSpecification: return "Device Operating Temperature Range Specification"
-        case .deviceOperatingTemperatureStatisticalValues: return "Device Operating Temperature Statistical Values"
-        case .deviceOverTemperatureEventStatistics: return "Device Over Temperature Event Statistics"
-        case .devicePowerRangeSpecification: return "Device Power Range Specification"
-        case .deviceRuntimeSinceTurnOn: return "Device Runtime Since Turn On"
-        case .deviceRuntimeWarranty: return "Device Runtime Warranty"
-        case .deviceSerialNumber: return "Device Serial Number"
-        case .deviceSoftwareRevision: return "Device Software Revision"
-        case .deviceUnderTemperatureEventStatistics: return "Device Under Temperature Event Statistics"
-        case .indoorAmbientTemperatureStatisticalValues: return "Indoor Ambient Temperature Statistical Values"
-        case .initialCIE1931ChromaticityCoordinates: return "Initial CIE 1931 Chromaticity Coordinates"
-        case .initialCorrelatedColorTemperature: return "Initial Correlated Color Temperature"
-        case .initialLuminousFlux: return "Initial Luminous Flux"
-        case .initialPlanckianDistance: return "Initial Planckian Distance"
-        case .inputCurrentRangeSpecification: return "Input Current Range Specification"
-        case .inputCurrentStatistics: return "Input Current Statistics"
-        case .inputOverCurrentEventStatistics: return "Input Over Current Event Statistics"
-        case .inputOverRippleVoltageEventStatistics: return "Input Over Ripple Voltage Event Statistics"
-        case .inputOverVoltageEventStatistics: return "Input Over Voltage Event Statistics"
-        case .inputUnderCurrentEventStatistics: return "Input Under Current Event Statistics"
-        case .inputUnderVoltageEventStatistics: return "Input Under Voltage Event Statistics"
-        case .inputVoltageRangeSpecification: return "Input Voltage Range Specification"
-        case .inputVoltageRippleSpecification: return "Input Voltage Ripple Specification"
-        case .inputVoltageStatistics: return "Input Voltage Statistics"
-        case .lightControlAmbientLuxLevelOn: return "Light Control Ambient LuxLevel On"
-        case .lightControlAmbientLuxLevelProlong: return "Light Control Ambient LuxLevel Prolong"
-        case .lightControlAmbientLuxLevelStandby: return "Light Control Ambient LuxLevel Standby"
-        case .lightControlLightnessOn: return "Light Control Lightness On"
-        case .lightControlLightnessProlong: return "Light Control Lightness Prolong"
-        case .lightControlLightnessStandby: return "Light Control Lightness Standby"
-        case .lightControlRegulatorAccuracy: return "Light Control Regulator Accuracy"
-        case .lightControlRegulatorKid: return "Light Control Regulator Kid"
-        case .lightControlRegulatorKiu: return "Light Control Regulator Kiu"
-        case .lightControlRegulatorKpd: return "Light Control Regulator Kpd"
-        case .lightControlRegulatorKpu: return "Light Control Regulator Kpu"
-        case .lightControlTimeFade: return "Light Control Time Fade"
-        case .lightControlTimeFadeOn: return "Light Control Time Fade On"
-        case .lightControlTimeFadeStandbyAuto: return "Light Control Time Fade Standby Auto"
-        case .lightControlTimeFadeStandbyManual: return "Light Control Time Fade Standby Manual"
-        case .lightControlTimeOccupancyDelay: return "Light Control Time Occupancy Delay"
-        case .lightControlTimeProlong: return "Light Control Time Prolong"
-        case .lightControlTimeRunOn: return "Light Control Time Run On"
-        case .lumenMaintenanceFactor: return "Lumen Maintenance Factor"
-        case .luminousEfficacy: return "Luminous Efficacy"
-        case .luminousEnergySinceTurnOn: return "Luminous Energy Since Turn On"
-        case .luminousExposure: return "Luminous Exposure"
-        case .luminousFluxRange: return "Luminous Flux Range"
-        case .motionSensed: return "Motion Sensed"
-        case .motionThreshold: return "Motion Threshold"
-        case .openCircuitEventStatistics: return "Open Circuit Event Statistics"
-        case .outdoorStatisticalValues: return "Outdoor Statistical Values"
-        case .outputCurrentRange: return "Output Current Range"
-        case .outputCurrentStatistics: return "Output Current Statistics"
-        case .outputRippleVoltageSpecification: return "Output Ripple Voltage Specification"
-        case .outputVoltageRange: return "Output Voltage Range"
-        case .outputVoltageStatistics: return "Output Voltage Statistics"
-        case .overOutputRippleVoltageEventStatistics: return "Over Output Ripple Voltage Event Statistics"
-        case .peopleCount: return "People Count"
-        case .presenceDetected: return "Presence Detected"
-        case .presentAmbientLightLevel: return "Present Ambient Light Level"
-        case .presentAmbientTemperature: return "Present Ambient Temperature"
-        case .presentCIE1931ChromaticityCoordinates: return "Present CIE 1931 Chromaticity Coordinates"
-        case .presentCorrelatedColorTemperature: return "Present Correlated Color Temperature"
-        case .presentDeviceInputPower: return "Present Device Input Power"
-        case .presentDeviceOperatingEfficiency: return "Present Device Operating Efficiency"
-        case .presentDeviceOperatingTemperature: return "Present Device Operating Temperature"
-        case .presentIlluminance: return "Present Illuminance"
-        case .presentIndoorAmbientTemperature: return "Present Indoor Ambient Temperature"
-        case .presentInputCurrent: return "Present Input Current"
-        case .presentInputRippleVoltage: return "Present Input Ripple Voltage"
-        case .presentInputVoltage: return "Present Input Voltage"
-        case .presentLuminousFlux: return "Present Luminous Flux"
-        case .presentOutdoorAmbientTemperature: return "Present Outdoor Ambient Temperature"
-        case .presentOutputCurrent: return "Present Output Current"
-        case .presentOutputVoltage: return "Present Output Voltage"
-        case .presentPlanckianDistance: return "Present Planckian Distance"
-        case .presentRelativeOutputRippleVoltage: return "Present Relative Output Ripple Voltage"
-        case .relativeDeviceEnergyUseInAPeriodOfDay: return "Relative Device Energy Use In A Period Of Day"
-        case .relativeDeviceRuntimeInAGenericLevelRange: return "Relative Device Runtime In A Generic Level Range"
-        case .relativeExposureTimeInAnIlluminanceRange: return "Relative Exposure Time In An Illuminance Range"
-        case .relativeRuntimeInACorrelatedColorTemperatureRange: return "Relative Runtime In A Correlated Color Temperature Range"
-        case .relativeRuntimeInADeviceOperatingTemperatureRange: return "Relative Runtime In A Device Operating Temperature Range"
-        case .relativeRuntimeInAnInputCurrentRange: return "Relative Runtime In An Input Current Range"
-        case .relativeRuntimeInAnInputVoltageRange: return "Relative Runtime In An Input Voltage Range"
-        case .shortCircuitEventStatistics: return "Short Circuit Event Statistics"
-        case .timeSinceMotionSensed: return "Time Since Motion Sensed"
-        case .timeSincePresenceDetected: return "Time Since Presence Detected"
-        case .totalDeviceEnergyUse: return "Total Device Energy Use"
-        case .totalDeviceOffOnCycles: return "Total Device Off On Cycles"
-        case .totalDevicePowerOnCycles: return "Total Device Power On Cycles"
-        case .totalDevicePowerOnTime: return "Total Device Power On Time"
-        case .totalDeviceRuntime: return "Total Device Runtime"
-        case .totalLightExposureTime: return "Total Light Exposure Time"
-        case .totalLuminousEnergy: return "Total Luminous Energy"
-        case .desiredAmbientTemperature: return "Desired Ambient Temperature"
-        case .preciseTotalDeviceEnergyUse: return "Precise Total Device Energy Use"
-        case .powerFactor: return "Power Factor"
-        case .sensorGain: return "Sensor Gain"
-        case .precisePresentAmbientTemperature: return "Precise Present Ambient Temperature"
-        case .presentAmbientRelativeHumidity: return "Present Ambient Relative Humidity"
-        case .presentAmbientCarbonDioxideConcentration: return "Present Ambient Carbon Dioxide Concentration"
-        case .presentAmbientVolatileOrganicCompoundsConcentration: return "Present Ambient Volatile Organic Compounds Concentration"
-        case .presentAmbientNoise: return "Present Ambient Noise"
-        case .activeEnergyLoadside: return "Active Energy Loadside"
-        case .activePowerLoadside: return "Active Power Loadside"
-        case .airPressure: return "Air Pressure"
-        case .apparentEnergy: return "Apparent Energy"
-        case .apparentPower: return "Apparent Power"
-        case .apparentWindDirection: return "Apparent Wind Direction"
-        case .apparentWindSpeed: return "Apparent Wind Speed"
-        case .dewPoint: return "Dew Point"
-        case .externalSupplyVoltage: return "External Supply Voltage"
-        case .externalSupplyVoltageFrequency: return "External Supply Voltage Frequency"
-        case .gustFactor: return "Gust Factor"
-        case .heatIndex: return "Heat Index"
-        case .lightDistribution: return "Light Distribution"
-        case .lightSourceCurrent: return "Light Source Current"
-        case .lightSourceOnTimeNotResettable: return "Light Source On Time Not Resettable"
-        case .lightSourceOnTimeResettable: return "Light Source On Time Resettable"
-        case .lightSourceOpenCircuitStatistics: return "Light Source Open Circuit Statistics"
-        case .lightSourceOverallFailuresStatistics: return "Light Source Overall Failures Statistics"
-        case .lightSourceShortCircuitStatistics: return "Light Source Short Circuit Statistics"
-        case .lightSourceStartCounterResettable: return "Light Source Start Counter Resettable"
-        case .lightSourceTemperature: return "Light Source Temperature"
-        case .lightSourceThermalDeratingStatistics: return "Light Source Thermal Derating Statistics"
-        case .lightSourceThermalShutdownStatistics: return "Light Source Thermal Shutdown Statistics"
-        case .lightSourceTotalPowerOnCycles: return "Light Source Total Power On Cycles"
-        case .lightSourceVoltage: return "Light Source Voltage"
-        case .luminaireColor: return "Luminaire Color"
-        case .luminaireIdentificationNumber: return "Luminaire Identification Number"
-        case .luminaireManufacturerGTIN: return "Luminaire Manufacturer GTIN"
-        case .luminaireNominalInputPower: return "Luminaire Nominal Input Power"
-        case .luminaireNominalMaximumACMainsVoltage: return "Luminaire Nominal Maximum AC Mains Voltage"
-        case .luminaireNominalMinimumACMainsVoltage: return "Luminaire Nominal Minimum AC Mains Voltage"
-        case .luminairePowerAtMinimumDimLevel: return "Luminaire Power At Minimum Dim Level"
-        case .luminaireTimeOfManufacture: return "Luminaire Time Of Manufacture"
-        case .magneticDeclination: return "Magnetic Declination"
-        case .magneticFluxDensity2D: return "Magnetic Flux Density - 2D"
-        case .magneticFluxDensity3D: return "Magnetic Flux Density - 3D"
-        case .nominalLightOutput: return "Nominal Light Output"
-        case .overallFailureCondition: return "Overall Failure Condition"
-        case .pollenConcentration: return "Pollen Concentration"
-        case .presentIndoorRelativeHumidity: return "Present Indoor Relative Humidity"
-        case .presentOutdoorRelativeHumidity: return "Present Outdoor Relative Humidity"
-        case .pressure: return "Pressure"
-        case .rainfall: return "Rainfall"
-        case .ratedMedianUsefulLifeOfLuminaire: return "Rated Median Useful Life Of Luminaire"
-        case .ratedMedianUsefulLightSourceStarts: return "Rated Median Useful Light Source Starts"
-        case .referenceTemperature: return "Reference Temperature"
-        case .totalDeviceStarts: return "Total Device Starts"
-        case .trueWindDirection: return "True Wind Direction"
-        case .trueWindSpeed: return "True Wind Speed"
-        case .uVIndex: return "UV Index"
-        case .windChill: return "Wind Chill"
-        case .lightSourceType: return "Light Source Type"
-        case .luminaireIdentificationString: return "Luminaire Identification String"
-        case .outputPowerLimitation: return "Output Power Limitation"
-        case .thermalDerating: return "Thermal Derating"
-        case .outputCurrentPercent: return "Output Current Percent"
-        case .unknown(let id): return "Unknown (Property ID: \(id))"
-        }
-    }
-    
-}
+// MARK: - Helper extenstions - decoding
 
 private extension BinaryInteger {
     
@@ -1349,23 +1356,15 @@ private extension BinaryInteger {
     
 }
 
-private extension Optional where Wrapped: DataConvertible & FixedWidthInteger {
+// MARK: - Helper extenstions - encoding
+
+private extension Bool {
     
-    /// Returns the value as Data. If the value is `nil`, the given
-    /// unknown value converted to Data is returned.
+    /// Returns the value as 1-octed Data.
     ///
-    /// - parameters:
-    ///   - numberOfBytes: Resulting number of bytes.
-    ///   - range: The range the value is to be located in.
-    ///   - unknownValue: The value to be returned when the value is unknown.
-    /// - returns: The Data.
-    func toData(ofLength numberOfBytes: Int = MemoryLayout<Wrapped>.size,
-                withRange range: ClosedRange<Wrapped>? = nil,
-                withUnknownValue unknownValue: Wrapped) -> Data {
-        guard let self = self else {
-            return unknownValue.toData(ofLength: numberOfBytes, withRange: range)
-        }
-        return self.toData(ofLength: numberOfBytes, withRange: range)
+    /// - returns: The Data representation of Bool.
+    func toData() -> Data {
+        return Data([self ? 0x01 : 0x00])
     }
     
 }
@@ -1386,24 +1385,23 @@ private extension DataConvertible where Self: Comparable {
     
 }
 
-private extension Optional where Wrapped == Decimal {
+private extension Optional where Wrapped: DataConvertible & FixedWidthInteger {
     
-    /// Returns the value as Data.
+    /// Returns the value as Data. If the value is `nil`, the given
+    /// unknown value converted to Data is returned.
     ///
     /// - parameters:
     ///   - numberOfBytes: Resulting number of bytes.
     ///   - range: The range the value is to be located in.
-    ///   - resolution: The convertion resolution.
-    ///   - unknownValue: The unknown value.
+    ///   - unknownValue: The value to be returned when the value is unknown.
     /// - returns: The Data.
-    func toData(ofLength numberOfBytes: Int,
-                withRange range: ClosedRange<Decimal>? = nil,
-                withResolution resolution: Decimal = 1.0,
-                withUnknownValue unknownValue: Int64) -> Data {
+    func toData(ofLength numberOfBytes: Int = MemoryLayout<Wrapped>.size,
+                withRange range: ClosedRange<Wrapped>? = nil,
+                withUnknownValue unknownValue: Wrapped) -> Data {
         guard let self = self else {
-            return unknownValue.toData(ofLength: numberOfBytes)
+            return unknownValue.toData(ofLength: numberOfBytes, withRange: range)
         }
-        return self.toData(ofLength: numberOfBytes, withRange: range, withResolution: resolution)
+        return self.toData(ofLength: numberOfBytes, withRange: range)
     }
     
 }
@@ -1428,13 +1426,24 @@ private extension Decimal {
     
 }
 
-private extension Bool {
+private extension Optional where Wrapped == Decimal {
     
-    /// Returns the value as 1-octed Data.
+    /// Returns the value as Data.
     ///
-    /// - returns: The Data representation of Bool.
-    func toData() -> Data {
-        return Data([self ? 0x01 : 0x00])
+    /// - parameters:
+    ///   - numberOfBytes: Resulting number of bytes.
+    ///   - range: The range the value is to be located in.
+    ///   - resolution: The convertion resolution.
+    ///   - unknownValue: The unknown value.
+    /// - returns: The Data.
+    func toData(ofLength numberOfBytes: Int,
+                withRange range: ClosedRange<Decimal>? = nil,
+                withResolution resolution: Decimal = 1.0,
+                withUnknownValue unknownValue: Int64) -> Data {
+        guard let self = self else {
+            return unknownValue.toData(ofLength: numberOfBytes)
+        }
+        return self.toData(ofLength: numberOfBytes, withRange: range, withResolution: resolution)
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/DeviceProperty.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/DeviceProperty.swift
@@ -1,0 +1,890 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// The device property.
+///
+/// - note: Each property has a corresponding `DevicePropertyCharacteristic`.
+///         However, currently not all values are implemented in this library.
+///         For those, `.other` should be used until they are implemented.
+public enum DeviceProperty: UInt16 {
+    case averageAmbientTemperatureInAPeriodOfDay = 0x0001
+    case averageInputCurrent = 0x0002
+    case averageInputVoltage = 0x0003
+    case averageOutputCurrent = 0x0004
+    case averageOutputVoltage = 0x0005
+    case centerBeamIntensityAtFullPower = 0x0006
+    case chromaticityTolerance = 0x0007
+    case colorRenderingIndexR9 = 0x0008
+    case colorRenderingIndexRa = 0x0009
+    case deviceAppearance = 0x000A
+    case deviceCountryOfOrigin = 0x000B
+    case deviceDateOfManufacture = 0x000C
+    case deviceEnergyUseSinceTurnOn = 0x000D
+    case deviceFirmwareRevision = 0x000E
+    case deviceGlobalTradeItemNumber = 0x000F
+    case deviceHardwareRevision = 0x0010
+    case deviceManufacturerName = 0x0011
+    case deviceModelNumber = 0x0012
+    case deviceOperatingTemperatureRangeSpecification = 0x0013
+    case deviceOperatingTemperatureStatisticalValues = 0x0014
+    case deviceOverTemperatureEventStatistics = 0x0015
+    case devicePowerRangeSpecification = 0x0016
+    case deviceRuntimeSinceTurnOn = 0x0017
+    case deviceRuntimeWarranty = 0x0018
+    case deviceSerialNumber = 0x0019
+    case deviceSoftwareRevision = 0x001A
+    case deviceUnderTemperatureEventStatistics = 0x001B
+    case indoorAmbientTemperatureStatisticalValues = 0x001C
+    case initialCIE1931ChromaticityCoordinates = 0x001D
+    case initialCorrelatedColorTemperature = 0x001E
+    case initialLuminousFlux = 0x001F
+    case initialPlanckianDistance = 0x0020
+    case inputCurrentRangeSpecification = 0x0021
+    case inputCurrentStatistics = 0x0022
+    case inputOverCurrentEventStatistics = 0x0023
+    case inputOverRippleVoltageEventStatistics = 0x0024
+    case inputOverVoltageEventStatistics = 0x0025
+    case inputUnderCurrentEventStatistics = 0x0026
+    case inputUnderVoltageEventStatistics = 0x0027
+    case inputVoltageRangeSpecification = 0x0028
+    case inputVoltageRippleSpecification = 0x0029
+    case inputVoltageStatistics = 0x002A
+    case lightControlAmbientLuxLevelOn = 0x002B
+    case lightControlAmbientLuxLevelProlong = 0x002C
+    case lightControlAmbientLuxLevelStandby = 0x002D
+    case lightControlLightnessOn = 0x002E
+    case lightControlLightnessProlong = 0x002F
+    case lightControlLightnessStandby = 0x0030
+    case lightControlRegulatorAccuracy = 0x0031
+    case lightControlRegulatorKid = 0x0032
+    case lightControlRegulatorKiu = 0x0033
+    case lightControlRegulatorKpd = 0x0034
+    case lightControlRegulatorKpu = 0x0035
+    case lightControlTimeFade = 0x0036
+    case lightControlTimeFadeOn = 0x0037
+    case lightControlTimeFadeStandbyAuto = 0x0038
+    case lightControlTimeFadeStandbyManual = 0x0039
+    case lightControlTimeOccupancyDelay = 0x003A
+    case lightControlTimeProlong = 0x003B
+    case lightControlTimeRunOn = 0x003C
+    case lumenMaintenanceFactor = 0x003D
+    case luminousEfficacy = 0x003E
+    case luminousEnergySinceTurnOn = 0x003F
+    case luminousExposure = 0x0040
+    case luminousFluxRange = 0x0041
+    case motionSensed = 0x0042
+    case motionThreshold = 0x0043
+    case openCircuitEventStatistics = 0x0044
+    case outdoorStatisticalValues = 0x0045
+    case outputCurrentRange = 0x0046
+    case outputCurrentStatistics = 0x0047
+    case outputRippleVoltageSpecification = 0x0048
+    case outputVoltageRange = 0x0049
+    case outputVoltageStatistics = 0x004A
+    case overOutputRippleVoltageEventStatistics = 0x004B
+    case peopleCount = 0x004C
+    case presenceDetected = 0x004D
+    case presentAmbientLightLevel = 0x004E
+    case presentAmbientTemperature = 0x004F
+    case presentCIE1931ChromaticityCoordinates = 0x0050
+    case presentCorrelatedColorTemperature = 0x0051
+    case presentDeviceInputPower = 0x0052
+    case presentDeviceOperatingEfficiency = 0x0053
+    case presentDeviceOperatingTemperature = 0x0054
+    case presentIlluminance = 0x0055
+    case presentIndoorAmbientTemperature = 0x0056
+    case presentInputCurrent = 0x0057
+    case presentInputRippleVoltage = 0x0058
+    case presentInputVoltage = 0x0059
+    case presentLuminousFlux = 0x005A
+    case presentOutdoorAmbientTemperature = 0x005B
+    case presentOutputCurrent = 0x005C
+    case presentOutputVoltage = 0x005D
+    case presentPlanckianDistance = 0x005E
+    case presentRelativeOutputRippleVoltage = 0x005F
+    case relativeDeviceEnergyUseInAPeriodOfDay = 0x0060
+    case relativeDeviceRuntimeInAGenericLevelRange = 0x0061
+    case relativeExposureTimeInAnIlluminanceRange = 0x0062
+    case relativeRuntimeInACorrelatedColorTemperatureRange = 0x0063
+    case relativeRuntimeInADeviceOperatingTemperatureRange = 0x0064
+    case relativeRuntimeInAnInputCurrentRange = 0x0065
+    case relativeRuntimeInAnInputVoltageRange = 0x0066
+    case shortCircuitEventStatistics = 0x0067
+    case timeSinceMotionSensed = 0x0068
+    case timeSincePresenceDetected = 0x0069
+    case totalDeviceEnergyUse = 0x006A
+    case totalDeviceOffOnCycles = 0x006B
+    case totalDevicePowerOnCycles = 0x006C
+    case totalDevicePowerOnTime = 0x006D
+    case totalDeviceRuntime = 0x006E
+    case totalLightExposureTime = 0x006F
+    case totalLuminousEnergy = 0x0070
+    case desiredAmbientTemperature = 0x0071
+    case preciseTotalDeviceEnergyUse = 0x0072
+    case powerFactor = 0x0073
+    case sensorGain = 0x0074
+    case precisePresentAmbientTemperature = 0x0075
+    case presentAmbientRelativeHumidity = 0x0076
+    case presentAmbientCarbonDioxideConcentration = 0x0077
+    case presentAmbientVolatileOrganicCompoundsConcentration = 0x0078
+    case presentAmbientNoise = 0x0079
+ // case these are undefined in Mesh Device Properties v2 = 0x007A
+ // case these are undefined in Mesh Device Properties v2 = 0x007B
+ // case these are undefined in Mesh Device Properties v2 = 0x007C
+ // case these are undefined in Mesh Device Properties v2 = 0x007D
+ // case these are undefined in Mesh Device Properties v2 = 0x007E
+ // case these are undefined in Mesh Device Properties v2 = 0x007F
+    case activeEnergyLoadside = 0x0080
+    case activePowerLoadside = 0x0081
+    case airPressure = 0x0082
+    case apparentEnergy = 0x0083
+    case apparentPower = 0x0084
+    case apparentWindDirection = 0x0085
+    case apparentWindSpeed = 0x0086
+    case dewPoint = 0x0087
+    case externalSupplyVoltage = 0x0088
+    case externalSupplyVoltageFrequency = 0x0089
+    case gustFactor = 0x008A
+    case heatIndex = 0x008B
+    case lightDistribution = 0x008C
+    case lightSourceCurrent = 0x008D
+    case lightSourceOnTimeNotResettable = 0x008E
+    case lightSourceOnTimeResettable = 0x008F
+    case lightSourceOpenCircuitStatistics = 0x0090
+    case lightSourceOverallFailuresStatistics = 0x0091
+    case lightSourceShortCircuitStatistics = 0x0092
+    case lightSourceStartCounterResettable = 0x0093
+    case lightSourceTemperature = 0x0094
+    case lightSourceThermalDeratingStatistics = 0x0095
+    case lightSourceThermalShutdownStatistics = 0x0096
+    case lightSourceTotalPowerOnCycles = 0x0097
+    case lightSourceVoltage = 0x0098
+    case luminaireColor = 0x0099
+    case luminaireIdentificationNumber = 0x009A
+    case luminaireManufacturerGTIN = 0x009B
+    case luminaireNominalInputPower = 0x009C
+    case luminaireNominalMaximumACMainsVoltage = 0x009D
+    case luminaireNominalMinimumACMainsVoltage = 0x009E
+    case luminairePowerAtMinimumDimLevel = 0x009F
+    case luminaireTimeOfManufacture = 0x00A0
+    case magneticDeclination = 0x00A1
+    case magneticFluxDensity2D = 0x00A2
+    case magneticFluxDensity3D = 0x00A3
+    case nominalLightOutput = 0x00A4
+    case overallFailureCondition = 0x00A5
+    case pollenConcentration = 0x00A6
+    case presentIndoorRelativeHumidity = 0x00A7
+    case presentOutdoorRelativeHumidity = 0x00A8
+    case pressure = 0x00A9
+    case rainfall = 0x00AA
+    case ratedMedianUsefulLifeOfLuminaire = 0x00AB
+    case ratedMedianUsefulLightSourceStarts = 0x00AC
+    case referenceTemperature = 0x00AD
+    case totalDeviceStarts = 0x00AE
+    case trueWindDirection = 0x00AF
+    case trueWindSpeed = 0x00B0
+    case uVIndex = 0x00B1
+    case windChill = 0x00B2
+    case lightSourceType = 0x00B3
+    case luminaireIdentificationString = 0x00B4
+    case outputPowerLimitation = 0x00B5
+    case thermalDerating = 0x00B6
+    case outputCurrentPercent = 0x00B7
+    
+}
+
+internal extension DeviceProperty {
+    
+    /// Lenght of the characteristic value in bytes.
+    ///
+    /// If the characteristic is not yet supported, this is `nil`.
+    var valueLength: Int? {
+        switch self {
+        case .presenceDetected,
+             .lightControlRegulatorAccuracy,
+             .outputRippleVoltageSpecification,
+             .inputVoltageRippleSpecification,
+             .outputCurrentPercent,
+             .lumenMaintenanceFactor,
+             .motionSensed,
+             .motionThreshold,
+             .presentDeviceOperatingEfficiency,
+             .presentRelativeOutputRippleVoltage,
+             .presentInputRippleVoltage,
+             .desiredAmbientTemperature,
+             .presentAmbientTemperature,
+             .presentIndoorAmbientTemperature,
+             .presentOutdoorAmbientTemperature:
+            return 1
+            
+        case .lightControlLightnessOn,
+             .lightControlLightnessProlong,
+             .lightControlLightnessStandby,
+             .peopleCount,
+             .presentAmbientRelativeHumidity,
+             .presentIndoorRelativeHumidity,
+             .presentOutdoorRelativeHumidity,
+             .timeSinceMotionSensed,
+             .timeSincePresenceDetected:
+            return 2
+            
+        case .deviceDateOfManufacture,
+             .deviceRuntimeSinceTurnOn,
+             .deviceRuntimeWarranty,
+             .totalDeviceStarts,
+             .totalDevicePowerOnTime,
+             .totalDeviceRuntime,
+             .totalLightExposureTime,
+             .totalDeviceOffOnCycles,
+             .totalDevicePowerOnCycles,
+             .lightControlTimeFade,
+             .lightControlTimeFadeOn,
+             .lightControlTimeFadeStandbyAuto,
+             .lightControlTimeFadeStandbyManual,
+             .lightControlTimeOccupancyDelay,
+             .lightControlTimeProlong,
+             .lightControlTimeRunOn,
+             .lightControlAmbientLuxLevelOn,
+             .lightControlAmbientLuxLevelProlong,
+             .lightControlAmbientLuxLevelStandby,
+             .lightSourceStartCounterResettable,
+             .lightSourceTotalPowerOnCycles,
+             .luminaireTimeOfManufacture,
+             .presentAmbientLightLevel,
+             .presentIlluminance,
+             .ratedMedianUsefulLightSourceStarts,
+             .ratedMedianUsefulLifeOfLuminaire:
+            return 3
+            
+        case .airPressure,
+             .pressure,
+             .lightControlRegulatorKid,
+             .lightControlRegulatorKiu,
+             .lightControlRegulatorKpd,
+             .lightControlRegulatorKpu,
+             .sensorGain:
+            return 4
+            
+        case .deviceFirmwareRevision,
+             .deviceSoftwareRevision:
+            return 8
+        case .deviceHardwareRevision,
+             .deviceSerialNumber:
+            return 16
+        case .deviceModelNumber,
+             .luminaireColor,
+             .luminaireIdentificationNumber:
+            return 24
+        case .deviceManufacturerName:
+            return 36
+        case .luminaireIdentificationString:
+            return 64
+            
+        default:
+            return nil // Unknown
+        }
+    }
+    
+    /// Parses the characteristic from given data.
+    ///
+    /// - important: This method does not ensure that the length of data is sufficient.
+    ///
+    /// - parameters:
+    ///   - data:   The data to be read from.
+    ///   - offset: The offset.
+    ///   - length: Expected length of the data.
+    /// - returns: The characteristic value.
+    func read(from data: Data, at offset: Int, length: Int) -> DevicePropertyCharacteristic {
+        switch self {
+        // Bool:
+        case .presenceDetected:
+            return .bool(data[offset] != 0x00)
+        
+        // UInt8:
+        case .lightControlRegulatorAccuracy,
+             .outputRippleVoltageSpecification,
+             .inputVoltageRippleSpecification,
+             .outputCurrentPercent,
+             .lumenMaintenanceFactor,
+             .motionSensed,
+             .motionThreshold,
+             .presentDeviceOperatingEfficiency,
+             .presentRelativeOutputRippleVoltage,
+             .presentInputRippleVoltage:
+            return .percentage8(data[offset])
+            
+        // Int8:
+        case .desiredAmbientTemperature,
+             .presentAmbientTemperature,
+             .presentIndoorAmbientTemperature,
+             .presentOutdoorAmbientTemperature:
+            return .temperature8(Int8(bitPattern: data[offset]))
+            
+        // UInt16:
+        case .peopleCount:
+            return .count16(data.read(fromOffset: offset))
+        case .presentAmbientRelativeHumidity,
+             .presentIndoorRelativeHumidity,
+             .presentOutdoorRelativeHumidity:
+            return .humidity(data.read(fromOffset: offset))
+        case .lightControlLightnessOn,
+             .lightControlLightnessProlong,
+             .lightControlLightnessStandby:
+            return .perceivedLightness(data.read(fromOffset: offset))
+        case .timeSinceMotionSensed,
+             .timeSincePresenceDetected:
+            return .timeSecond16(data.read(fromOffset: offset))
+            
+        // UInt24:
+        case .lightSourceStartCounterResettable,
+             .lightSourceTotalPowerOnCycles,
+             .ratedMedianUsefulLightSourceStarts,
+             .totalDeviceOffOnCycles,
+             .totalDevicePowerOnCycles,
+             .totalDeviceStarts:
+            return .count24(data.readUInt24(fromOffset: offset))
+        case .lightControlAmbientLuxLevelOn,
+             .lightControlAmbientLuxLevelProlong,
+             .lightControlAmbientLuxLevelStandby,
+             .presentAmbientLightLevel,
+             .presentIlluminance:
+            return .illuminance(data.readUInt24(fromOffset: offset))
+        case .deviceRuntimeSinceTurnOn,
+             .deviceRuntimeWarranty,
+             .ratedMedianUsefulLifeOfLuminaire,
+             .totalDevicePowerOnTime,
+             .totalDeviceRuntime,
+             .totalLightExposureTime:
+            return .timeHour24(data.readUInt24(fromOffset: offset))
+        case .lightControlTimeFade,
+             .lightControlTimeFadeOn,
+             .lightControlTimeFadeStandbyAuto,
+             .lightControlTimeFadeStandbyManual,
+             .lightControlTimeOccupancyDelay,
+             .lightControlTimeProlong,
+             .lightControlTimeRunOn:
+            return .timeMillisecond24(data.readUInt24(fromOffset: offset))
+        case .deviceDateOfManufacture,
+             .luminaireTimeOfManufacture:
+            let numberOfDays = data.readUInt24(fromOffset: offset)
+            let timeInterval = TimeInterval(numberOfDays) * 86400.0
+            return .dateUTC(Date(timeIntervalSince1970: timeInterval))
+            
+        // UInt32:
+        case .pressure,
+             .airPressure:
+            return .pressure(data.read(fromOffset: offset))
+            
+        // Float32 (IEEE 754):
+        case .lightControlRegulatorKid,
+             .lightControlRegulatorKiu,
+             .lightControlRegulatorKpd,
+             .lightControlRegulatorKpu,
+             .sensorGain:
+            let asInt32: UInt32 = data.read(fromOffset: offset)
+            return .coefficient(Float(bitPattern: asInt32))
+            
+        // String:
+        case .deviceFirmwareRevision,
+             .deviceSoftwareRevision:
+            return .fixedString8(String(data: data.subdata(in: offset..<offset + 8), encoding: .utf8)!)
+        case .deviceHardwareRevision,
+             .deviceSerialNumber:
+            return .fixedString16(String(data: data.subdata(in: offset..<offset + 16), encoding: .utf8)!)
+        case .deviceModelNumber,
+             .luminaireColor,
+             .luminaireIdentificationNumber:
+            return .fixedString24(String(data: data.subdata(in: offset..<offset + 24), encoding: .utf8)!)
+        case .deviceManufacturerName:
+            return .fixedString36(String(data: data.subdata(in: offset..<offset + 36), encoding: .utf8)!)
+        case .luminaireIdentificationString:
+            return .fixedString64(String(data: data.subdata(in: offset..<offset + 64), encoding: .utf8)!)
+            
+        // Other:
+        default:
+            return .other(data.subdata(in: offset..<offset + length))
+        }
+    }
+    
+}
+
+/// A representation of a property charactersitic.
+public enum DevicePropertyCharacteristic {
+    /// True or false.
+    case bool(Bool)
+    /// The Count 16 characteristic is used to represent a general count value.
+    ///
+    /// A value of 0xFFFF represents 'value is not known'.
+    case count16(UInt16)
+    /// The Count 24 characteristic is used to represent a general count value.
+    ///
+    /// A value of 0xFFFFFF represents 'value is not known'.
+    case count24(UInt32)
+    /// The Coefficient characteristic is used to represent a general coefficient value.
+    case coefficient(Float32)
+    /// Date as days elapsed since the Epoch (Jan 1, 1970) in the Coordinated Universal
+    /// Time (UTC) time zone.
+    ///
+    /// A value of 0x000000 (Jan 1, 1970) represents 'value is not known'.
+    case dateUTC(Date)
+    /// The Fixed String 8 characteristic represents an 8-octet UTF-8 string.
+    case fixedString8(String)
+    /// The Fixed String 16 characteristic represents a 16-octet UTF-8 string.
+    case fixedString16(String)
+    /// The Fixed String 24 characteristic represents a 24-octet UTF-8 string.
+    case fixedString24(String)
+    /// The Fixed String 36 characteristic represents a 36-octet UTF-8 string.
+    case fixedString36(String)
+    /// The Fixed String 64 characteristic represents a 64-octet UTF-8 string.
+    case fixedString64(String)
+    /// The Humidity characteristic is used to represent humidity value in
+    /// percent with a resolution of 0.01 percent.
+    case humidity(UInt16)
+    /// The Illuminance characteristic is used to represent a measure of illuminance
+    /// in units of lux with resolution 0.01 lux.
+    ///
+    /// A value of 0xFFFFFF represents 'value is not known'.
+    case illuminance(UInt32)
+    /// The Percentage 8 characteristic is used to represent a measure of percentage.
+    ///
+    /// Unit is a percentage with a resolution of 0.5.
+    ///
+    /// A value of 0xFF represents 'value is not known'.
+    /// Values 201..254 are Prohibited.
+    case percentage8(UInt8)
+    /// The Perceived Lightness characteristic is used to represent the perceived
+    /// lightness of a light.
+    case perceivedLightness(UInt16)
+    /// The Pressure characteristic is used to represent a pressure value.
+    ///
+    /// Unit is in pascals with a resolution of 0.1 Pa.
+    case pressure(UInt32)
+    /// The Temperature 8 characteristic is used to represent a measure of
+    /// temperature with a unit of 0.5 degree Celsius.
+    ///
+    /// A value of 0x7F represents 'value is not known'.
+    case temperature8(Int8)
+    /// The Time Hour 24 characteristic is used to represent a period of time in hours.
+    ///
+    /// A value of 0xFFFFFF represents 'value is not known'.
+    case timeHour24(UInt32)
+    /// The Time Millisecond 24 characteristic is used to represent a period of time
+    /// with a resolution of 1 millisecond.
+    ///
+    /// A value of 0xFFFFFF represents 'value is not known'.
+    case timeMillisecond24(UInt32)
+    /// The Time Second 16 characteristic is used to represent a period of time with
+    /// a unit of 1 second.
+    ///
+    /// A value of 0xFFFF represents 'value is not known'.
+    case timeSecond16(UInt16)
+    /// The Time Second 32 characteristic is used to represent a period of time with
+    /// a unit of 1 second.
+    ///
+    /// A value of 0xFFFFFF represents 'value is not known'.
+    case timeSecond32(UInt32)
+    /// Generic data type for other characteristics.
+    case other(Data)
+    
+}
+
+internal extension DevicePropertyCharacteristic {
+    
+    /// The characteristic value as Data.
+    var data: Data {
+        switch self {
+        // Bool:
+        case .bool(let value):
+            return Data([value ? 0x01 : 0x00])
+            
+        // UInt8:
+        case .percentage8(let value):
+            return Data([value])
+            
+        // Int8:
+        case .temperature8(let value):
+            return Data([UInt8(bitPattern: value)])
+            
+        // UInt16:
+        case .count16(let value),
+             .humidity(let value),
+             .timeSecond16(let value),
+             .perceivedLightness(let value):
+            return Data() + value
+            
+        // UInt24:
+        case .count24(let value),
+             .illuminance(let value),
+             .timeHour24(let value),
+             .timeMillisecond24(let value):
+            return (Data() + value).dropLast()
+            
+        case .dateUTC(let date):
+            let numberOfDays = UInt32(date.timeIntervalSince1970 / 86400.0) // convert to days
+            return (Data() + numberOfDays).dropLast()
+        
+        // UInt32:
+        case .pressure(let value),
+             .timeSecond32(let value):
+            return Data() + value
+        
+        // Float32 (IEEE 754):
+        case .coefficient(let value):
+            return Data() + value.bitPattern
+            
+        // String: (we need to ensure the required number of bytes)
+        case .fixedString8(let string):
+            return string.padding(toLength: 8, withPad: " ", startingAt: 0).data(using: .utf8)!.prefix(8)
+        case .fixedString16(let string):
+            return string.padding(toLength: 16, withPad: " ", startingAt: 0).data(using: .utf8)!.prefix(16)
+        case .fixedString24(let string):
+            return string.padding(toLength: 24, withPad: " ", startingAt: 0).data(using: .utf8)!.prefix(24)
+        case .fixedString36(let string):
+            return string.padding(toLength: 36, withPad: " ", startingAt: 0).data(using: .utf8)!.prefix(36)
+        case .fixedString64(let string):
+            return string.padding(toLength: 64, withPad: " ", startingAt: 0).data(using: .utf8)!.prefix(64)
+            
+        // Other:
+        case .other(let data):
+            return data
+        }
+    }
+}
+
+extension DevicePropertyCharacteristic: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        switch self {
+        // Bool:
+        case .bool(let value):
+            // There's only one Boolean property: .presenceDetected.
+            return value ? "Presence Detected" : "Presence Not Detected"
+            
+        // UInt8:
+        case .percentage8(let percent):
+            switch percent {
+            case 0xFF:
+                return "Value is not known"
+            case let percent where percent >= 0 && percent <= 200:
+                return String(format: "%.1f%%", Float(percent) / 2.0)
+            default:
+                return "Prohibited (\(percent))"
+            }
+            
+        // Int8:
+        case .temperature8(let temp):
+            switch temp {
+            case 0x7F:
+                return "Value is not known"
+            default:
+                return String(format: "%.1f°C", Float(temp) / 2.0)
+            }
+            
+        // UInt16:
+        case .count16(let count):
+            switch count {
+            case 0xFFFF:
+                return "Value is not known"
+            default:
+                return "\(count)" // unitless
+            }
+        case .perceivedLightness(let count):
+            return "\(count)"
+        case .timeSecond16(let count):
+            switch count {
+            case 0xFFFF:
+                return "Value is not known"
+            default:
+                return "\(count) seconds"
+            }
+            
+        // UInt24:
+        case .count24(let count):
+            switch count {
+            case 0xFFFFFF:
+                return "Value is not known"
+            default:
+                return "\(count)" // unitless
+            }
+        case .humidity(let percent):
+            switch percent {
+            case let percent where percent <= 10000:
+                return String(format: "%.2f%%", Float(percent) / 100.0)
+            default:
+                return "Prohibited (\(percent))"
+            }
+        case .illuminance(let millilux):
+            switch millilux {
+            case 0xFFFFFF:
+                return "Value is not known"
+            default:
+                return String(format: "%.2f lux", Float(millilux) / 100.0)
+            }
+        case .timeHour24(let count):
+            switch count {
+            case let count where count >= 0xFFFFFF:
+                return "Value is not known"
+            default:
+                return "\(count) hours"
+            }
+        case .timeMillisecond24(let count):
+            switch count {
+            case let invalid where invalid >= 0xFFFFFF:
+                return "Value is not known"
+            default:
+                return "\(count) ms"
+            }
+        case .dateUTC(let date):
+            if date.timeIntervalSince1970 < 86400 {
+                return "Value is not known"
+            }
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateStyle = .medium
+            dateFormatter.timeStyle = .none
+            return dateFormatter.string(from: date)
+            
+        // UInt32:
+        case .pressure(let pressure):
+            return String(format: "%.1f Pa", Double(pressure) / 10.0)
+        case .timeSecond32(let count):
+            switch count {
+            case 0xFFFFFFFF:
+                return "Value is not known"
+            default:
+                return "\(count) seconds"
+            }
+            
+        // Float32 (IEEE 754):
+        case .coefficient(let coefficient):
+            return "\(coefficient)" // unitless
+            
+        // String:
+        case .fixedString8(let string),
+             .fixedString16(let string),
+             .fixedString24(let string),
+             .fixedString36(let string),
+             .fixedString64(let string):
+            return string
+            
+        // Other:
+        case .other(let data):
+            return data.hex
+        }
+    }
+    
+}
+
+extension DeviceProperty: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        switch self {
+        case .averageAmbientTemperatureInAPeriodOfDay: return "Average Ambient Temperature In A Period Of Day"
+        case .averageInputCurrent: return "Average Input Current"
+        case .averageInputVoltage: return "Average Input Voltage"
+        case .averageOutputCurrent: return "Average Output Current"
+        case .averageOutputVoltage: return "Average Output Voltage"
+        case .centerBeamIntensityAtFullPower: return "Center Beam Intensity At Full Power"
+        case .chromaticityTolerance: return "Chromaticity T olerance"
+        case .colorRenderingIndexR9: return "Color Rendering Index R9"
+        case .colorRenderingIndexRa: return "Color Rendering Index Ra"
+        case .deviceAppearance: return "Device Appearance"
+        case .deviceCountryOfOrigin: return "Device Country Of Origin"
+        case .deviceDateOfManufacture: return "Device Date Of Manufacture"
+        case .deviceEnergyUseSinceTurnOn: return "Device Energy Use Since Turn On"
+        case .deviceFirmwareRevision: return "Device Firmware Revision"
+        case .deviceGlobalTradeItemNumber: return "Device Global Trade Item Number"
+        case .deviceHardwareRevision: return "Device Hardware Revision"
+        case .deviceManufacturerName: return "Device Manufacturer Name"
+        case .deviceModelNumber: return "Device Model Number"
+        case .deviceOperatingTemperatureRangeSpecification: return "Device Operating Temperature Range Specification"
+        case .deviceOperatingTemperatureStatisticalValues: return "Device Operating Temperature Statistical Values"
+        case .deviceOverTemperatureEventStatistics: return "Device Over Temperature Event Statistics"
+        case .devicePowerRangeSpecification: return "Device Power Range Specification"
+        case .deviceRuntimeSinceTurnOn: return "Device Runtime Since Turn On"
+        case .deviceRuntimeWarranty: return "Device Runtime Warranty"
+        case .deviceSerialNumber: return "Device Serial Number"
+        case .deviceSoftwareRevision: return "Device Software Revision"
+        case .deviceUnderTemperatureEventStatistics: return "Device Under Temperature Event Statistics"
+        case .indoorAmbientTemperatureStatisticalValues: return "Indoor Ambient Temperature Statistical Values"
+        case .initialCIE1931ChromaticityCoordinates: return "Initial CIE 1931 Chromaticity Coordinates"
+        case .initialCorrelatedColorTemperature: return "Initial Correlated Color Temperature"
+        case .initialLuminousFlux: return "Initial Luminous Flux"
+        case .initialPlanckianDistance: return "Initial Planckian Distance"
+        case .inputCurrentRangeSpecification: return "Input Current Range Specification"
+        case .inputCurrentStatistics: return "Input Current Statistics"
+        case .inputOverCurrentEventStatistics: return "Input Over Current Event Statistics"
+        case .inputOverRippleVoltageEventStatistics: return "Input Over Ripple Voltage Event Statistics"
+        case .inputOverVoltageEventStatistics: return "Input Over Voltage Event Statistics"
+        case .inputUnderCurrentEventStatistics: return "Input Under Current Event Statistics"
+        case .inputUnderVoltageEventStatistics: return "Input Under Voltage Event Statistics"
+        case .inputVoltageRangeSpecification: return "Input Voltage Range Specification"
+        case .inputVoltageRippleSpecification: return "Input Voltage Ripple Specification"
+        case .inputVoltageStatistics: return "Input Voltage Statistics"
+        case .lightControlAmbientLuxLevelOn: return "Light Control Ambient LuxLevel On"
+        case .lightControlAmbientLuxLevelProlong: return "Light Control Ambient LuxLevel Prolong"
+        case .lightControlAmbientLuxLevelStandby: return "Light Control Ambient LuxLevel Standby"
+        case .lightControlLightnessOn: return "Light Control Lightness On"
+        case .lightControlLightnessProlong: return "Light Control Lightness Prolong"
+        case .lightControlLightnessStandby: return "Light Control Lightness Standby"
+        case .lightControlRegulatorAccuracy: return "Light Control Regulator Accuracy"
+        case .lightControlRegulatorKid: return "Light Control Regulator Kid"
+        case .lightControlRegulatorKiu: return "Light Control Regulator Kiu"
+        case .lightControlRegulatorKpd: return "Light Control Regulator Kpd"
+        case .lightControlRegulatorKpu: return "Light Control Regulator Kpu"
+        case .lightControlTimeFade: return "Light Control Time Fade"
+        case .lightControlTimeFadeOn: return "Light Control Time Fade On"
+        case .lightControlTimeFadeStandbyAuto: return "Light Control Time Fade Standby Auto"
+        case .lightControlTimeFadeStandbyManual: return "Light Control Time Fade Standby Manual"
+        case .lightControlTimeOccupancyDelay: return "Light Control Time Occupancy Delay"
+        case .lightControlTimeProlong: return "Light Control Time Prolong"
+        case .lightControlTimeRunOn: return "Light Control Time Run On"
+        case .lumenMaintenanceFactor: return "Lumen Maintenance Factor"
+        case .luminousEfficacy: return "Luminous Efficacy"
+        case .luminousEnergySinceTurnOn: return "Luminous Energy Since Turn On"
+        case .luminousExposure: return "Luminous Exposure"
+        case .luminousFluxRange: return "Luminous Flux Range"
+        case .motionSensed: return "Motion Sensed"
+        case .motionThreshold: return "Motion Threshold"
+        case .openCircuitEventStatistics: return "Open Circuit Event Statistics"
+        case .outdoorStatisticalValues: return "Outdoor Statistical Values"
+        case .outputCurrentRange: return "Output Current Range"
+        case .outputCurrentStatistics: return "Output Current Statistics"
+        case .outputRippleVoltageSpecification: return "Output Ripple Voltage Specification"
+        case .outputVoltageRange: return "Output Voltage Range"
+        case .outputVoltageStatistics: return "Output Voltage Statistics"
+        case .overOutputRippleVoltageEventStatistics: return "Over Output Ripple Voltage Event Statistics"
+        case .peopleCount: return "People Count"
+        case .presenceDetected: return "Presence Detected"
+        case .presentAmbientLightLevel: return "Present Ambient Light Level"
+        case .presentAmbientTemperature: return "Present Ambient Temperature"
+        case .presentCIE1931ChromaticityCoordinates: return "Present CIE 1931 Chromaticity Coordinates"
+        case .presentCorrelatedColorTemperature: return "Present Correlated Color Temperature"
+        case .presentDeviceInputPower: return "Present Device Input Power"
+        case .presentDeviceOperatingEfficiency: return "Present Device Operating Efficiency"
+        case .presentDeviceOperatingTemperature: return "Present Device Operating Temperature"
+        case .presentIlluminance: return "Present Illuminance"
+        case .presentIndoorAmbientTemperature: return "Present Indoor Ambient Temperature"
+        case .presentInputCurrent: return "Present Input Current"
+        case .presentInputRippleVoltage: return "Present Input Ripple Voltage"
+        case .presentInputVoltage: return "Present Input Voltage"
+        case .presentLuminousFlux: return "Present Luminous Flux"
+        case .presentOutdoorAmbientTemperature: return "Present Outdoor Ambient Temperature"
+        case .presentOutputCurrent: return "Present Output Current"
+        case .presentOutputVoltage: return "Present Output Voltage"
+        case .presentPlanckianDistance: return "Present Planckian Distance"
+        case .presentRelativeOutputRippleVoltage: return "Present Relative Output Ripple Voltage"
+        case .relativeDeviceEnergyUseInAPeriodOfDay: return "Relative Device Energy Use In A Period Of Day"
+        case .relativeDeviceRuntimeInAGenericLevelRange: return "Relative Device Runtime In A Generic Level Range"
+        case .relativeExposureTimeInAnIlluminanceRange: return "Relative Exposure Time In An Illuminance Range"
+        case .relativeRuntimeInACorrelatedColorTemperatureRange: return "Relative Runtime In A Correlated Color Temperature Range"
+        case .relativeRuntimeInADeviceOperatingTemperatureRange: return "Relative Runtime In A Device Operating Temperature Range"
+        case .relativeRuntimeInAnInputCurrentRange: return "Relative Runtime In An Input Current Range"
+        case .relativeRuntimeInAnInputVoltageRange: return "Relative Runtime In An Input Voltage Range"
+        case .shortCircuitEventStatistics: return "Short Circuit Event Statistics"
+        case .timeSinceMotionSensed: return "Time Since Motion Sensed"
+        case .timeSincePresenceDetected: return "Time Since Presence Detected"
+        case .totalDeviceEnergyUse: return "Total Device Energy Use"
+        case .totalDeviceOffOnCycles: return "Total Device Off On Cycles"
+        case .totalDevicePowerOnCycles: return "Total Device Power On Cycles"
+        case .totalDevicePowerOnTime: return "Total Device Power On Time"
+        case .totalDeviceRuntime: return "Total Device Runtime"
+        case .totalLightExposureTime: return "Total Light Exposure Time"
+        case .totalLuminousEnergy: return "Total Luminous Energy"
+        case .desiredAmbientTemperature: return "Desired Ambient Temperature"
+        case .preciseTotalDeviceEnergyUse: return "Precise Total Device Energy Use"
+        case .powerFactor: return "Power Factor"
+        case .sensorGain: return "Sensor Gain"
+        case .precisePresentAmbientTemperature: return "Precise Present Ambient Temperature"
+        case .presentAmbientRelativeHumidity: return "Present Ambient Relative Humidity"
+        case .presentAmbientCarbonDioxideConcentration: return "Present Ambient Carbon Dioxide Concentration"
+        case .presentAmbientVolatileOrganicCompoundsConcentration: return "Present Ambient Volatile Organic Compounds Concentration"
+        case .presentAmbientNoise: return "Present Ambient Noise"
+        case .activeEnergyLoadside: return "Active Energy Loadside"
+        case .activePowerLoadside: return "Active Power Loadside"
+        case .airPressure: return "Air Pressure"
+        case .apparentEnergy: return "Apparent Energy"
+        case .apparentPower: return "Apparent Power"
+        case .apparentWindDirection: return "Apparent Wind Direction"
+        case .apparentWindSpeed: return "Apparent Wind Speed"
+        case .dewPoint: return "Dew Point"
+        case .externalSupplyVoltage: return "External Supply Voltage"
+        case .externalSupplyVoltageFrequency: return "External Supply Voltage Frequency"
+        case .gustFactor: return "Gust Factor"
+        case .heatIndex: return "Heat Index"
+        case .lightDistribution: return "Light Distribution"
+        case .lightSourceCurrent: return "Light Source Current"
+        case .lightSourceOnTimeNotResettable: return "Light Source On Time Not Resettable"
+        case .lightSourceOnTimeResettable: return "Light Source On Time Resettable"
+        case .lightSourceOpenCircuitStatistics: return "Light Source Open Circuit Statistics"
+        case .lightSourceOverallFailuresStatistics: return "Light Source Overall Failures Statistics"
+        case .lightSourceShortCircuitStatistics: return "Light Source Short Circuit Statistics"
+        case .lightSourceStartCounterResettable: return "Light Source Start Counter Resettable"
+        case .lightSourceTemperature: return "Light Source Temperature"
+        case .lightSourceThermalDeratingStatistics: return "Light Source Thermal Derating Statistics"
+        case .lightSourceThermalShutdownStatistics: return "Light Source Thermal Shutdown Statistics"
+        case .lightSourceTotalPowerOnCycles: return "Light Source Total Power On Cycles"
+        case .lightSourceVoltage: return "Light Source Voltage"
+        case .luminaireColor: return "Luminaire Color"
+        case .luminaireIdentificationNumber: return "Luminaire Identification Number"
+        case .luminaireManufacturerGTIN: return "Luminaire Manufacturer GTIN"
+        case .luminaireNominalInputPower: return "Luminaire Nominal Input Power"
+        case .luminaireNominalMaximumACMainsVoltage: return "Luminaire Nominal Maximum AC Mains Voltage"
+        case .luminaireNominalMinimumACMainsVoltage: return "Luminaire Nominal Minimum AC Mains Voltage"
+        case .luminairePowerAtMinimumDimLevel: return "Luminaire Power At Minimum Dim Level"
+        case .luminaireTimeOfManufacture: return "Luminaire Time Of Manufacture"
+        case .magneticDeclination: return "Magnetic Declination"
+        case .magneticFluxDensity2D: return "Magnetic Flux Density - 2D"
+        case .magneticFluxDensity3D: return "Magnetic Flux Density - 3D"
+        case .nominalLightOutput: return "Nominal Light Output"
+        case .overallFailureCondition: return "Overall Failure Condition"
+        case .pollenConcentration: return "Pollen Concentration"
+        case .presentIndoorRelativeHumidity: return "Present Indoor Relative Humidity"
+        case .presentOutdoorRelativeHumidity: return "Present Outdoor Relative Humidity"
+        case .pressure: return "Pressure"
+        case .rainfall: return "Rainfall"
+        case .ratedMedianUsefulLifeOfLuminaire: return "Rated Median Useful Life Of Luminaire"
+        case .ratedMedianUsefulLightSourceStarts: return "Rated Median Useful Light Source Starts"
+        case .referenceTemperature: return "Reference Temperature"
+        case .totalDeviceStarts: return "Total Device Starts"
+        case .trueWindDirection: return "True Wind Direction"
+        case .trueWindSpeed: return "True Wind Speed"
+        case .uVIndex: return "UV Index"
+        case .windChill: return "Wind Chill"
+        case .lightSourceType: return "Light Source Type"
+        case .luminaireIdentificationString: return "Luminaire Identification String"
+        case .outputPowerLimitation: return "Output Power Limitation"
+        case .thermalDerating: return "Thermal Derating"
+        case .outputCurrentPercent: return "Output Current Percent"
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/DeviceProperty.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/DeviceProperty.swift
@@ -35,191 +35,558 @@ import Foundation
 /// - note: Each property has a corresponding `DevicePropertyCharacteristic`.
 ///         However, currently not all values are implemented in this library.
 ///         For those, `.other` should be used until they are implemented.
-public enum DeviceProperty: UInt16 {
-    case averageAmbientTemperatureInAPeriodOfDay = 0x0001
-    case averageInputCurrent = 0x0002
-    case averageInputVoltage = 0x0003
-    case averageOutputCurrent = 0x0004
-    case averageOutputVoltage = 0x0005
-    case centerBeamIntensityAtFullPower = 0x0006
-    case chromaticityTolerance = 0x0007
-    case colorRenderingIndexR9 = 0x0008
-    case colorRenderingIndexRa = 0x0009
-    case deviceAppearance = 0x000A
-    case deviceCountryOfOrigin = 0x000B
-    case deviceDateOfManufacture = 0x000C
-    case deviceEnergyUseSinceTurnOn = 0x000D
-    case deviceFirmwareRevision = 0x000E
-    case deviceGlobalTradeItemNumber = 0x000F
-    case deviceHardwareRevision = 0x0010
-    case deviceManufacturerName = 0x0011
-    case deviceModelNumber = 0x0012
-    case deviceOperatingTemperatureRangeSpecification = 0x0013
-    case deviceOperatingTemperatureStatisticalValues = 0x0014
-    case deviceOverTemperatureEventStatistics = 0x0015
-    case devicePowerRangeSpecification = 0x0016
-    case deviceRuntimeSinceTurnOn = 0x0017
-    case deviceRuntimeWarranty = 0x0018
-    case deviceSerialNumber = 0x0019
-    case deviceSoftwareRevision = 0x001A
-    case deviceUnderTemperatureEventStatistics = 0x001B
-    case indoorAmbientTemperatureStatisticalValues = 0x001C
-    case initialCIE1931ChromaticityCoordinates = 0x001D
-    case initialCorrelatedColorTemperature = 0x001E
-    case initialLuminousFlux = 0x001F
-    case initialPlanckianDistance = 0x0020
-    case inputCurrentRangeSpecification = 0x0021
-    case inputCurrentStatistics = 0x0022
-    case inputOverCurrentEventStatistics = 0x0023
-    case inputOverRippleVoltageEventStatistics = 0x0024
-    case inputOverVoltageEventStatistics = 0x0025
-    case inputUnderCurrentEventStatistics = 0x0026
-    case inputUnderVoltageEventStatistics = 0x0027
-    case inputVoltageRangeSpecification = 0x0028
-    case inputVoltageRippleSpecification = 0x0029
-    case inputVoltageStatistics = 0x002A
-    case lightControlAmbientLuxLevelOn = 0x002B
-    case lightControlAmbientLuxLevelProlong = 0x002C
-    case lightControlAmbientLuxLevelStandby = 0x002D
-    case lightControlLightnessOn = 0x002E
-    case lightControlLightnessProlong = 0x002F
-    case lightControlLightnessStandby = 0x0030
-    case lightControlRegulatorAccuracy = 0x0031
-    case lightControlRegulatorKid = 0x0032
-    case lightControlRegulatorKiu = 0x0033
-    case lightControlRegulatorKpd = 0x0034
-    case lightControlRegulatorKpu = 0x0035
-    case lightControlTimeFade = 0x0036
-    case lightControlTimeFadeOn = 0x0037
-    case lightControlTimeFadeStandbyAuto = 0x0038
-    case lightControlTimeFadeStandbyManual = 0x0039
-    case lightControlTimeOccupancyDelay = 0x003A
-    case lightControlTimeProlong = 0x003B
-    case lightControlTimeRunOn = 0x003C
-    case lumenMaintenanceFactor = 0x003D
-    case luminousEfficacy = 0x003E
-    case luminousEnergySinceTurnOn = 0x003F
-    case luminousExposure = 0x0040
-    case luminousFluxRange = 0x0041
-    case motionSensed = 0x0042
-    case motionThreshold = 0x0043
-    case openCircuitEventStatistics = 0x0044
-    case outdoorStatisticalValues = 0x0045
-    case outputCurrentRange = 0x0046
-    case outputCurrentStatistics = 0x0047
-    case outputRippleVoltageSpecification = 0x0048
-    case outputVoltageRange = 0x0049
-    case outputVoltageStatistics = 0x004A
-    case overOutputRippleVoltageEventStatistics = 0x004B
-    case peopleCount = 0x004C
-    case presenceDetected = 0x004D
-    case presentAmbientLightLevel = 0x004E
-    case presentAmbientTemperature = 0x004F
-    case presentCIE1931ChromaticityCoordinates = 0x0050
-    case presentCorrelatedColorTemperature = 0x0051
-    case presentDeviceInputPower = 0x0052
-    case presentDeviceOperatingEfficiency = 0x0053
-    case presentDeviceOperatingTemperature = 0x0054
-    case presentIlluminance = 0x0055
-    case presentIndoorAmbientTemperature = 0x0056
-    case presentInputCurrent = 0x0057
-    case presentInputRippleVoltage = 0x0058
-    case presentInputVoltage = 0x0059
-    case presentLuminousFlux = 0x005A
-    case presentOutdoorAmbientTemperature = 0x005B
-    case presentOutputCurrent = 0x005C
-    case presentOutputVoltage = 0x005D
-    case presentPlanckianDistance = 0x005E
-    case presentRelativeOutputRippleVoltage = 0x005F
-    case relativeDeviceEnergyUseInAPeriodOfDay = 0x0060
-    case relativeDeviceRuntimeInAGenericLevelRange = 0x0061
-    case relativeExposureTimeInAnIlluminanceRange = 0x0062
-    case relativeRuntimeInACorrelatedColorTemperatureRange = 0x0063
-    case relativeRuntimeInADeviceOperatingTemperatureRange = 0x0064
-    case relativeRuntimeInAnInputCurrentRange = 0x0065
-    case relativeRuntimeInAnInputVoltageRange = 0x0066
-    case shortCircuitEventStatistics = 0x0067
-    case timeSinceMotionSensed = 0x0068
-    case timeSincePresenceDetected = 0x0069
-    case totalDeviceEnergyUse = 0x006A
-    case totalDeviceOffOnCycles = 0x006B
-    case totalDevicePowerOnCycles = 0x006C
-    case totalDevicePowerOnTime = 0x006D
-    case totalDeviceRuntime = 0x006E
-    case totalLightExposureTime = 0x006F
-    case totalLuminousEnergy = 0x0070
-    case desiredAmbientTemperature = 0x0071
-    case preciseTotalDeviceEnergyUse = 0x0072
-    case powerFactor = 0x0073
-    case sensorGain = 0x0074
-    case precisePresentAmbientTemperature = 0x0075
-    case presentAmbientRelativeHumidity = 0x0076
-    case presentAmbientCarbonDioxideConcentration = 0x0077
-    case presentAmbientVolatileOrganicCompoundsConcentration = 0x0078
-    case presentAmbientNoise = 0x0079
- // case these are undefined in Mesh Device Properties v2 = 0x007A
- // case these are undefined in Mesh Device Properties v2 = 0x007B
- // case these are undefined in Mesh Device Properties v2 = 0x007C
- // case these are undefined in Mesh Device Properties v2 = 0x007D
- // case these are undefined in Mesh Device Properties v2 = 0x007E
- // case these are undefined in Mesh Device Properties v2 = 0x007F
-    case activeEnergyLoadside = 0x0080
-    case activePowerLoadside = 0x0081
-    case airPressure = 0x0082
-    case apparentEnergy = 0x0083
-    case apparentPower = 0x0084
-    case apparentWindDirection = 0x0085
-    case apparentWindSpeed = 0x0086
-    case dewPoint = 0x0087
-    case externalSupplyVoltage = 0x0088
-    case externalSupplyVoltageFrequency = 0x0089
-    case gustFactor = 0x008A
-    case heatIndex = 0x008B
-    case lightDistribution = 0x008C
-    case lightSourceCurrent = 0x008D
-    case lightSourceOnTimeNotResettable = 0x008E
-    case lightSourceOnTimeResettable = 0x008F
-    case lightSourceOpenCircuitStatistics = 0x0090
-    case lightSourceOverallFailuresStatistics = 0x0091
-    case lightSourceShortCircuitStatistics = 0x0092
-    case lightSourceStartCounterResettable = 0x0093
-    case lightSourceTemperature = 0x0094
-    case lightSourceThermalDeratingStatistics = 0x0095
-    case lightSourceThermalShutdownStatistics = 0x0096
-    case lightSourceTotalPowerOnCycles = 0x0097
-    case lightSourceVoltage = 0x0098
-    case luminaireColor = 0x0099
-    case luminaireIdentificationNumber = 0x009A
-    case luminaireManufacturerGTIN = 0x009B
-    case luminaireNominalInputPower = 0x009C
-    case luminaireNominalMaximumACMainsVoltage = 0x009D
-    case luminaireNominalMinimumACMainsVoltage = 0x009E
-    case luminairePowerAtMinimumDimLevel = 0x009F
-    case luminaireTimeOfManufacture = 0x00A0
-    case magneticDeclination = 0x00A1
-    case magneticFluxDensity2D = 0x00A2
-    case magneticFluxDensity3D = 0x00A3
-    case nominalLightOutput = 0x00A4
-    case overallFailureCondition = 0x00A5
-    case pollenConcentration = 0x00A6
-    case presentIndoorRelativeHumidity = 0x00A7
-    case presentOutdoorRelativeHumidity = 0x00A8
-    case pressure = 0x00A9
-    case rainfall = 0x00AA
-    case ratedMedianUsefulLifeOfLuminaire = 0x00AB
-    case ratedMedianUsefulLightSourceStarts = 0x00AC
-    case referenceTemperature = 0x00AD
-    case totalDeviceStarts = 0x00AE
-    case trueWindDirection = 0x00AF
-    case trueWindSpeed = 0x00B0
-    case uVIndex = 0x00B1
-    case windChill = 0x00B2
-    case lightSourceType = 0x00B3
-    case luminaireIdentificationString = 0x00B4
-    case outputPowerLimitation = 0x00B5
-    case thermalDerating = 0x00B6
-    case outputCurrentPercent = 0x00B7
+public enum DeviceProperty {
+    case averageAmbientTemperatureInAPeriodOfDay
+    case averageInputCurrent
+    case averageInputVoltage
+    case averageOutputCurrent
+    case averageOutputVoltage
+    case centerBeamIntensityAtFullPower
+    case chromaticityTolerance
+    case colorRenderingIndexR9
+    case colorRenderingIndexRa
+    case deviceAppearance
+    case deviceCountryOfOrigin
+    case deviceDateOfManufacture
+    case deviceEnergyUseSinceTurnOn
+    case deviceFirmwareRevision
+    case deviceGlobalTradeItemNumber
+    case deviceHardwareRevision
+    case deviceManufacturerName
+    case deviceModelNumber
+    case deviceOperatingTemperatureRangeSpecification
+    case deviceOperatingTemperatureStatisticalValues
+    case deviceOverTemperatureEventStatistics
+    case devicePowerRangeSpecification
+    case deviceRuntimeSinceTurnOn
+    case deviceRuntimeWarranty
+    case deviceSerialNumber
+    case deviceSoftwareRevision
+    case deviceUnderTemperatureEventStatistics
+    case indoorAmbientTemperatureStatisticalValues
+    case initialCIE1931ChromaticityCoordinates
+    case initialCorrelatedColorTemperature
+    case initialLuminousFlux
+    case initialPlanckianDistance
+    case inputCurrentRangeSpecification
+    case inputCurrentStatistics
+    case inputOverCurrentEventStatistics
+    case inputOverRippleVoltageEventStatistics
+    case inputOverVoltageEventStatistics
+    case inputUnderCurrentEventStatistics
+    case inputUnderVoltageEventStatistics
+    case inputVoltageRangeSpecification
+    case inputVoltageRippleSpecification
+    case inputVoltageStatistics
+    case lightControlAmbientLuxLevelOn
+    case lightControlAmbientLuxLevelProlong
+    case lightControlAmbientLuxLevelStandby
+    case lightControlLightnessOn
+    case lightControlLightnessProlong
+    case lightControlLightnessStandby
+    case lightControlRegulatorAccuracy
+    case lightControlRegulatorKid
+    case lightControlRegulatorKiu
+    case lightControlRegulatorKpd
+    case lightControlRegulatorKpu
+    case lightControlTimeFade
+    case lightControlTimeFadeOn
+    case lightControlTimeFadeStandbyAuto
+    case lightControlTimeFadeStandbyManual
+    case lightControlTimeOccupancyDelay
+    case lightControlTimeProlong
+    case lightControlTimeRunOn
+    case lumenMaintenanceFactor
+    case luminousEfficacy
+    case luminousEnergySinceTurnOn
+    case luminousExposure
+    case luminousFluxRange
+    case motionSensed
+    case motionThreshold
+    case openCircuitEventStatistics
+    case outdoorStatisticalValues
+    case outputCurrentRange
+    case outputCurrentStatistics
+    case outputRippleVoltageSpecification
+    case outputVoltageRange
+    case outputVoltageStatistics
+    case overOutputRippleVoltageEventStatistics
+    case peopleCount
+    case presenceDetected
+    case presentAmbientLightLevel
+    case presentAmbientTemperature
+    case presentCIE1931ChromaticityCoordinates
+    case presentCorrelatedColorTemperature
+    case presentDeviceInputPower
+    case presentDeviceOperatingEfficiency
+    case presentDeviceOperatingTemperature
+    case presentIlluminance
+    case presentIndoorAmbientTemperature
+    case presentInputCurrent
+    case presentInputRippleVoltage
+    case presentInputVoltage
+    case presentLuminousFlux
+    case presentOutdoorAmbientTemperature
+    case presentOutputCurrent
+    case presentOutputVoltage
+    case presentPlanckianDistance
+    case presentRelativeOutputRippleVoltage
+    case relativeDeviceEnergyUseInAPeriodOfDay
+    case relativeDeviceRuntimeInAGenericLevelRange
+    case relativeExposureTimeInAnIlluminanceRange
+    case relativeRuntimeInACorrelatedColorTemperatureRange
+    case relativeRuntimeInADeviceOperatingTemperatureRange
+    case relativeRuntimeInAnInputCurrentRange
+    case relativeRuntimeInAnInputVoltageRange
+    case shortCircuitEventStatistics
+    case timeSinceMotionSensed
+    case timeSincePresenceDetected
+    case totalDeviceEnergyUse
+    case totalDeviceOffOnCycles
+    case totalDevicePowerOnCycles
+    case totalDevicePowerOnTime
+    case totalDeviceRuntime
+    case totalLightExposureTime
+    case totalLuminousEnergy
+    case desiredAmbientTemperature
+    case preciseTotalDeviceEnergyUse
+    case powerFactor
+    case sensorGain
+    case precisePresentAmbientTemperature
+    case presentAmbientRelativeHumidity
+    case presentAmbientCarbonDioxideConcentration
+    case presentAmbientVolatileOrganicCompoundsConcentration
+    case presentAmbientNoise
+    case activeEnergyLoadside
+    case activePowerLoadside
+    case airPressure
+    case apparentEnergy
+    case apparentPower
+    case apparentWindDirection
+    case apparentWindSpeed
+    case dewPoint
+    case externalSupplyVoltage
+    case externalSupplyVoltageFrequency
+    case gustFactor
+    case heatIndex
+    case lightDistribution
+    case lightSourceCurrent
+    case lightSourceOnTimeNotResettable
+    case lightSourceOnTimeResettable
+    case lightSourceOpenCircuitStatistics
+    case lightSourceOverallFailuresStatistics
+    case lightSourceShortCircuitStatistics
+    case lightSourceStartCounterResettable
+    case lightSourceTemperature
+    case lightSourceThermalDeratingStatistics
+    case lightSourceThermalShutdownStatistics
+    case lightSourceTotalPowerOnCycles
+    case lightSourceVoltage
+    case luminaireColor
+    case luminaireIdentificationNumber
+    case luminaireManufacturerGTIN
+    case luminaireNominalInputPower
+    case luminaireNominalMaximumACMainsVoltage
+    case luminaireNominalMinimumACMainsVoltage
+    case luminairePowerAtMinimumDimLevel
+    case luminaireTimeOfManufacture
+    case magneticDeclination
+    case magneticFluxDensity2D
+    case magneticFluxDensity3D
+    case nominalLightOutput
+    case overallFailureCondition
+    case pollenConcentration
+    case presentIndoorRelativeHumidity
+    case presentOutdoorRelativeHumidity
+    case pressure
+    case rainfall
+    case ratedMedianUsefulLifeOfLuminaire
+    case ratedMedianUsefulLightSourceStarts
+    case referenceTemperature
+    case totalDeviceStarts
+    case trueWindDirection
+    case trueWindSpeed
+    case uVIndex
+    case windChill
+    case lightSourceType
+    case luminaireIdentificationString
+    case outputPowerLimitation
+    case thermalDerating
+    case outputCurrentPercent
+    case unknown(UInt16)
     
+    init(_ id: UInt16) {
+        switch id {
+        case 0x0001: self = .averageAmbientTemperatureInAPeriodOfDay
+        case 0x0002: self = .averageInputCurrent
+        case 0x0003: self = .averageInputVoltage
+        case 0x0004: self = .averageOutputCurrent
+        case 0x0005: self = .averageOutputVoltage
+        case 0x0006: self = .centerBeamIntensityAtFullPower
+        case 0x0007: self = .chromaticityTolerance
+        case 0x0008: self = .colorRenderingIndexR9
+        case 0x0009: self = .colorRenderingIndexRa
+        case 0x000A: self = .deviceAppearance
+        case 0x000B: self = .deviceCountryOfOrigin
+        case 0x000C: self = .deviceDateOfManufacture
+        case 0x000D: self = .deviceEnergyUseSinceTurnOn
+        case 0x000E: self = .deviceFirmwareRevision
+        case 0x000F: self = .deviceGlobalTradeItemNumber
+        case 0x0010: self = .deviceHardwareRevision
+        case 0x0011: self = .deviceManufacturerName
+        case 0x0012: self = .deviceModelNumber
+        case 0x0013: self = .deviceOperatingTemperatureRangeSpecification
+        case 0x0014: self = .deviceOperatingTemperatureStatisticalValues
+        case 0x0015: self = .deviceOverTemperatureEventStatistics
+        case 0x0016: self = .devicePowerRangeSpecification
+        case 0x0017: self = .deviceRuntimeSinceTurnOn
+        case 0x0018: self = .deviceRuntimeWarranty
+        case 0x0019: self = .deviceSerialNumber
+        case 0x001A: self = .deviceSoftwareRevision
+        case 0x001B: self = .deviceUnderTemperatureEventStatistics
+        case 0x001C: self = .indoorAmbientTemperatureStatisticalValues
+        case 0x001D: self = .initialCIE1931ChromaticityCoordinates
+        case 0x001E: self = .initialCorrelatedColorTemperature
+        case 0x001F: self = .initialLuminousFlux
+        case 0x0020: self = .initialPlanckianDistance
+        case 0x0021: self = .inputCurrentRangeSpecification
+        case 0x0022: self = .inputCurrentStatistics
+        case 0x0023: self = .inputOverCurrentEventStatistics
+        case 0x0024: self = .inputOverRippleVoltageEventStatistics
+        case 0x0025: self = .inputOverVoltageEventStatistics
+        case 0x0026: self = .inputUnderCurrentEventStatistics
+        case 0x0027: self = .inputUnderVoltageEventStatistics
+        case 0x0028: self = .inputVoltageRangeSpecification
+        case 0x0029: self = .inputVoltageRippleSpecification
+        case 0x002A: self = .inputVoltageStatistics
+        case 0x002B: self = .lightControlAmbientLuxLevelOn
+        case 0x002C: self = .lightControlAmbientLuxLevelProlong
+        case 0x002D: self = .lightControlAmbientLuxLevelStandby
+        case 0x002E: self = .lightControlLightnessOn
+        case 0x002F: self = .lightControlLightnessProlong
+        case 0x0030: self = .lightControlLightnessStandby
+        case 0x0031: self = .lightControlRegulatorAccuracy
+        case 0x0032: self = .lightControlRegulatorKid
+        case 0x0033: self = .lightControlRegulatorKiu
+        case 0x0034: self = .lightControlRegulatorKpd
+        case 0x0035: self = .lightControlRegulatorKpu
+        case 0x0036: self = .lightControlTimeFade
+        case 0x0037: self = .lightControlTimeFadeOn
+        case 0x0038: self = .lightControlTimeFadeStandbyAuto
+        case 0x0039: self = .lightControlTimeFadeStandbyManual
+        case 0x003A: self = .lightControlTimeOccupancyDelay
+        case 0x003B: self = .lightControlTimeProlong
+        case 0x003C: self = .lightControlTimeRunOn
+        case 0x003D: self = .lumenMaintenanceFactor
+        case 0x003E: self = .luminousEfficacy
+        case 0x003F: self = .luminousEnergySinceTurnOn
+        case 0x0040: self = .luminousExposure
+        case 0x0041: self = .luminousFluxRange
+        case 0x0042: self = .motionSensed
+        case 0x0043: self = .motionThreshold
+        case 0x0044: self = .openCircuitEventStatistics
+        case 0x0045: self = .outdoorStatisticalValues
+        case 0x0046: self = .outputCurrentRange
+        case 0x0047: self = .outputCurrentStatistics
+        case 0x0048: self = .outputRippleVoltageSpecification
+        case 0x0049: self = .outputVoltageRange
+        case 0x004A: self = .outputVoltageStatistics
+        case 0x004B: self = .overOutputRippleVoltageEventStatistics
+        case 0x004C: self = .peopleCount
+        case 0x004D: self = .presenceDetected
+        case 0x004E: self = .presentAmbientLightLevel
+        case 0x004F: self = .presentAmbientTemperature
+        case 0x0050: self = .presentCIE1931ChromaticityCoordinates
+        case 0x0051: self = .presentCorrelatedColorTemperature
+        case 0x0052: self = .presentDeviceInputPower
+        case 0x0053: self = .presentDeviceOperatingEfficiency
+        case 0x0054: self = .presentDeviceOperatingTemperature
+        case 0x0055: self = .presentIlluminance
+        case 0x0056: self = .presentIndoorAmbientTemperature
+        case 0x0057: self = .presentInputCurrent
+        case 0x0058: self = .presentInputRippleVoltage
+        case 0x0059: self = .presentInputVoltage
+        case 0x005A: self = .presentLuminousFlux
+        case 0x005B: self = .presentOutdoorAmbientTemperature
+        case 0x005C: self = .presentOutputCurrent
+        case 0x005D: self = .presentOutputVoltage
+        case 0x005E: self = .presentPlanckianDistance
+        case 0x005F: self = .presentRelativeOutputRippleVoltage
+        case 0x0060: self = .relativeDeviceEnergyUseInAPeriodOfDay
+        case 0x0061: self = .relativeDeviceRuntimeInAGenericLevelRange
+        case 0x0062: self = .relativeExposureTimeInAnIlluminanceRange
+        case 0x0063: self = .relativeRuntimeInACorrelatedColorTemperatureRange
+        case 0x0064: self = .relativeRuntimeInADeviceOperatingTemperatureRange
+        case 0x0065: self = .relativeRuntimeInAnInputCurrentRange
+        case 0x0066: self = .relativeRuntimeInAnInputVoltageRange
+        case 0x0067: self = .shortCircuitEventStatistics
+        case 0x0068: self = .timeSinceMotionSensed
+        case 0x0069: self = .timeSincePresenceDetected
+        case 0x006A: self = .totalDeviceEnergyUse
+        case 0x006B: self = .totalDeviceOffOnCycles
+        case 0x006C: self = .totalDevicePowerOnCycles
+        case 0x006D: self = .totalDevicePowerOnTime
+        case 0x006E: self = .totalDeviceRuntime
+        case 0x006F: self = .totalLightExposureTime
+        case 0x0070: self = .totalLuminousEnergy
+        case 0x0071: self = .desiredAmbientTemperature
+        case 0x0072: self = .preciseTotalDeviceEnergyUse
+        case 0x0073: self = .powerFactor
+        case 0x0074: self = .sensorGain
+        case 0x0075: self = .precisePresentAmbientTemperature
+        case 0x0076: self = .presentAmbientRelativeHumidity
+        case 0x0077: self = .presentAmbientCarbonDioxideConcentration
+        case 0x0078: self = .presentAmbientVolatileOrganicCompoundsConcentration
+        case 0x0079: self = .presentAmbientNoise
+        case 0x0080: self = .activeEnergyLoadside
+        case 0x0081: self = .activePowerLoadside
+        case 0x0082: self = .airPressure
+        case 0x0083: self = .apparentEnergy
+        case 0x0084: self = .apparentPower
+        case 0x0085: self = .apparentWindDirection
+        case 0x0086: self = .apparentWindSpeed
+        case 0x0087: self = .dewPoint
+        case 0x0088: self = .externalSupplyVoltage
+        case 0x0089: self = .externalSupplyVoltageFrequency
+        case 0x008A: self = .gustFactor
+        case 0x008B: self = .heatIndex
+        case 0x008C: self = .lightDistribution
+        case 0x008D: self = .lightSourceCurrent
+        case 0x008E: self = .lightSourceOnTimeNotResettable
+        case 0x008F: self = .lightSourceOnTimeResettable
+        case 0x0090: self = .lightSourceOpenCircuitStatistics
+        case 0x0091: self = .lightSourceOverallFailuresStatistics
+        case 0x0092: self = .lightSourceShortCircuitStatistics
+        case 0x0093: self = .lightSourceStartCounterResettable
+        case 0x0094: self = .lightSourceTemperature
+        case 0x0095: self = .lightSourceThermalDeratingStatistics
+        case 0x0096: self = .lightSourceThermalShutdownStatistics
+        case 0x0097: self = .lightSourceTotalPowerOnCycles
+        case 0x0098: self = .lightSourceVoltage
+        case 0x0099: self = .luminaireColor
+        case 0x009A: self = .luminaireIdentificationNumber
+        case 0x009B: self = .luminaireManufacturerGTIN
+        case 0x009C: self = .luminaireNominalInputPower
+        case 0x009D: self = .luminaireNominalMaximumACMainsVoltage
+        case 0x009E: self = .luminaireNominalMinimumACMainsVoltage
+        case 0x009F: self = .luminairePowerAtMinimumDimLevel
+        case 0x00A0: self = .luminaireTimeOfManufacture
+        case 0x00A1: self = .magneticDeclination
+        case 0x00A2: self = .magneticFluxDensity2D
+        case 0x00A3: self = .magneticFluxDensity3D
+        case 0x00A4: self = .nominalLightOutput
+        case 0x00A5: self = .overallFailureCondition
+        case 0x00A6: self = .pollenConcentration
+        case 0x00A7: self = .presentIndoorRelativeHumidity
+        case 0x00A8: self = .presentOutdoorRelativeHumidity
+        case 0x00A9: self = .pressure
+        case 0x00AA: self = .rainfall
+        case 0x00AB: self = .ratedMedianUsefulLifeOfLuminaire
+        case 0x00AC: self = .ratedMedianUsefulLightSourceStarts
+        case 0x00AD: self = .referenceTemperature
+        case 0x00AE: self = .totalDeviceStarts
+        case 0x00AF: self = .trueWindDirection
+        case 0x00B0: self = .trueWindSpeed
+        case 0x00B1: self = .uVIndex
+        case 0x00B2: self = .windChill
+        case 0x00B3: self = .lightSourceType
+        case 0x00B4: self = .luminaireIdentificationString
+        case 0x00B5: self = .outputPowerLimitation
+        case 0x00B6: self = .thermalDerating
+        case 0x00B7: self = .outputCurrentPercent
+        default:     self = .unknown(id)
+        }
+    }
+    
+    /// The Property ID.
+    public var id: UInt16 {
+        switch self {
+        case .averageAmbientTemperatureInAPeriodOfDay: return 0x0001
+        case .averageInputCurrent: return 0x0002
+        case .averageInputVoltage: return 0x0003
+        case .averageOutputCurrent: return 0x0004
+        case .averageOutputVoltage: return 0x0005
+        case .centerBeamIntensityAtFullPower: return 0x0006
+        case .chromaticityTolerance: return 0x0007
+        case .colorRenderingIndexR9: return 0x0008
+        case .colorRenderingIndexRa: return 0x0009
+        case .deviceAppearance: return 0x000A
+        case .deviceCountryOfOrigin: return 0x000B
+        case .deviceDateOfManufacture: return 0x000C
+        case .deviceEnergyUseSinceTurnOn: return 0x000D
+        case .deviceFirmwareRevision: return 0x000E
+        case .deviceGlobalTradeItemNumber: return 0x000F
+        case .deviceHardwareRevision: return 0x0010
+        case .deviceManufacturerName: return 0x0011
+        case .deviceModelNumber: return 0x0012
+        case .deviceOperatingTemperatureRangeSpecification: return 0x0013
+        case .deviceOperatingTemperatureStatisticalValues: return 0x0014
+        case .deviceOverTemperatureEventStatistics: return 0x0015
+        case .devicePowerRangeSpecification: return 0x0016
+        case .deviceRuntimeSinceTurnOn: return 0x0017
+        case .deviceRuntimeWarranty: return 0x0018
+        case .deviceSerialNumber: return 0x0019
+        case .deviceSoftwareRevision: return 0x001A
+        case .deviceUnderTemperatureEventStatistics: return 0x001B
+        case .indoorAmbientTemperatureStatisticalValues: return 0x001C
+        case .initialCIE1931ChromaticityCoordinates: return 0x001D
+        case .initialCorrelatedColorTemperature: return 0x001E
+        case .initialLuminousFlux: return 0x001F
+        case .initialPlanckianDistance: return 0x0020
+        case .inputCurrentRangeSpecification: return 0x0021
+        case .inputCurrentStatistics: return 0x0022
+        case .inputOverCurrentEventStatistics: return 0x0023
+        case .inputOverRippleVoltageEventStatistics: return 0x0024
+        case .inputOverVoltageEventStatistics: return 0x0025
+        case .inputUnderCurrentEventStatistics: return 0x0026
+        case .inputUnderVoltageEventStatistics: return 0x0027
+        case .inputVoltageRangeSpecification: return 0x0028
+        case .inputVoltageRippleSpecification: return 0x0029
+        case .inputVoltageStatistics: return 0x002A
+        case .lightControlAmbientLuxLevelOn: return 0x002B
+        case .lightControlAmbientLuxLevelProlong: return 0x002C
+        case .lightControlAmbientLuxLevelStandby: return 0x002D
+        case .lightControlLightnessOn: return 0x002E
+        case .lightControlLightnessProlong: return 0x002F
+        case .lightControlLightnessStandby: return 0x0030
+        case .lightControlRegulatorAccuracy: return 0x0031
+        case .lightControlRegulatorKid: return 0x0032
+        case .lightControlRegulatorKiu: return 0x0033
+        case .lightControlRegulatorKpd: return 0x0034
+        case .lightControlRegulatorKpu: return 0x0035
+        case .lightControlTimeFade: return 0x0036
+        case .lightControlTimeFadeOn: return 0x0037
+        case .lightControlTimeFadeStandbyAuto: return 0x0038
+        case .lightControlTimeFadeStandbyManual: return 0x0039
+        case .lightControlTimeOccupancyDelay: return 0x003A
+        case .lightControlTimeProlong: return 0x003B
+        case .lightControlTimeRunOn: return 0x003C
+        case .lumenMaintenanceFactor: return 0x003D
+        case .luminousEfficacy: return 0x003E
+        case .luminousEnergySinceTurnOn: return 0x003F
+        case .luminousExposure: return 0x0040
+        case .luminousFluxRange: return 0x0041
+        case .motionSensed: return 0x0042
+        case .motionThreshold: return 0x0043
+        case .openCircuitEventStatistics: return 0x0044
+        case .outdoorStatisticalValues: return 0x0045
+        case .outputCurrentRange: return 0x0046
+        case .outputCurrentStatistics: return 0x0047
+        case .outputRippleVoltageSpecification: return 0x0048
+        case .outputVoltageRange: return 0x0049
+        case .outputVoltageStatistics: return 0x004A
+        case .overOutputRippleVoltageEventStatistics: return 0x004B
+        case .peopleCount: return 0x004C
+        case .presenceDetected: return 0x004D
+        case .presentAmbientLightLevel: return 0x004E
+        case .presentAmbientTemperature: return 0x004F
+        case .presentCIE1931ChromaticityCoordinates: return 0x0050
+        case .presentCorrelatedColorTemperature: return 0x0051
+        case .presentDeviceInputPower: return 0x0052
+        case .presentDeviceOperatingEfficiency: return 0x0053
+        case .presentDeviceOperatingTemperature: return 0x0054
+        case .presentIlluminance: return 0x0055
+        case .presentIndoorAmbientTemperature: return 0x0056
+        case .presentInputCurrent: return 0x0057
+        case .presentInputRippleVoltage: return 0x0058
+        case .presentInputVoltage: return 0x0059
+        case .presentLuminousFlux: return 0x005A
+        case .presentOutdoorAmbientTemperature: return 0x005B
+        case .presentOutputCurrent: return 0x005C
+        case .presentOutputVoltage: return 0x005D
+        case .presentPlanckianDistance: return 0x005E
+        case .presentRelativeOutputRippleVoltage: return 0x005F
+        case .relativeDeviceEnergyUseInAPeriodOfDay: return 0x0060
+        case .relativeDeviceRuntimeInAGenericLevelRange: return 0x0061
+        case .relativeExposureTimeInAnIlluminanceRange: return 0x0062
+        case .relativeRuntimeInACorrelatedColorTemperatureRange: return 0x0063
+        case .relativeRuntimeInADeviceOperatingTemperatureRange: return 0x0064
+        case .relativeRuntimeInAnInputCurrentRange: return 0x0065
+        case .relativeRuntimeInAnInputVoltageRange: return 0x0066
+        case .shortCircuitEventStatistics: return 0x0067
+        case .timeSinceMotionSensed: return 0x0068
+        case .timeSincePresenceDetected: return 0x0069
+        case .totalDeviceEnergyUse: return 0x006A
+        case .totalDeviceOffOnCycles: return 0x006B
+        case .totalDevicePowerOnCycles: return 0x006C
+        case .totalDevicePowerOnTime: return 0x006D
+        case .totalDeviceRuntime: return 0x006E
+        case .totalLightExposureTime: return 0x006F
+        case .totalLuminousEnergy: return 0x0070
+        case .desiredAmbientTemperature: return 0x0071
+        case .preciseTotalDeviceEnergyUse: return 0x0072
+        case .powerFactor: return 0x0073
+        case .sensorGain: return 0x0074
+        case .precisePresentAmbientTemperature: return 0x0075
+        case .presentAmbientRelativeHumidity: return 0x0076
+        case .presentAmbientCarbonDioxideConcentration: return 0x0077
+        case .presentAmbientVolatileOrganicCompoundsConcentration: return 0x0078
+        case .presentAmbientNoise: return 0x0079
+     // case these are undefined in Mesh Device Properties v2 = 0x007A
+     // case these are undefined in Mesh Device Properties v2 = 0x007B
+     // case these are undefined in Mesh Device Properties v2 = 0x007C
+     // case these are undefined in Mesh Device Properties v2 = 0x007D
+     // case these are undefined in Mesh Device Properties v2 = 0x007E
+     // case these are undefined in Mesh Device Properties v2 = 0x007F
+        case .activeEnergyLoadside: return 0x0080
+        case .activePowerLoadside: return 0x0081
+        case .airPressure: return 0x0082
+        case .apparentEnergy: return 0x0083
+        case .apparentPower: return 0x0084
+        case .apparentWindDirection: return 0x0085
+        case .apparentWindSpeed: return 0x0086
+        case .dewPoint: return 0x0087
+        case .externalSupplyVoltage: return 0x0088
+        case .externalSupplyVoltageFrequency: return 0x0089
+        case .gustFactor: return 0x008A
+        case .heatIndex: return 0x008B
+        case .lightDistribution: return 0x008C
+        case .lightSourceCurrent: return 0x008D
+        case .lightSourceOnTimeNotResettable: return 0x008E
+        case .lightSourceOnTimeResettable: return 0x008F
+        case .lightSourceOpenCircuitStatistics: return 0x0090
+        case .lightSourceOverallFailuresStatistics: return 0x0091
+        case .lightSourceShortCircuitStatistics: return 0x0092
+        case .lightSourceStartCounterResettable: return 0x0093
+        case .lightSourceTemperature: return 0x0094
+        case .lightSourceThermalDeratingStatistics: return 0x0095
+        case .lightSourceThermalShutdownStatistics: return 0x0096
+        case .lightSourceTotalPowerOnCycles: return 0x0097
+        case .lightSourceVoltage: return 0x0098
+        case .luminaireColor: return 0x0099
+        case .luminaireIdentificationNumber: return 0x009A
+        case .luminaireManufacturerGTIN: return 0x009B
+        case .luminaireNominalInputPower: return 0x009C
+        case .luminaireNominalMaximumACMainsVoltage: return 0x009D
+        case .luminaireNominalMinimumACMainsVoltage: return 0x009E
+        case .luminairePowerAtMinimumDimLevel: return 0x009F
+        case .luminaireTimeOfManufacture: return 0x00A0
+        case .magneticDeclination: return 0x00A1
+        case .magneticFluxDensity2D: return 0x00A2
+        case .magneticFluxDensity3D: return 0x00A3
+        case .nominalLightOutput: return 0x00A4
+        case .overallFailureCondition: return 0x00A5
+        case .pollenConcentration: return 0x00A6
+        case .presentIndoorRelativeHumidity: return 0x00A7
+        case .presentOutdoorRelativeHumidity: return 0x00A8
+        case .pressure: return 0x00A9
+        case .rainfall: return 0x00AA
+        case .ratedMedianUsefulLifeOfLuminaire: return 0x00AB
+        case .ratedMedianUsefulLightSourceStarts: return 0x00AC
+        case .referenceTemperature: return 0x00AD
+        case .totalDeviceStarts: return 0x00AE
+        case .trueWindDirection: return 0x00AF
+        case .trueWindSpeed: return 0x00B0
+        case .uVIndex: return 0x00B1
+        case .windChill: return 0x00B2
+        case .lightSourceType: return 0x00B3
+        case .luminaireIdentificationString: return 0x00B4
+        case .outputPowerLimitation: return 0x00B5
+        case .thermalDerating: return 0x00B6
+        case .outputCurrentPercent: return 0x00B7
+        case .unknown(let id): return id
+        }
+    }
 }
 
 internal extension DeviceProperty {
@@ -253,6 +620,8 @@ internal extension DeviceProperty {
              .presentAmbientRelativeHumidity,
              .presentIndoorRelativeHumidity,
              .presentOutdoorRelativeHumidity,
+             .presentDeviceOperatingTemperature,
+             .precisePresentAmbientTemperature,
              .timeSinceMotionSensed,
              .timeSincePresenceDetected:
             return 2
@@ -316,17 +685,22 @@ internal extension DeviceProperty {
     
     /// Parses the characteristic from given data.
     ///
+    /// If the given length is 0, the returned characterisitc will be returned with default
+    /// value (false, 0, etc.).
+    ///
     /// - important: This method does not ensure that the length of data is sufficient.
     ///
     /// - parameters:
     ///   - data:   The data to be read from.
     ///   - offset: The offset.
-    ///   - length: Expected length of the data.
+    ///   - length: Expected length of the data. If 0, the characteristic will be returned
+    ///             with default value.
     /// - returns: The characteristic value.
     func read(from data: Data, at offset: Int, length: Int) -> DevicePropertyCharacteristic {
         switch self {
         // Bool:
         case .presenceDetected:
+            guard length == valueLength else { return .bool(false) }
             return .bool(data[offset] != 0x00)
         
         // UInt8:
@@ -340,6 +714,7 @@ internal extension DeviceProperty {
              .presentDeviceOperatingEfficiency,
              .presentRelativeOutputRippleVoltage,
              .presentInputRippleVoltage:
+            guard length == valueLength else { return .percentage8(0) }
             return .percentage8(data[offset])
             
         // Int8:
@@ -347,22 +722,33 @@ internal extension DeviceProperty {
              .presentAmbientTemperature,
              .presentIndoorAmbientTemperature,
              .presentOutdoorAmbientTemperature:
+            guard length == valueLength else { return .temperature8(0) }
             return .temperature8(Int8(bitPattern: data[offset]))
             
         // UInt16:
         case .peopleCount:
+            guard length == valueLength else { return .count16(0) }
             return .count16(data.read(fromOffset: offset))
         case .presentAmbientRelativeHumidity,
              .presentIndoorRelativeHumidity,
              .presentOutdoorRelativeHumidity:
+            guard length == valueLength else { return .humidity(0) }
             return .humidity(data.read(fromOffset: offset))
         case .lightControlLightnessOn,
              .lightControlLightnessProlong,
              .lightControlLightnessStandby:
+            guard length == valueLength else { return .perceivedLightness(0) }
             return .perceivedLightness(data.read(fromOffset: offset))
         case .timeSinceMotionSensed,
              .timeSincePresenceDetected:
+            guard length == valueLength else { return .timeSecond16(0) }
             return .timeSecond16(data.read(fromOffset: offset))
+            
+        // Int16:
+        case .precisePresentAmbientTemperature,
+             .presentDeviceOperatingTemperature:
+            guard length == valueLength else { return .temperature(0) }
+            return .temperature(data.read(fromOffset: offset))
             
         // UInt24:
         case .lightSourceStartCounterResettable,
@@ -371,12 +757,14 @@ internal extension DeviceProperty {
              .totalDeviceOffOnCycles,
              .totalDevicePowerOnCycles,
              .totalDeviceStarts:
+            guard length == valueLength else { return .count24(0) }
             return .count24(data.readUInt24(fromOffset: offset))
         case .lightControlAmbientLuxLevelOn,
              .lightControlAmbientLuxLevelProlong,
              .lightControlAmbientLuxLevelStandby,
              .presentAmbientLightLevel,
              .presentIlluminance:
+            guard length == valueLength else { return .illuminance(0) }
             return .illuminance(data.readUInt24(fromOffset: offset))
         case .deviceRuntimeSinceTurnOn,
              .deviceRuntimeWarranty,
@@ -384,6 +772,7 @@ internal extension DeviceProperty {
              .totalDevicePowerOnTime,
              .totalDeviceRuntime,
              .totalLightExposureTime:
+            guard length == valueLength else { return .timeHour24(0) }
             return .timeHour24(data.readUInt24(fromOffset: offset))
         case .lightControlTimeFade,
              .lightControlTimeFadeOn,
@@ -392,9 +781,11 @@ internal extension DeviceProperty {
              .lightControlTimeOccupancyDelay,
              .lightControlTimeProlong,
              .lightControlTimeRunOn:
+            guard length == valueLength else { return .timeMillisecond24(0) }
             return .timeMillisecond24(data.readUInt24(fromOffset: offset))
         case .deviceDateOfManufacture,
              .luminaireTimeOfManufacture:
+            guard length == valueLength else { return .dateUTC(Date(timeIntervalSince1970: 0)) }
             let numberOfDays = data.readUInt24(fromOffset: offset)
             let timeInterval = TimeInterval(numberOfDays) * 86400.0
             return .dateUTC(Date(timeIntervalSince1970: timeInterval))
@@ -402,6 +793,7 @@ internal extension DeviceProperty {
         // UInt32:
         case .pressure,
              .airPressure:
+            guard length == valueLength else { return .pressure(0) }
             return .pressure(data.read(fromOffset: offset))
             
         // Float32 (IEEE 754):
@@ -410,23 +802,29 @@ internal extension DeviceProperty {
              .lightControlRegulatorKpd,
              .lightControlRegulatorKpu,
              .sensorGain:
+            guard length == valueLength else { return .coefficient(0.0) }
             let asInt32: UInt32 = data.read(fromOffset: offset)
             return .coefficient(Float(bitPattern: asInt32))
             
         // String:
         case .deviceFirmwareRevision,
              .deviceSoftwareRevision:
+            guard length == valueLength else { return .fixedString8(String(repeating: " ", count: 8)) }
             return .fixedString8(String(data: data.subdata(in: offset..<offset + 8), encoding: .utf8)!)
         case .deviceHardwareRevision,
              .deviceSerialNumber:
+            guard length == valueLength else { return .fixedString16(String(repeating: " ", count: 16)) }
             return .fixedString16(String(data: data.subdata(in: offset..<offset + 16), encoding: .utf8)!)
         case .deviceModelNumber,
              .luminaireColor,
              .luminaireIdentificationNumber:
+            guard length == valueLength else { return .fixedString24(String(repeating: " ", count: 24)) }
             return .fixedString24(String(data: data.subdata(in: offset..<offset + 24), encoding: .utf8)!)
         case .deviceManufacturerName:
+            guard length == valueLength else { return .fixedString36(String(repeating: " ", count: 36)) }
             return .fixedString36(String(data: data.subdata(in: offset..<offset + 36), encoding: .utf8)!)
         case .luminaireIdentificationString:
+            guard length == valueLength else { return .fixedString64(String(repeating: " ", count: 64)) }
             return .fixedString64(String(data: data.subdata(in: offset..<offset + 64), encoding: .utf8)!)
             
         // Other:
@@ -488,6 +886,13 @@ public enum DevicePropertyCharacteristic {
     ///
     /// Unit is in pascals with a resolution of 0.1 Pa.
     case pressure(UInt32)
+    /// The Temperature characteristic is used to represent a temperature is degrees
+    /// Celsius with a resolution of 0.01 degrees Celsius.
+    ///
+    /// Allowed range is: -273.15 to 327.67.
+    ///
+    /// A value of 0x8000 represents ‘value is not known’.
+    case temperature(Int16)
     /// The Temperature 8 characteristic is used to represent a measure of
     /// temperature with a unit of 0.5 degree Celsius.
     ///
@@ -539,6 +944,10 @@ internal extension DevicePropertyCharacteristic {
              .humidity(let value),
              .timeSecond16(let value),
              .perceivedLightness(let value):
+            return Data() + value
+            
+        // Int16:
+        case .temperature(let value):
             return Data() + value
             
         // UInt24:
@@ -625,6 +1034,15 @@ extension DevicePropertyCharacteristic: CustomDebugStringConvertible {
                 return "Value is not known"
             default:
                 return "\(count) seconds"
+            }
+            
+        // Int16:
+        case .temperature(let temp):
+            switch temp {
+            case Int16.min:
+                return "Value is not known"
+            default:
+                return String(format: "%.2f°C", Float(temp) / 100.0)
             }
             
         // UInt24:
@@ -884,6 +1302,7 @@ extension DeviceProperty: CustomDebugStringConvertible {
         case .outputPowerLimitation: return "Output Power Limitation"
         case .thermalDerating: return "Thermal Derating"
         case .outputCurrentPercent: return "Output Current Percent"
+        case .unknown(let id): return "Unknown (Property ID: \(id))"
         }
     }
     

--- a/nRFMeshProvision/Classes/Mesh Messages/SensorMessage.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/SensorMessage.swift
@@ -51,7 +51,7 @@ public extension Array where Element == SensorMessage.Type {
 }
 
 public protocol SensorPropertyMessage: SensorMessage {
-    /// Property ID for the sensor.
+    /// Property for the sensor.
     var property: DeviceProperty { get }
 }
 

--- a/nRFMeshProvision/Classes/Mesh Messages/SensorMessage.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/SensorMessage.swift
@@ -1,0 +1,453 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public protocol SensorMessage: StaticMeshMessage {
+    // No additional fields.
+}
+
+public protocol AcknowledgedSensorMessage: SensorMessage, StaticAcknowledgedMeshMessage {
+    // No additional fields.
+}
+
+public extension Array where Element == SensorMessage.Type {
+    
+    /// A helper method that can create a map of message types required
+    /// by the `ModelDelegate` from a list of `SensorMessage`s.
+    ///
+    /// - returns: A map of message types.
+    func toMap() -> [UInt32 : MeshMessage.Type] {
+        return (self as [StaticMeshMessage.Type]).toMap()
+    }
+    
+}
+
+public protocol SensorPropertyMessage: SensorMessage {
+    /// Property ID for the sensor.
+    var property: DeviceProperty { get }
+}
+
+public protocol AcknowledgedSensorPropertyMessage: SensorPropertyMessage, StaticAcknowledgedMeshMessage {
+    // No additional fields.
+}
+
+/// The Sensor Descriptor state represents the attributes describing the
+/// sensor data. This state does not change throughout the lifetime of an
+/// Element.
+public struct SensorDescriptor {
+    /// The Sensor Property describes the meaning and the format of data
+    /// reported by a sensor.
+    public let property: DeviceProperty
+    /// The Sensor Positive Tolerance field is a 12-bit value representing
+    /// the magnitude of a possible positive error associated with the
+    /// measurements that the sensor is reporting.
+    ///
+    /// The error can be calculated using the following formula:
+    /// ```
+    /// possible error [%] = 100[%] * tolerance / 4095
+    /// ```
+    ///
+    /// A tolerance of 0 should be interpreted as “unspecified”.
+    public let positiveTolerance: UInt16
+    /// The Sensor Negative Tolerance field is a 12-bit value representing
+    /// the magnitude of a possible negative error associated with the
+    /// measurements that the sensor is reporting.
+    ///
+    /// The error can be calculated using the following formula:
+    /// ```
+    /// possible error [%] = 100[%] * tolerance / 4095
+    /// ```
+    ///
+    /// A tolerance of 0 should be interpreted as “unspecified”.
+    public let negativeTolerance: UInt16
+    /// This Sensor Sampling Function field specifies the averaging
+    /// operation or type of sampling function applied to the measured value.
+    public let samplingFunction: SensorSamplingFunction
+    /// This Sensor Measurement Period field specifies a UInt8 value n
+    /// that represents the averaging time span, accumulation time, or
+    /// measurement period in seconds over which the measurement is taken.
+    ///
+    /// The period is calculated using formula:
+    /// ```
+    /// represented value = 1.1^(n-64)
+    /// ```
+    /// For those cases where a value for the measurement period is not
+    /// available or is not applicable, a special number has been assigned
+    /// to indicate Not Applicable equal to 0.
+    /// - seeAlso: `measurementPeriod`
+    internal let measurementPeriodValue: UInt8
+    /// The measurement reported by a sensor is internally refreshed at
+    /// the frequency indicated in the Sensor Update Interval field
+    /// (e.g., a temperature value that is internally updated every 15 minutes).
+    ///
+    /// This field specifies a UInt8 value n that determines the interval
+    /// (in seconds) between updates, using the formula:
+    /// ```
+    /// represented value = 1.1^(n-64)
+    /// ```
+    /// For those cases where a value for the Sensor Update Interval is
+    /// not available or is not applicable, a special number has been assigned
+    /// to indicate Not Applicable equal to 0.
+    /// - seeAlso: `updateInteval
+    internal let updateIntervalValue: UInt8
+    
+    /// Whether the positive tolerance is specified.
+    public var isPositiveToleranceSpecified: Bool {
+        return positiveTolerance > 0
+    }
+    /// Whether the negatove tolerance is specified.
+    public var isNegativeToleranceSpecified: Bool {
+        return negativeTolerance > 0
+    }
+    /// The measurement period in seconds, or `nil`, if measurement period is
+    /// not available or is not applicable.
+    ///
+    /// For example, the measurement period can specify the length of the
+    /// period used to obtain an average reading.
+    public var measurementPeriod: TimeInterval? {
+        if measurementPeriodValue == 0 {
+            return nil
+        }
+        return pow(1.1, Double(measurementPeriodValue) - 64.0)
+    }
+    /// The update interval in seconds, or `nil`, if update interval is
+    /// not available or is not applicable.
+    public var updateInteval: TimeInterval? {
+        if updateIntervalValue == 0 {
+            return nil
+        }
+        return pow(1.1, Double(updateIntervalValue) - 64.0)
+    }
+    
+    /// Descriptor as Data.
+    internal var data: Data {
+        // Encode two 12-bit tolerance values in 2 bytes.
+        let tolerances: UInt32 = UInt32(negativeTolerance) << 12 | UInt32(positiveTolerance)
+        
+        var data = Data() + property.rawValue
+        data += (Data() + tolerances.littleEndian).dropLast()
+        data += samplingFunction.rawValue
+        data += measurementPeriodValue
+        data += updateIntervalValue
+        return data
+    }
+    
+    /// Creates Sensor Descriptor object.
+    ///
+    /// - parameters:
+    ///   - property: The device property that describes the meaning and
+    ///               the format of data reported by a sensor.
+    ///   - positiveTolerance: The magnitude of a possible positive error
+    ///                        associated with the measurements that the
+    ///                        sensor is reporting.
+    ///                        A tolerance of 0 should be interpreted as
+    ///                        “unspecified”.
+    ///   - negativeTolerance: The magnitude of a possible negative error
+    ///                        associated with the measurements that the
+    ///                        sensor is reporting.
+    ///                        A tolerance of 0 should be interpreted as
+    ///                        “unspecified”.
+    ///   - samplingFunction:  The averaging operation or type of sampling
+    ///                        function applied to the measured value.
+    ///   - measurementPeriod: The averaging time span, accumulation
+    ///                        time, or measurement period in seconds over
+    ///                        which the measurement is taken.
+    ///                        Represented value is equal to `1.1^(n-64)`.
+    ///                        Value 0 indicates that the period is not
+    ///                        available or is not applicable.
+    ///   - updateInterval:    The interval of internal refreshing.
+    ///                        Represented value is equal to `1.1^(n-64)`.
+    ///                        Value 0 indicates that the interval is not
+    ///                        available or is not applicable.
+    public init(_ property: DeviceProperty,
+         positiveTolerance: UInt16,
+         negativeTolerance: UInt16,
+         samplingFunction: SensorSamplingFunction,
+         measurementPeriod: UInt8,
+         updateInterval: UInt8) {
+        self.property = property
+        self.positiveTolerance = positiveTolerance
+        self.negativeTolerance = negativeTolerance
+        self.samplingFunction = samplingFunction
+        self.measurementPeriodValue = measurementPeriod
+        self.updateIntervalValue = updateInterval
+    }
+    
+    internal init?(from parameters: Data, at offset: Int) {
+        guard parameters.count >= offset + 8 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: offset)
+        guard let property = DeviceProperty(rawValue: propertyId) else {
+            return nil
+        }
+        self.property = property
+        // Decode two 12-bit tolerace values from 2 bytes.
+        self.positiveTolerance = UInt16(parameters[offset + 3] & 0x0F) << 8 | UInt16(parameters[offset + 2])
+        self.negativeTolerance = UInt16(parameters[offset + 4]) << 4 | UInt16(parameters[offset + 3] >> 4)
+        guard let function = SensorSamplingFunction(rawValue: parameters[offset + 5]) else {
+            return nil
+        }
+        self.samplingFunction = function
+        self.measurementPeriodValue = parameters[offset + 6]
+        self.updateIntervalValue = parameters[offset + 7]
+    }
+}
+
+public enum SensorSamplingFunction: UInt8 {
+    /// Sampling function is not made available.
+    case unspecified    = 0x00
+    /// The presented value is an instantaneous sample.
+    case instantaneous  = 0x01
+    /// The presented value is the arithmetic mean of multiple samples.
+    case arithmeticMean = 0x02
+    /// The presented value is the root mean square of multiple samples.
+    case rms            = 0x03
+    /// The presented value is the maximum of multiple samples.
+    case maximum        = 0x04
+    /// The presented value is the minimum of multiple samples.
+    case minimum        = 0x05
+    /// The Accumulated sampling function is intended to represent a
+    /// cumulative moving average.
+    ///
+    /// The Sensor Measurement Period in this case would state the length
+    /// of the period over which a counted number of lightning strikes was
+    /// detected.
+    case accumulated    = 0x06
+    /// The Count sampling function can be used for a discrete variable
+    /// such as the number of lightning discharges detected by a lightning
+    /// detector.
+    ///
+    /// The measurement value would be a cumulative moving average value
+    /// that was continually updated with a frequency indicated by the
+    /// Sensor Update Interval.
+    case count          = 0x07
+}
+
+public struct SensorCadence {
+    
+    /// The Status Trigger Delta controls the positive and negative
+    /// change of a measured quantity that triggers more rapid publication of
+    /// a Sensor Status message.
+    ///
+    /// Depending on the Sensor Trigger Type value, the
+    public enum StatusTriggerDelta {
+        /// The delta type and unit is defined by the Format Type of the characteristic
+        /// of the Sensor Property.
+        case values(down: DevicePropertyCharacteristic, up: DevicePropertyCharacteristic)
+        /// The unit is «unitless», and the value is represented as a percentage
+        /// change with a resolution of 0.01 percent.
+        case percentage(down: UInt16, up: UInt16)
+        
+        internal var data: Data {
+            switch self {
+            case let .values(down: deltaDown, up: deltaUp):
+                return deltaDown.data + deltaUp.data
+            case let .percentage(down: down, up: up):
+                return Data() + down + up
+            }
+        }
+    }
+    
+    /// The Fast Cadence Period Divisor field is a 7-bit value that shall
+    /// control the increased cadence of publishing Sensor Status messages.
+    /// The value is represented as a 2^n divisor of the Publish Period.
+    /// For example, the value 0x04 would have a divisor of 16, and the value 0x00
+    /// would have a divisor of 1 (i.e., the Publish Period would not change).
+    ///
+    /// The valid range for the Fast Cadence Period Divisor state is 0..15
+    /// and other values are Prohibited.
+    public let fastCadencePeriodDivisor: UInt8
+    /// Defines the unit and format of the Status Trigger Delta fields.
+    ///
+    /// The value of 0x00 means that the format shall be defined by the Format Type
+    /// of the characteristic that the Sensor Property ID state references.
+    /// The value of 0x01 means that the unit is «unitless», and the value is
+    /// represented as a percentage change with a resolution of 0.01 percent.
+    internal let statusTriggerType: UInt8
+    /// The Status Trigger Delta field shall control the positive and negative
+    /// change of a measured quantity that triggers more rapid publication of
+    /// a Sensor Status message.
+    ///
+    /// A value represented by the Fast Cadence Period Divisor state is used as
+    /// a divider for the Publish Period (configured for the model) if the change
+    /// exceeds the conditions determined by delta.
+    public let statusTriggerDelta: StatusTriggerDelta
+    /// The Status Min Interval field is a 1-octet value that shall control
+    /// the minimum interval between publishing two consecutive Sensor Status
+    /// messages.
+    ///
+    /// The value is represented as 2^n milliseconds. For example, the value
+    /// 0x0A would represent an interval of 1024 ms.
+    ///
+    /// The valid range for the Status Min Interval is 0–26 and other values
+    /// are Prohibited.
+    public let statusMinIntervalValue: UInt8
+    /// The Fast Cadence Low field shall define the lower boundary of a range
+    /// of measured quantities when the publishing cadence is increased as
+    /// defined by the Fast Cadence Period Divisor field.
+    public let fastCadenceLow: DevicePropertyCharacteristic
+    /// The Fast Cadence High field shall define the upper boundary of a range
+    /// of measured quantities when the publishing cadence is increased as
+    /// defined by the Fast Cadence Period Divisor field.
+    public let fastCadenceHigh: DevicePropertyCharacteristic
+    
+    /// The Status Min Interval field controls the minimum interval between
+    /// publishing two consecutive Sensor Status messages.
+    public var statusMinInterval: TimeInterval {
+        return pow(2.0, Double(statusMinIntervalValue)) / 1000.0
+    }
+    
+    /// Creates Sensor Cadence object.
+    ///
+    /// - parameters:
+    ///   - divider: Publish period divider.
+    ///   - low: Low threshold value of characteristic to initiate publishing
+    ///          with publish period divider.
+    ///   - high: High threshold value of characteristic to initiate publishing
+    ///           with publish period divider.
+    ///   - deltaDown: Smallest delta down to initiate fast publishing.
+    ///   - deltaUp:   Smallest delta up to initiate fast publishing.
+    ///   - minInterval: Minimum interval between publications, in `2^n`
+    ///                  milliseconds. Valid range is 0..26.
+    public init(increasePublishingFrequencyWithPeriodDivider divider: UInt8,
+                whenValueIsAbove low: DevicePropertyCharacteristic,
+                andBelow high: DevicePropertyCharacteristic,
+                orChangesDownByMoreThan deltaDown: DevicePropertyCharacteristic,
+                orUpBy deltaUp: DevicePropertyCharacteristic,
+                withMinIntervalExponent minInterval: UInt8) {
+        self.fastCadencePeriodDivisor = divider
+        self.fastCadenceLow = low
+        self.fastCadenceHigh = high
+        self.statusMinIntervalValue = min(minInterval, 26)
+        self.statusTriggerType = 0x00
+        self.statusTriggerDelta = .values(down: deltaDown, up: deltaUp)
+    }
+    
+    /// Creates Sensor Cadence object.
+    ///
+    /// - parameters:
+    ///   - divider: Publish period divider.
+    ///   - low: Low threshold value of characteristic to initiate publishing
+    ///          with publish period divider.
+    ///   - high: High threshold value of characteristic to initiate publishing
+    ///           with publish period divider.
+    ///   - deltaDown: Smallest delta down to initiate fast publishing,
+    ///                in 0.01 percent.
+    ///   - deltaUp:   Smallest delta up to initiate fast publishing,
+    ///                in 0.01 percent.
+    ///   - minInterval: Minimum interval between publications, in `2^n`
+    ///                  milliseconds. Valid range is 0..26.
+    public init(increasePublishingFrequencyWithPeriodDivider divider: UInt8,
+                whenValueIsAbove low: DevicePropertyCharacteristic,
+                andBelow high: DevicePropertyCharacteristic,
+                orChangesDownByMoreThan deltaDown: UInt16, millipercentOrUpBy deltaUp: UInt16,
+                millipercentWithMinIntervalExponent minInterval: UInt8) {
+        self.fastCadencePeriodDivisor = divider
+        self.fastCadenceLow = low
+        self.fastCadenceHigh = high
+        self.statusMinIntervalValue = min(minInterval, 26)
+        self.statusTriggerType = 0x01
+        self.statusTriggerDelta = .percentage(down: deltaDown, up: deltaUp)
+    }
+    
+    internal init?(of property: DeviceProperty, from parameters: Data, at offset: Int) {
+        // At least 6 bytes are needed if the Characteristic Value is just 1 byte.
+        guard parameters.count + offset >= 6 else {
+            return nil
+        }
+        self.fastCadencePeriodDivisor = parameters[offset] >> 1
+        var len = 1
+        let statusTriggerType = parameters[offset] & 0x01
+        self.statusTriggerType = statusTriggerType
+        if statusTriggerType == 0x00 {
+            // Fast Cadence Period Divider and Status Min Interval are 1 byte each.
+            // Status Trigger Delta Down, Up and Fast Cadence Low and High have the same length.
+            guard (parameters.count - offset - 1 - 1) & 0b11 == 0b00 else {
+                return nil
+            }
+            len = (parameters.count - offset - 1 - 1) / 4
+            guard property.valueLength == nil || property.valueLength == len else {
+                return nil
+            }
+            self.statusTriggerDelta = .values(
+                down: property.read(from: parameters, at: offset + 1, length: len),
+                up: property.read(from: parameters, at: offset + 1 + len, length: len)
+            )
+            self.statusMinIntervalValue = parameters[offset + 1 + 2 * len]
+            self.fastCadenceLow = property.read(from: parameters, at: offset + 1 + 2 * len + 1, length: len)
+            self.fastCadenceHigh = property.read(from: parameters, at: offset + 1 + 3 * len + 1, length: len)
+        } else {
+            // Fast Cadence Period Divider and Status Min Interval are 1 byte each.
+            // Status Trigger Delta Down and Up are UInt16.
+            // Fast Cadence Low and High have the same length.
+            guard (parameters.count - offset - 1 - 1 - 2 - 2) & 0b1 == 0b0 else {
+                return nil
+            }
+            len = (parameters.count - offset - 1 - 1 - 2 - 2) / 2
+            guard property.valueLength == nil || property.valueLength == len else {
+                return nil
+            }
+            self.statusTriggerDelta = .percentage(
+                down: parameters.read(fromOffset: offset + 1),
+                up: parameters.read(fromOffset: offset + 3)
+            )
+            self.statusMinIntervalValue = parameters[offset + 5]
+            self.fastCadenceLow = property.read(from: parameters, at: offset + 6, length: len)
+            self.fastCadenceHigh = property.read(from: parameters, at: offset + 6 + len, length: len)
+        }
+    }
+    
+    /// The sensor cadence object encoded as Data.
+    internal var data: Data {
+        var data = Data([(fastCadencePeriodDivisor << 1) | statusTriggerType])
+        data += statusTriggerDelta.data + statusMinInterval
+        data += fastCadenceLow.data + fastCadenceHigh.data
+        return data
+    }
+}
+
+extension SensorSamplingFunction: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        switch self {
+        case .unspecified:    return "Unspecified"
+        case .instantaneous:  return "Instantaneous"
+        case .arithmeticMean: return "Arithmetic Mean"
+        case .rms:            return "Root Mean Square"
+        case .maximum:        return "Maximum"
+        case .minimum:        return "Minimum"
+        case .accumulated:    return "Accumulated"
+        case .count:          return "Count"
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/SensorMessage.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/SensorMessage.swift
@@ -152,7 +152,7 @@ public struct SensorDescriptor {
         // Encode two 12-bit tolerance values in 2 bytes.
         let tolerances: UInt32 = UInt32(negativeTolerance) << 12 | UInt32(positiveTolerance)
         
-        var data = Data() + property.rawValue
+        var data = Data() + property.id
         data += (Data() + tolerances.littleEndian).dropLast()
         data += samplingFunction.rawValue
         data += measurementPeriodValue
@@ -206,10 +206,7 @@ public struct SensorDescriptor {
             return nil
         }
         let propertyId: UInt16 = parameters.read(fromOffset: offset)
-        guard let property = DeviceProperty(rawValue: propertyId) else {
-            return nil
-        }
-        self.property = property
+        self.property = DeviceProperty(propertyId)
         // Decode two 12-bit tolerace values from 2 bytes.
         self.positiveTolerance = UInt16(parameters[offset + 3] & 0x0F) << 8 | UInt16(parameters[offset + 2])
         self.negativeTolerance = UInt16(parameters[offset + 4]) << 4 | UInt16(parameters[offset + 3] >> 4)

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceGet.swift
@@ -37,7 +37,7 @@ public struct SensorCadenceGet: AcknowledgedSensorPropertyMessage {
     public let property: DeviceProperty
     
     public var parameters: Data? {
-        return Data() + property.rawValue
+        return Data() + property.id
     }
     
     /// Creates the Sensor Cadence Get message.
@@ -52,10 +52,7 @@ public struct SensorCadenceGet: AcknowledgedSensorPropertyMessage {
             return nil
         }
         let propertyId: UInt16 = parameters.read(fromOffset: 0)
-        guard let property = DeviceProperty(rawValue: propertyId) else {
-            return nil
-        }
-        self.property = property
+        self.property = DeviceProperty(propertyId)
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceGet.swift
@@ -1,0 +1,61 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct SensorCadenceGet: AcknowledgedSensorPropertyMessage {
+    public static let opCode: UInt32 = 0x8234
+    public static let responseType: StaticMeshMessage.Type = SensorCadenceStatus.self
+    
+    public let property: DeviceProperty
+    
+    public var parameters: Data? {
+        return Data() + property.rawValue
+    }
+    
+    /// Creates the Sensor Cadence Get message.
+    ///
+    /// - parameter property: The property to get cadence of.
+    public init(of property: DeviceProperty) {
+        self.property = property
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 2 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        guard let property = DeviceProperty(rawValue: propertyId) else {
+            return nil
+        }
+        self.property = property
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceSet.swift
@@ -30,30 +30,31 @@
 
 import Foundation
 
-public struct SensorCadenceStatus: SensorPropertyMessage {
-    public static let opCode: UInt32 = 0x57
+public struct SensorCadenceSet: AcknowledgedSensorPropertyMessage {
+    public static let opCode: UInt32 = 0x55
+    public static let responseType: StaticMeshMessage.Type = SensorCadenceStatus.self
     
     public let property: DeviceProperty
     
-    /// The current status cadence.
-    public let cadence: SensorCadence?
+    /// The new status cadence.
+    public let cadence: SensorCadence
     
     public var parameters: Data? {
-        return Data() + property.rawValue + cadence?.data
+        return Data() + property.rawValue + cadence.data
     }
     
-    /// Creates the Sensor Cadence Status message.
+    /// Creates the Sensor Cadence Set message.
     ///
     /// - parameters:
     ///   - property: The device property.
-    ///   - cadence:  The cadence to be returned.
-    public init(of property: DeviceProperty, cadence: SensorCadence?) {
+    ///   - cadence:  The cadence to set.
+    public init(of property: DeviceProperty, to cadence: SensorCadence) {
         self.property = property
         self.cadence = cadence
     }
     
     public init?(parameters: Data) {
-        guard parameters.count == 2 || parameters.count >= 8 else {
+        guard parameters.count >= 8 else {
             return nil
         }
         let propertyId: UInt16 = parameters.read(fromOffset: 0)
@@ -61,14 +62,11 @@ public struct SensorCadenceStatus: SensorPropertyMessage {
             return nil
         }
         self.property = property
-        if parameters.count != 2 {
-            guard let cadence = SensorCadence(of: property, from: parameters, at: 2) else {
-                return nil
-            }
-            self.cadence = cadence
-        } else {
-            self.cadence = nil
+        
+        guard let cadence = SensorCadence(of: property, from: parameters, at: 2) else {
+            return nil
         }
+        self.cadence = cadence
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceSet.swift
@@ -40,7 +40,7 @@ public struct SensorCadenceSet: AcknowledgedSensorPropertyMessage {
     public let cadence: SensorCadence
     
     public var parameters: Data? {
-        return Data() + property.rawValue + cadence.data
+        return Data() + property.id + cadence.data
     }
     
     /// Creates the Sensor Cadence Set message.
@@ -58,10 +58,7 @@ public struct SensorCadenceSet: AcknowledgedSensorPropertyMessage {
             return nil
         }
         let propertyId: UInt16 = parameters.read(fromOffset: 0)
-        guard let property = DeviceProperty(rawValue: propertyId) else {
-            return nil
-        }
-        self.property = property
+        self.property = DeviceProperty(propertyId)
         
         guard let cadence = SensorCadence(of: property, from: parameters, at: 2) else {
             return nil

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceSetUnacknowledged.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceSetUnacknowledged.swift
@@ -39,7 +39,7 @@ public struct SensorCadenceSetUnacknowledged: SensorPropertyMessage {
     public let cadence: SensorCadence
     
     public var parameters: Data? {
-        return Data() + property.rawValue + cadence.data
+        return Data() + property.id + cadence.data
     }
     
     /// Creates the Sensor Cadence Set Unacknowledged message.
@@ -57,10 +57,7 @@ public struct SensorCadenceSetUnacknowledged: SensorPropertyMessage {
             return nil
         }
         let propertyId: UInt16 = parameters.read(fromOffset: 0)
-        guard let property = DeviceProperty(rawValue: propertyId) else {
-            return nil
-        }
-        self.property = property
+        self.property = DeviceProperty(propertyId)
         
         guard let cadence = SensorCadence(of: property, from: parameters, at: 2) else {
             return nil

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceSetUnacknowledged.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceSetUnacknowledged.swift
@@ -30,30 +30,30 @@
 
 import Foundation
 
-public struct SensorCadenceStatus: SensorPropertyMessage {
-    public static let opCode: UInt32 = 0x57
+public struct SensorCadenceSetUnacknowledged: SensorPropertyMessage {
+    public static let opCode: UInt32 = 0x56
     
     public let property: DeviceProperty
     
-    /// The current status cadence.
-    public let cadence: SensorCadence?
+    /// The new status cadence.
+    public let cadence: SensorCadence
     
     public var parameters: Data? {
-        return Data() + property.rawValue + cadence?.data
+        return Data() + property.rawValue + cadence.data
     }
     
-    /// Creates the Sensor Cadence Status message.
+    /// Creates the Sensor Cadence Set Unacknowledged message.
     ///
     /// - parameters:
     ///   - property: The device property.
-    ///   - cadence:  The cadence to be returned.
-    public init(of property: DeviceProperty, cadence: SensorCadence?) {
+    ///   - cadence:  The cadence to set.
+    public init(of property: DeviceProperty, to cadence: SensorCadence) {
         self.property = property
         self.cadence = cadence
     }
     
     public init?(parameters: Data) {
-        guard parameters.count == 2 || parameters.count >= 8 else {
+        guard parameters.count >= 8 else {
             return nil
         }
         let propertyId: UInt16 = parameters.read(fromOffset: 0)
@@ -61,14 +61,11 @@ public struct SensorCadenceStatus: SensorPropertyMessage {
             return nil
         }
         self.property = property
-        if parameters.count != 2 {
-            guard let cadence = SensorCadence(of: property, from: parameters, at: 2) else {
-                return nil
-            }
-            self.cadence = cadence
-        } else {
-            self.cadence = nil
+        
+        guard let cadence = SensorCadence(of: property, from: parameters, at: 2) else {
+            return nil
         }
+        self.cadence = cadence
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceStatus.swift
@@ -39,7 +39,7 @@ public struct SensorCadenceStatus: SensorPropertyMessage {
     public let cadence: SensorCadence?
     
     public var parameters: Data? {
-        return Data() + property.rawValue + cadence?.data
+        return Data() + property.id + cadence?.data
     }
     
     /// Creates the Sensor Cadence Status message.
@@ -57,10 +57,7 @@ public struct SensorCadenceStatus: SensorPropertyMessage {
             return nil
         }
         let propertyId: UInt16 = parameters.read(fromOffset: 0)
-        guard let property = DeviceProperty(rawValue: propertyId) else {
-            return nil
-        }
-        self.property = property
+        self.property = DeviceProperty(propertyId)
         if parameters.count != 2 {
             guard let cadence = SensorCadence(of: property, from: parameters, at: 2) else {
                 return nil

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorCadenceStatus.swift
@@ -1,0 +1,74 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct SensorCadenceStatus: SensorPropertyMessage {
+    public static let opCode: UInt32 = 0x57
+    
+    public let property: DeviceProperty
+    
+    /// The current status cadence.
+    public let cadence: SensorCadence?
+    
+    public var parameters: Data? {
+        return Data() + property.rawValue
+    }
+    
+    /// Creates the Sensor Cadence Status message.
+    ///
+    /// - parameters:
+    ///   - property: The device property.
+    ///   - cadence:  The cadence to be returned.
+    public init(of property: DeviceProperty, cadence: SensorCadence?) {
+        self.property = property
+        self.cadence = cadence
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 2 || parameters.count >= 8 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        guard let property = DeviceProperty(rawValue: propertyId) else {
+            return nil
+        }
+        self.property = property
+        if parameters.count != 2 {
+            guard let cadence = SensorCadence(of: property, from: parameters, at: 2) else {
+                return nil
+            }
+            self.cadence = cadence
+        } else {
+            self.cadence = nil
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorColumnGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorColumnGet.swift
@@ -1,0 +1,64 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct SensorColumnGet: AcknowledgedSensorPropertyMessage {
+    public static let opCode: UInt32 = 0x8232
+    public static let responseType: StaticMeshMessage.Type = SensorColumnStatus.self
+    
+    public let property: DeviceProperty
+    /// Raw value identifying a column.
+    public let rawValueX: Data
+    
+    public var parameters: Data? {
+        return Data() + property.id + rawValueX
+    }
+    
+    /// Creates the Sensor Column Get message.
+    ///
+    /// - parameters:
+    ///   - property:  Property identifying a sensor.
+    ///   - rawValueX: Raw value identifying a column.
+    public init(of property: DeviceProperty, rawValueX: Data) {
+        self.property  = property
+        self.rawValueX = rawValueX
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count > 2 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        self.property  = DeviceProperty(propertyId)
+        self.rawValueX = parameters.dropFirst(2)
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorColumnStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorColumnStatus.swift
@@ -1,0 +1,76 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct SensorColumnStatus: SensorPropertyMessage {
+    public static let opCode: UInt32 = 0x53
+    
+    public let property: DeviceProperty
+    /// The state of Sensor Series Column state.
+    ///
+    /// The result consists of:
+    ///  - Raw Value X,
+    ///  - Column Width (Optional),
+    ///  - Raw Value Y (C.1)
+    ///
+    /// C.1: If the Column Width field is present, the Raw Value Y field
+    /// shall also be present; otherwise this field shall not be present.
+    ///
+    /// The values are returned as a single `Data` object, as their lenghts
+    /// and types may differ depending on the sensor implementation.
+    public let result: Data
+    
+    public var parameters: Data? {
+        return Data() + property.id + result
+    }
+    
+    /// Creates the Sensor Column Status message.
+    ///
+    /// - parameters:
+    ///   - property: Property identifying a sensor and the Y axis.
+    ///   - result:   Raw Value X and optionally Column Width and Raw Value Y
+    ///               in a single `Data` object. Little Endian should be used
+    ///               for marshalling multi-octed values.
+    public init(of property: DeviceProperty, result: Data) {
+        self.property = property
+        self.result   = result
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count > 2 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        self.property = DeviceProperty(propertyId)
+        self.result   = parameters.dropFirst(2)
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorDescriptorGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorDescriptorGet.swift
@@ -41,7 +41,7 @@ public struct SensorDescriptorGet: AcknowledgedSensorMessage {
     
     public var parameters: Data? {
         if let property = property {
-            return Data() + property.rawValue
+            return Data() + property.id
         }
         return nil
     }
@@ -60,10 +60,7 @@ public struct SensorDescriptorGet: AcknowledgedSensorMessage {
             self.property = nil
         case 2:
             let propertyId: UInt16 = parameters.read(fromOffset: 0)
-            guard let property = DeviceProperty(rawValue: propertyId) else {
-                return nil
-            }
-            self.property = property
+            self.property = DeviceProperty(propertyId)
         default:
             return nil
         }

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorDescriptorGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorDescriptorGet.swift
@@ -1,0 +1,72 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct SensorDescriptorGet: AcknowledgedSensorMessage {
+    public static let opCode: UInt32 = 0x8230
+    public static let responseType: StaticMeshMessage.Type = SensorDescriptorStatus.self
+    
+    /// The sensor property to get the descriptor of.
+    ///
+    /// If set to `nil`, all sensor descriptors found on the Element will be returned.
+    public let property: DeviceProperty?
+    
+    public var parameters: Data? {
+        if let property = property {
+            return Data() + property.rawValue
+        }
+        return nil
+    }
+    
+    /// Creates the Sensor Descriptor Get message.
+    ///
+    /// - parameter property: An optional property parameter to request only the sensor
+    ///                       descriptor of the given property.
+    public init(of property: DeviceProperty? = nil) {
+        self.property = property
+    }
+    
+    public init?(parameters: Data) {
+        switch parameters.count {
+        case 0:
+            self.property = nil
+        case 2:
+            let propertyId: UInt16 = parameters.read(fromOffset: 0)
+            guard let property = DeviceProperty(rawValue: propertyId) else {
+                return nil
+            }
+            self.property = property
+        default:
+            return nil
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorDescriptorStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorDescriptorStatus.swift
@@ -55,7 +55,7 @@ public struct SensorDescriptorStatus: SensorMessage {
     public var parameters: Data? {
         switch result {
         case let .propertyNotFound(property):
-            return Data() + property.rawValue
+            return Data() + property.id
         case let .descriptors(descriptors):
             return descriptors.reduce(Data()) { $0 + $1.data }
         }
@@ -82,9 +82,7 @@ public struct SensorDescriptorStatus: SensorMessage {
         switch parameters.count {
         case 2:
             let propertyId: UInt16 = parameters.read(fromOffset: 0)
-            guard let property = DeviceProperty(rawValue: propertyId) else {
-                return nil
-            }
+            let property = DeviceProperty(propertyId)
             result = .propertyNotFound(property)
         case let count where count % 8 == 0:
             var descriptors: [SensorDescriptor] = []

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorDescriptorStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorDescriptorStatus.swift
@@ -1,0 +1,102 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct SensorDescriptorStatus: SensorMessage {
+    public static let opCode: UInt32 = 0x51
+    
+    /// The result returned in Sensor Descriptor Status message.
+    public enum Result {
+        /// List of sensor descriptors returned in the response.
+        ///
+        /// If Sensor Descriptor Get was sent with the `property` parameter set
+        /// to `nil`, the result will contain a list of all sensor descriptors
+        /// found on the target Element. Otherwise, in case the requested property
+        /// was found, this list will contain only the requested descriptor.
+        case descriptors([SensorDescriptor])
+        /// The Propery was not found on the Element.
+        ///
+        /// This result is returned when a Sensor Descriptor Get was sent with
+        /// a `property` parameter that does not exist on the target Element.
+        case propertyNotFound(DeviceProperty)
+    }
+    
+    /// The result received.
+    public let result: Result
+    
+    public var parameters: Data? {
+        switch result {
+        case let .propertyNotFound(property):
+            return Data() + property.rawValue
+        case let .descriptors(descriptors):
+            return descriptors.reduce(Data()) { $0 + $1.data }
+        }
+    }
+    
+    /// Creates a Sensor Descriptor Status message for a property that has not
+    /// been found on the Element.
+    ///
+    /// - parameter property: The requested property that has not been found.
+    public init(propertyNotFound property: DeviceProperty) {
+        result = .propertyNotFound(property)
+    }
+    
+    /// Creates a Sensor Descriptor Status message.
+    ///
+    /// The list shall contain one or more sensor descriptors.
+    ///
+    /// - parameter descriptors: List of sensor descriptors.
+    public init(_ descriptors: [SensorDescriptor]) {
+        result = .descriptors(descriptors)
+    }
+    
+    public init?(parameters: Data) {
+        switch parameters.count {
+        case 2:
+            let propertyId: UInt16 = parameters.read(fromOffset: 0)
+            guard let property = DeviceProperty(rawValue: propertyId) else {
+                return nil
+            }
+            result = .propertyNotFound(property)
+        case let count where count % 8 == 0:
+            var descriptors: [SensorDescriptor] = []
+            for offset in stride(from: 0, to: count, by: 8) {
+                if let descriptor = SensorDescriptor(from: parameters, at: offset) {
+                    descriptors.append(descriptor)
+                }
+            }
+            result = .descriptors(descriptors)
+        default:
+            return nil
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorGet.swift
@@ -30,37 +30,40 @@
 
 import Foundation
 
-public struct SensorSettingGet: AcknowledgedSensorPropertyMessage {
-    public static let opCode: UInt32 = 0x8236
-    public static let responseType: StaticMeshMessage.Type = SensorSettingStatus.self
+public struct SensorGet: AcknowledgedSensorMessage {
+    public static let opCode: UInt32 = 0x8231
+    public static let responseType: StaticMeshMessage.Type = SensorStatus.self
     
-    public let property: DeviceProperty
-    /// Setting Property identifying a setting within a sensor.
-    public let settingProperty: DeviceProperty
+    /// The sensor property to get the value of.
+    ///
+    /// If set to `nil`, all sensor values found on the Element will be returned.
+    public let property: DeviceProperty?
     
     public var parameters: Data? {
-        return Data() + property.id + settingProperty.id
+        if let property = property {
+            return Data() + property.id
+        }
+        return nil
     }
     
-    /// Creates the Sensor Setting Get message.
+    /// Creates the Sensor Get message.
     ///
-    /// - parameters:
-    ///   - setting:  Setting Property identifying a setting within a sensor.
-    ///   - property: Property identifying a sensor.
-    public init(_ setting: DeviceProperty, of property: DeviceProperty) {
+    /// - parameter property: An optional property parameter to request only the
+    ///                       value of the given property.
+    public init(_ property: DeviceProperty? = nil) {
         self.property = property
-        self.settingProperty = setting
     }
     
     public init?(parameters: Data) {
-        guard parameters.count == 4 else {
+        switch parameters.count {
+        case 0:
+            self.property = nil
+        case 2:
+            let propertyId: UInt16 = parameters.read(fromOffset: 0)
+            self.property = DeviceProperty(propertyId)
+        default:
             return nil
         }
-        let propertyId: UInt16 = parameters.read(fromOffset: 0)
-        self.property = DeviceProperty(propertyId)
-        
-        let settingPropertyId: UInt16 = parameters.read(fromOffset: 2)
-        self.settingProperty = DeviceProperty(settingPropertyId)
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSeriesGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSeriesGet.swift
@@ -1,0 +1,70 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct SensorSeriesGet: AcknowledgedSensorPropertyMessage {
+    public static let opCode: UInt32 = 0x8233
+    public static let responseType: StaticMeshMessage.Type = SensorSeriesStatus.self
+    
+    public let property: DeviceProperty
+    /// Raw value identifying a starting column.
+    public let rawValueX1: Data
+    /// Raw value identifying an ending column.
+    public let rawValueX2: Data
+    
+    public var parameters: Data? {
+        return Data() + property.id + rawValueX1 + rawValueX2
+    }
+    
+    /// Creates the Sensor Series Get message.
+    ///
+    /// - parameters:
+    ///   - property:   Property identifying a sensor.
+    ///   - rawValueX1: Raw value identifying a starting column.
+    ///   - rawValueX2: Raw value identifying an ending column.
+    public init(of property: DeviceProperty, rawValueX1: Data, rawValueX2: Data) {
+        self.property  = property
+        self.rawValueX1 = rawValueX1
+        self.rawValueX2 = rawValueX2
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count > 2 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        self.property  = DeviceProperty(propertyId)
+        let length = (parameters.count - 2) / 2
+        self.rawValueX1 = parameters.subdata(in: 2..<2 + length)
+        self.rawValueX2 = parameters.subdata(in: 2 + length..<parameters.count)
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSeriesStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSeriesStatus.swift
@@ -52,7 +52,7 @@ public struct SensorSeriesStatus: SensorPropertyMessage {
     /// Creates the Sensor Series Status message.
     ///
     /// - parameters:
-    ///   - property: Property identifying a sensor.
+    ///   - property: Property identifying a sensor and the Y axis.
     ///   - seriesRawData: Series of Raw Value X, Column Width and Raw Value Y
     ///                    marshalled into a single `Data` object.
     ///                    Little Endian should be used for marshalling

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSeriesStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSeriesStatus.swift
@@ -1,0 +1,78 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct SensorSeriesStatus: SensorPropertyMessage {
+    public static let opCode: UInt32 = 0x54
+    
+    public let property: DeviceProperty
+    /// A sequence of Sensor Series Column states.
+    ///
+    /// Each serie consists of:
+    ///  - Raw Value X,
+    ///  - Column Width,
+    ///  - Raw Value Y
+    ///
+    /// The series are returned as a single `Data` object, as their lenghts
+    /// and types may differ depending on the sensor implementation.
+    public let seriesRawData: Data?
+    
+    public var parameters: Data? {
+        return Data() + property.id + seriesRawData
+    }
+    
+    /// Creates the Sensor Series Status message.
+    ///
+    /// - parameters:
+    ///   - property: Property identifying a sensor.
+    ///   - seriesRawData: Series of Raw Value X, Column Width and Raw Value Y
+    ///                    marshalled into a single `Data` object.
+    ///                    Little Endian should be used for marshalling
+    ///                    multi-octed values.
+    public init(of property: DeviceProperty, seriesRawData: Data?) {
+        self.property = property
+        self.seriesRawData = seriesRawData
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count >= 2 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        self.property = DeviceProperty(propertyId)
+        if parameters.count > 2 {
+            self.seriesRawData = parameters.dropFirst(2)
+        } else {
+            self.seriesRawData = nil
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingGet.swift
@@ -29,52 +29,44 @@
 */
 
 import Foundation
-import nRFMeshProvision
 
-class SensorClientDelegate: ModelDelegate {
+public struct SensorSettingGet: AcknowledgedSensorPropertyMessage {
+    public static let opCode: UInt32 = 0x8236
+    public static let responseType: StaticMeshMessage.Type = SensorSettingStatus.self
     
-    let messageTypes: [UInt32 : MeshMessage.Type]
-    let isSubscriptionSupported: Bool = true
+    public let property: DeviceProperty
+    /// Setting Property identifying a setting within a sensor.
+    public let settingProperty: DeviceProperty
     
-    // TODO: Implement Sensor Client publications.
-    let publicationMessageComposer: MessageComposer? = nil
-    
-    init() {
-        let types: [SensorMessage.Type] = [
-            SensorDescriptorStatus.self,
-            SensorCadenceStatus.self,
-            SensorSettingsStatus.self,
-            SensorSettingStatus.self,
-        ]
-        messageTypes = types.toMap()
+    public var parameters: Data? {
+        return Data() + property.rawValue + settingProperty.rawValue
     }
     
-    func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) throws -> MeshMessage {
-        switch request {
-            // No acknowledged message supported by this Model.
-        default:
-            fatalError("Message not supported: \(request)")
+    /// Creates the Sensor Setting Get message.
+    ///
+    /// - parameters:
+    ///   - setting:  Setting Property identifying a setting within a sensor.
+    ///   - property: Property identifying a sensor.
+    public init(_ setting: DeviceProperty, of property: DeviceProperty) {
+        self.property = property
+        self.settingProperty = setting
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 4 else {
+            return nil
         }
-    }
-    
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
-               from source: Address, sentTo destination: MeshAddress) {
-        handle(message, sentFrom: source)
-    }
-    
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
-               toAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address) {
-        handle(response, sentFrom: source)
-    }
-    
-}
-
-private extension SensorClientDelegate {
-    
-    func handle(_ message: MeshMessage, sentFrom source: Address) {
-        // Ignore.
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        guard let property = DeviceProperty(rawValue: propertyId) else {
+            return nil
+        }
+        self.property = property
+        
+        let settingPropertyId: UInt16 = parameters.read(fromOffset: 2)
+        guard let settingProperty = DeviceProperty(rawValue: settingPropertyId) else {
+            return nil
+        }
+        self.settingProperty = settingProperty
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingSet.swift
@@ -41,7 +41,7 @@ public struct SensorSettingSet: AcknowledgedSensorPropertyMessage {
     public let settingValue: DevicePropertyCharacteristic
     
     public var parameters: Data? {
-        return Data() + property.rawValue + settingProperty.rawValue + settingValue.data
+        return Data() + property.id + settingProperty.id + settingValue.data
     }
     
     /// Creates the Sensor Setting Set message.
@@ -62,16 +62,10 @@ public struct SensorSettingSet: AcknowledgedSensorPropertyMessage {
             return nil
         }
         let propertyId: UInt16 = parameters.read(fromOffset: 0)
-        guard let property = DeviceProperty(rawValue: propertyId) else {
-            return nil
-        }
-        self.property = property
+        self.property = DeviceProperty(propertyId)
         
         let settingPropertyId: UInt16 = parameters.read(fromOffset: 2)
-        guard let settingProperty = DeviceProperty(rawValue: settingPropertyId) else {
-            return nil
-        }
-        self.settingProperty = settingProperty
+        self.settingProperty = DeviceProperty(settingPropertyId)
         
         // For known properties, make sure we have enough of data to parse value from.
         if let expectedValueLength = settingProperty.valueLength {

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingSet.swift
@@ -1,0 +1,85 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct SensorSettingSet: AcknowledgedSensorPropertyMessage {
+    public static let opCode: UInt32 = 0x59
+    public static let responseType: StaticMeshMessage.Type = SensorSettingStatus.self
+    
+    public let property: DeviceProperty
+    /// Setting Property identifying a setting within a sensor.
+    public let settingProperty: DeviceProperty
+    /// The value of the setting.
+    public let settingValue: DevicePropertyCharacteristic
+    
+    public var parameters: Data? {
+        return Data() + property.rawValue + settingProperty.rawValue + settingValue.data
+    }
+    
+    /// Creates the Sensor Setting Set message.
+    ///
+    /// - parameters:
+    ///   - setting:  Setting Property identifying a setting within a sensor.
+    ///   - property: Property identifying a sensor.
+    ///   - value:    The value of the setting.
+    public init(_ setting: DeviceProperty, of property: DeviceProperty,
+                to value: DevicePropertyCharacteristic) {
+        self.property = property
+        self.settingProperty = setting
+        self.settingValue = value
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count >= 5 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        guard let property = DeviceProperty(rawValue: propertyId) else {
+            return nil
+        }
+        self.property = property
+        
+        let settingPropertyId: UInt16 = parameters.read(fromOffset: 2)
+        guard let settingProperty = DeviceProperty(rawValue: settingPropertyId) else {
+            return nil
+        }
+        self.settingProperty = settingProperty
+        
+        // For known properties, make sure we have enough of data to parse value from.
+        if let expectedValueLength = settingProperty.valueLength {
+            guard expectedValueLength == parameters.count - 4 else {
+                return nil
+            }
+        }
+        self.settingValue = settingProperty.read(from: parameters, at: 4, length: parameters.count - 4)
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingSetUnacknowledged.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingSetUnacknowledged.swift
@@ -40,7 +40,7 @@ public struct SensorSettingSetUnacknowledged: SensorPropertyMessage {
     public let settingValue: DevicePropertyCharacteristic
     
     public var parameters: Data? {
-        return Data() + property.rawValue + settingProperty.rawValue + settingValue.data
+        return Data() + property.id + settingProperty.id + settingValue.data
     }
     
     /// Creates the Sensor Setting Set Unacknowledged message.
@@ -61,16 +61,10 @@ public struct SensorSettingSetUnacknowledged: SensorPropertyMessage {
             return nil
         }
         let propertyId: UInt16 = parameters.read(fromOffset: 0)
-        guard let property = DeviceProperty(rawValue: propertyId) else {
-            return nil
-        }
-        self.property = property
+        self.property = DeviceProperty(propertyId)
         
         let settingPropertyId: UInt16 = parameters.read(fromOffset: 2)
-        guard let settingProperty = DeviceProperty(rawValue: settingPropertyId) else {
-            return nil
-        }
-        self.settingProperty = settingProperty
+        self.settingProperty = DeviceProperty(settingPropertyId)
         
         // For known properties, make sure we have enough of data to parse value from.
         if let expectedValueLength = settingProperty.valueLength {

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingSetUnacknowledged.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingSetUnacknowledged.swift
@@ -1,0 +1,84 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct SensorSettingSetUnacknowledged: SensorPropertyMessage {
+    public static let opCode: UInt32 = 0x5A
+    
+    public let property: DeviceProperty
+    /// Setting Property identifying a setting within a sensor.
+    public let settingProperty: DeviceProperty
+    /// The value of the setting.
+    public let settingValue: DevicePropertyCharacteristic
+    
+    public var parameters: Data? {
+        return Data() + property.rawValue + settingProperty.rawValue + settingValue.data
+    }
+    
+    /// Creates the Sensor Setting Set Unacknowledged message.
+    ///
+    /// - parameters:
+    ///   - setting:  Setting Property identifying a setting within a sensor.
+    ///   - property: Property identifying a sensor.
+    ///   - value:    The value of the setting.
+    public init(_ setting: DeviceProperty, of property: DeviceProperty,
+                to value: DevicePropertyCharacteristic) {
+        self.property = property
+        self.settingProperty = setting
+        self.settingValue = value
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count >= 5 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        guard let property = DeviceProperty(rawValue: propertyId) else {
+            return nil
+        }
+        self.property = property
+        
+        let settingPropertyId: UInt16 = parameters.read(fromOffset: 2)
+        guard let settingProperty = DeviceProperty(rawValue: settingPropertyId) else {
+            return nil
+        }
+        self.settingProperty = settingProperty
+        
+        // For known properties, make sure we have enough of data to parse value from.
+        if let expectedValueLength = settingProperty.valueLength {
+            guard expectedValueLength == parameters.count - 4 else {
+                return nil
+            }
+        }
+        self.settingValue = settingProperty.read(from: parameters, at: 4, length: parameters.count - 4)
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingStatus.swift
@@ -1,0 +1,126 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct SensorSettingStatus: SensorPropertyMessage {
+    public static let opCode: UInt32 = 0x5B
+    
+    /// The Sensor Setting Access field is an enumeration indicating whether
+    /// the device property can be read or written.
+    public enum SensorSettingAccess: UInt8 {
+        /// The device property can be read.
+        case readonly  = 0x01
+        /// The device property can be read and written.
+        case readwrite = 0x03
+    }
+    
+    public let property: DeviceProperty
+    /// Setting Property identifying a setting within a sensor.
+    public let settingProperty: DeviceProperty
+    /// Read / Write access rights for the setting.
+    ///
+    /// This property is `nil` when requested setting property was not found.
+    public let settingAccess: SensorSettingAccess?
+    /// The value of the setting.
+    ///
+    /// This property is `nil` when requested setting property was not found.
+    public let settingValue: DevicePropertyCharacteristic?
+    
+    public var parameters: Data? {
+        let data = Data() + property.rawValue + settingProperty.rawValue
+        if let access = settingAccess,
+           let setting = settingValue {
+            return data + access.rawValue + setting.data
+        } else {
+            return data
+        }
+    }
+    
+    /// Creates the Sensor Setting Status message for a setting that does not
+    /// exist.
+    ///
+    /// - parameters:
+    ///   - setting:  Setting Property identifying a setting within a sensor.
+    ///   - property: Property identifying a sensor.
+    public init(settingNotFound setting: DeviceProperty, for property: DeviceProperty) {
+        self.property = property
+        self.settingProperty = setting
+        self.settingAccess = nil
+        self.settingValue = nil
+    }
+    
+    /// Creates the Sensor Setting Status message.
+    ///
+    /// - parameters:
+    ///   - setting:  Setting Property identifying a setting within a sensor.
+    ///   - property: Property identifying a sensor.
+    ///   - access:   Read / Write access rights for the setting.
+    ///   - value:    The value of the setting.
+    public init(_ setting: DeviceProperty, of property: DeviceProperty,
+                access: SensorSettingAccess, value: DevicePropertyCharacteristic) {
+        self.property = property
+        self.settingProperty = setting
+        self.settingAccess = access
+        self.settingValue = value
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 4 || parameters.count >= 6 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        guard let property = DeviceProperty(rawValue: propertyId) else {
+            return nil
+        }
+        self.property = property
+        
+        let settingPropertyId: UInt16 = parameters.read(fromOffset: 2)
+        guard let settingProperty = DeviceProperty(rawValue: settingPropertyId) else {
+            return nil
+        }
+        self.settingProperty = settingProperty
+        
+        // Sensor Setting Access and Setting Raw are optional.
+        if parameters.count == 4 {
+            self.settingAccess = nil
+            self.settingValue = nil
+            return
+        }
+        
+        let accessId: UInt8 = parameters[4]
+        guard let access = SensorSettingAccess(rawValue: accessId) else {
+            return nil
+        }
+        self.settingAccess = access
+        self.settingValue = settingProperty.read(from: parameters, at: 5, length: parameters.count - 5)
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingStatus.swift
@@ -94,7 +94,7 @@ public struct SensorSettingStatus: SensorPropertyMessage {
     }
     
     public init?(parameters: Data) {
-        guard parameters.count == 4 || parameters.count >= 6 else {
+        guard parameters.count >= 4 else {
             return nil
         }
         let propertyId: UInt16 = parameters.read(fromOffset: 0)
@@ -114,6 +114,14 @@ public struct SensorSettingStatus: SensorPropertyMessage {
             return nil
         }
         self.settingAccess = access
+        
+        // If Sensor Setting Set message was sent, and the sensor value is read-only,
+        // the Status should have the Access state field set to `SensorSettingAccess.readonly`
+        // and the value field shall be omitted.
+        if parameters.count == 5 {
+            self.settingValue = nil
+            return
+        }
         self.settingValue = settingProperty.read(from: parameters, at: 5, length: parameters.count - 5)
     }
     

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingsGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingsGet.swift
@@ -29,51 +29,33 @@
 */
 
 import Foundation
-import nRFMeshProvision
 
-class SensorClientDelegate: ModelDelegate {
+public struct SensorSettingsGet: AcknowledgedSensorPropertyMessage {
+    public static let opCode: UInt32 = 0x8235
+    public static let responseType: StaticMeshMessage.Type = SensorSettingsStatus.self
     
-    let messageTypes: [UInt32 : MeshMessage.Type]
-    let isSubscriptionSupported: Bool = true
+    public let property: DeviceProperty
     
-    // TODO: Implement Sensor Client publications.
-    let publicationMessageComposer: MessageComposer? = nil
-    
-    init() {
-        let types: [SensorMessage.Type] = [
-            SensorDescriptorStatus.self,
-            SensorCadenceStatus.self,
-            SensorSettingsStatus.self,
-        ]
-        messageTypes = types.toMap()
+    public var parameters: Data? {
+        return Data() + property.rawValue
     }
     
-    func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) throws -> MeshMessage {
-        switch request {
-            // No acknowledged message supported by this Model.
-        default:
-            fatalError("Message not supported: \(request)")
+    /// Creates the Sensor Settings Get message.
+    ///
+    /// - parameter property: The property to get settings of.
+    public init(of property: DeviceProperty) {
+        self.property = property
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 2 else {
+            return nil
         }
-    }
-    
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
-               from source: Address, sentTo destination: MeshAddress) {
-        handle(message, sentFrom: source)
-    }
-    
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
-               toAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address) {
-        handle(response, sentFrom: source)
-    }
-    
-}
-
-private extension SensorClientDelegate {
-    
-    func handle(_ message: MeshMessage, sentFrom source: Address) {
-        // Ignore.
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        guard let property = DeviceProperty(rawValue: propertyId) else {
+            return nil
+        }
+        self.property = property
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingsGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingsGet.swift
@@ -37,7 +37,7 @@ public struct SensorSettingsGet: AcknowledgedSensorPropertyMessage {
     public let property: DeviceProperty
     
     public var parameters: Data? {
-        return Data() + property.rawValue
+        return Data() + property.id
     }
     
     /// Creates the Sensor Settings Get message.
@@ -52,10 +52,7 @@ public struct SensorSettingsGet: AcknowledgedSensorPropertyMessage {
             return nil
         }
         let propertyId: UInt16 = parameters.read(fromOffset: 0)
-        guard let property = DeviceProperty(rawValue: propertyId) else {
-            return nil
-        }
-        self.property = property
+        self.property = DeviceProperty(propertyId)
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingsStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingsStatus.swift
@@ -40,8 +40,8 @@ public struct SensorSettingsStatus: SensorPropertyMessage {
     
     public var parameters: Data? {
         return settingsProperties?
-            .reduce(Data() + property.rawValue) { $0 + $1.rawValue } ??
-            Data() + property.rawValue
+            .reduce(Data() + property.id) { $0 + $1.id } ??
+            Data() + property.id
     }
     
     /// Creates the Sensor Settings Status message.
@@ -62,19 +62,14 @@ public struct SensorSettingsStatus: SensorPropertyMessage {
             return nil
         }
         let propertyId: UInt16 = parameters.read(fromOffset: 0)
-        guard let property = DeviceProperty(rawValue: propertyId) else {
-            return nil
-        }
-        self.property = property
+        self.property = DeviceProperty(propertyId)
         if parameters.count == 2 {
             self.settingsProperties = nil
         } else {
             var settingsProperties: [DeviceProperty] = []
             for i in stride(from: 2, to: parameters.count, by: 2) {
                 let propertyId: UInt16 = parameters.read(fromOffset: i)
-                guard let property = DeviceProperty(rawValue: propertyId) else {
-                    return nil
-                }
+                let property = DeviceProperty(propertyId)
                 settingsProperties.append(property)
             }
             self.settingsProperties = settingsProperties

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingsStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorSettingsStatus.swift
@@ -1,0 +1,84 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct SensorSettingsStatus: SensorPropertyMessage {
+    public static let opCode: UInt32 = 0x58
+    
+    public let property: DeviceProperty
+    /// If present, the Sensor Setting Properties field contains a sequence
+    /// of all Sensor Setting Property states of a sensor.
+    public let settingsProperties: [DeviceProperty]?
+    
+    public var parameters: Data? {
+        return settingsProperties?
+            .reduce(Data() + property.rawValue) { $0 + $1.rawValue } ??
+            Data() + property.rawValue
+    }
+    
+    /// Creates the Sensor Settings Status message.
+    ///
+    /// - parameters:
+    ///   - property: The Sensor Property field identifies a Sensor Property
+    ///               state of a sensor.
+    ///   - settingsProperties: If present, the Sensor Setting Properties
+    ///                         contains a sequence of all Sensor Setting Property
+    ///                         states of a sensor.
+    public init(of property: DeviceProperty, settingsProperties: [DeviceProperty]?) {
+        self.property = property
+        self.settingsProperties = settingsProperties
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count >= 2 && parameters.count % 2 == 0 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        guard let property = DeviceProperty(rawValue: propertyId) else {
+            return nil
+        }
+        self.property = property
+        if parameters.count == 2 {
+            self.settingsProperties = nil
+        } else {
+            var settingsProperties: [DeviceProperty] = []
+            for i in stride(from: 2, to: parameters.count, by: 2) {
+                let propertyId: UInt16 = parameters.read(fromOffset: i)
+                guard let property = DeviceProperty(rawValue: propertyId) else {
+                    return nil
+                }
+                settingsProperties.append(property)
+            }
+            self.settingsProperties = settingsProperties
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorStatus.swift
@@ -1,0 +1,150 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public typealias SensorValue = (property: DeviceProperty, value: DevicePropertyCharacteristic)
+
+public struct SensorStatus: SensorMessage {
+    public static let opCode: UInt32 = 0x52
+    
+    /// The sensor values.
+    public let values: [SensorValue]
+    
+    public var parameters: Data? {
+        return values.reduce(Data()) { $0 + Self.marshal($1) }
+    }
+    
+    /// Creates the Sensor Status message.
+    ///
+    /// - parameter value: A single property values. Maximum data length is 128 octets.
+    public init(_ value: SensorValue) {
+        self.init([value])
+    }
+    
+    /// Creates the Sensor Status message.
+    ///
+    /// - parameter values: A list of property values. Maximum data length for each value
+    ///                     is 128 octets.
+    public init(_ values: [SensorValue]) {
+        self.values = values
+    }
+    
+    public init?(parameters: Data) {
+        values = Self.unmarshall(parameters)
+    }
+    
+}
+
+private extension SensorStatus {
+    
+    /// Marshalls the given property value to format A or B, depending on the
+    /// Property ID and data length.
+    ///
+    /// - parameter value: The property value to be marshalled.
+    /// - returns: The marshalled data.
+    static func marshal(_ value: SensorValue) -> Data {
+        let data = value.value.data.prefix(128)
+        let length: UInt8 = UInt8(data.count)
+        
+        // Can the data be encoded using Format A?
+        // - Property ID must be less than 2048
+        // - Value length must be in range 1-16
+        // Otherwise, use Format B.
+        if value.property.id < 2048 && length >= 1 && length <= 16 {
+            // Format A
+            let len = length - 1
+            let octet0 = 0b00 | (len << 1) | UInt8(value.property.id << 5)
+            let octet1 = UInt8(value.property.id >> 3)
+            return Data([octet0, octet1]) + data
+        } else {
+            // Format B
+            let len = length == 0 ? 0x7F : length - 1
+            let octet0 = 0b01 | (len << 1)
+            return Data([octet0]) + value.property.id.bigEndian + data
+        }
+    }
+    
+    /// Unmarshalls the received data.
+    ///
+    /// - parameter data: The received data.
+    /// - returns: List of sensor values.
+    static func unmarshall(_ data: Data) -> [SensorValue] {
+        var result: [SensorValue] = []
+        var offset = 0
+        while offset < data.count {
+            // At least 3 bytes per MPID + Raw Value.
+            // In Format A the data must be at least 1 byte long, which gives min 3 bytes.
+            // In Format B the data can be 0 octets long, but the MPID is 3 bytes.
+            // Decode Format field.
+            let type = data[offset] & 0b1
+            if type == 0b0 {
+                // Format A
+                let length = Int((data[offset] >> 1) & 0xF) + 1
+                guard data.count >= offset + 2 + length else {
+                    // Skip this TLV as invalid
+                    offset += 2 + length
+                    continue
+                }
+                let propertyId = UInt16(data[offset]) >> 5 | (UInt16(data[offset + 1]) << 3)
+                let property = DeviceProperty(propertyId)
+                guard property.valueLength == nil || property.valueLength == length else {
+                    // Skip this TLV as invalid
+                    offset += 2 + length
+                    continue
+                }
+                let value = property.read(from: data, at: offset + 2, length: length)
+                result.append((property, value))
+                offset += 2 + length
+            } else {
+                // Format B
+                let len = Int(data[offset] >> 1)
+                let length = len == 0x7F ? 0 : len + 1
+                guard data.count >= offset + 3 + length else {
+                    // Skip this TLV as invalid
+                    offset += 3 + length
+                    continue
+                }
+                let propertyId: UInt16 = data.read(fromOffset: offset + 1)
+                let property = DeviceProperty(propertyId)
+                guard property.valueLength == nil || property.valueLength == length || length == 0 else {
+                    // Skip this TLV as invalid
+                    offset += 3 + length
+                    continue
+                }
+                let value = property.read(from: data, at: offset + 3, length: length)
+                result.append((property, value))
+                offset += 3 + length
+            }
+        }
+        return result
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Sensors/SensorStatus.swift
@@ -81,7 +81,7 @@ private extension SensorStatus {
         if value.property.id < 2048 && length >= 1 && length <= 16 {
             // Format A
             let len = length - 1
-            let octet0 = 0b00 | (len << 1) | UInt8(value.property.id << 5)
+            let octet0 = 0b00 | (len << 1) | UInt8((value.property.id & 0x07) << 5)
             let octet1 = UInt8(value.property.id >> 3)
             return Data([octet0, octet1]) + data
         } else {

--- a/nRFMeshProvision/Classes/Type Extensions/Data.swift
+++ b/nRFMeshProvision/Classes/Type Extensions/Data.swift
@@ -86,9 +86,11 @@ extension DataConvertible {
 extension UInt8  : DataConvertible { }
 extension UInt16 : DataConvertible { }
 extension UInt32 : DataConvertible { }
+extension UInt64 : DataConvertible { }
 extension Int8   : DataConvertible { }
 extension Int16  : DataConvertible { }
 extension Int32  : DataConvertible { }
+extension Int64  : DataConvertible { }
 
 extension Int    : DataConvertible { }
 extension UInt   : DataConvertible { }

--- a/nRFMeshProvision/Classes/Type Extensions/Data.swift
+++ b/nRFMeshProvision/Classes/Type Extensions/Data.swift
@@ -49,10 +49,15 @@ extension Data {
         #endif
     }
     
+    func readUInt24(fromOffset offset: Int = 0) -> UInt32 {
+        return UInt32(self[offset]) | UInt32(self[offset + 1]) << 8 | UInt32(self[offset + 2]) << 16
+    }
+    
     func readBigEndian<R: FixedWidthInteger>(fromOffset offset: Int = 0) -> R {
         let r: R = read(fromOffset: offset)
         return r.bigEndian
     }
+    
 }
 
 // Source: http://stackoverflow.com/a/42241894/2115352

--- a/nRFMeshProvision/Classes/Type Extensions/Int+Hex.swift
+++ b/nRFMeshProvision/Classes/Type Extensions/Int+Hex.swift
@@ -54,6 +54,30 @@ internal extension UInt8 {
     
 }
 
+internal extension Int8 {
+    
+    init?(hex: String) {
+        guard hex.count == 2, let value = UInt8(hex, radix: 16) else {
+            return nil
+        }
+        self = Int8(bitPattern: value)
+    }
+    
+    var hex: String {
+        // This is to ensure that even negative numbers are printed with length 2.
+        return String(String(format: "%02X", self).suffix(2))
+    }
+    
+    init(data: Data) {
+        self = Int8(bitPattern: data[0])
+    }
+    
+    var data: Data {
+        return Data([UInt8(bitPattern: self)])
+    }
+    
+}
+
 internal extension UInt16 {
     
     init?(hex: String) {
@@ -78,6 +102,30 @@ internal extension UInt16 {
     
 }
 
+internal extension Int16 {
+    
+    init?(hex: String) {
+        guard hex.count == 4, let value = UInt16(hex, radix: 16) else {
+            return nil
+        }
+        self = Int16(bitPattern: value)
+    }
+    
+    var hex: String {
+        // This is to ensure that even negative numbers are printed with length 4.
+        return String(String(format: "%04X", self).suffix(4))
+    }
+    
+    init(data: Data) {
+        self = data.withUnsafeBytes { $0.load(as: Int16.self) }
+    }
+    
+    var data: Data {
+        return Data() + self
+    }
+    
+}
+
 internal extension UInt32 {
     
     init?(hex: String) {
@@ -93,6 +141,33 @@ internal extension UInt32 {
     
     init(data: Data) {
         self = data.withUnsafeBytes { $0.load(as: UInt32.self) }
+    }
+    
+    var data: Data {
+        return Data() + self
+    }
+    
+}
+
+internal extension Int32 {
+    
+    init?(hex: String) {
+        guard hex.count == 8, let value = UInt32(hex, radix: 16) else {
+            return nil
+        }
+        self = Int32(bitPattern: value)
+    }
+    
+    var hex: String {
+        return String(format: "%08X", self)
+    }
+    
+    init(data: Data) {
+        self = data.withUnsafeBytes { $0.load(as: Int32.self) }
+    }
+    
+    var data: Data {
+        return Data() + self
     }
     
 }


### PR DESCRIPTION
This PR adds library support for Sensor messages.
All device property characteristics with decimal value (except `.coefficient`) are returned as `Decimal` (instead of `Float` or `Double`), to avoid rounding errors. Integer characteristics have a type as in specification.
Characteristics of Properties, which have complex format, or that are not yet supported, are returned as `.other(Data)`.

Supported characteristics:
https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/blob/93ee7fe6eda8504f79fb81304f7fbfd0ee223061/nRFMeshProvision/Classes/Mesh%20Messages/DeviceProperty.swift#L1048-L1111

Currently 68 / 179 device properties have been implemented:
```swift
        case deviceDateOfManufacture = 0x000C // DateUTC
        case deviceFirmwareRevision = 0x000E // FixedString8
        case deviceHardwareRevision = 0x0010 // FixedString16
        case deviceManufacturerName = 0x0011 // FixedString36
        case deviceModelNumber = 0x0012 // FixedString24
        case deviceRuntimeSinceTurnOn = 0x0017 // TimeHour24
        case deviceRuntimeWarranty = 0x0018 // TimeHour24
        case deviceSerialNumber = 0x0019 // FixedString16
        case deviceSoftwareRevision = 0x001A // FixedString8
        case inputVoltageRippleSpecification = 0x0029 // Percent8 (UInt8)
        case lightControlAmbientLuxLevelOn = 0x002B // Illuminance (UInt24)
        case lightControlAmbientLuxLevelProlong = 0x002C // Illuminance (UInt24)
        case lightControlAmbientLuxLevelStandby = 0x002D // Illuminance (UInt24)
        case lightControlLightnessOn = 0x002E // Perceived Lightness (UInt16)
        case lightControlLightnessProlong = 0x002F // Perceived Lightness (UInt16)
        case lightControlLightnessStandby = 0x0030 // Perceived Lightness (UInt16)
        case lightControlRegulatorAccuracy = 0x0031 // Percent8 (UInt8)
        case lightControlRegulatorKid = 0x0032 // Coefficient (Float IEEE 754)
        case lightControlRegulatorKiu = 0x0033 // Coefficient (Float IEEE 754)
        case lightControlRegulatorKpd = 0x0034 // Coefficient (Float IEEE 754)
        case lightControlRegulatorKpu = 0x0035 // Coefficient (Float IEEE 754)
        case lightControlTimeFade = 0x0036 // TimeMillisecond24 (UInt24)
        case lightControlTimeFadeOn = 0x0037 // TimeMillisecond24 (UInt24)
        case lightControlTimeFadeStandbyAuto = 0x0038 // TimeMillisecond24 (UInt24)
        case lightControlTimeFadeStandbyManual = 0x0039 // TimeMillisecond24 (UInt24)
        case lightControlTimeOccupancyDelay = 0x003A // TimeMillisecond24 (UInt24)
        case lightControlTimeProlong = 0x003B // TimeMillisecond24 (UInt24)
        case lightControlTimeRunOn = 0x003C // TimeMillisecond24 (UInt24)
        case lumenMaintenanceFactor = 0x003D // Percent8 (UInt8)
        case motionSensed = 0x0042 // Percent8 (UInt8)
        case motionThreshold = 0x0043 // Percent8 (UInt8)
        case outputRippleVoltageSpecification = 0x0048 // Percent8 (UInt8)
        case peopleCount = 0x004C // Count24 (UInt24)
        case presenceDetected = 0x004D // Bool
        case presentAmbientLightLevel = 0x004E // Illuminance (UInt24)
        case presentAmbientTemperature = 0x004F // Temperature8 (SInt8)
        case presentDeviceOperatingEfficiency = 0x0053 // Percent8 (UInt8)
        case presentDeviceOperatingTemperature = 0x0054 // Temperature (UInt16)
        case presentIlluminance = 0x0055 // Illuminance (UInt24)
        case presentIndoorAmbientTemperature = 0x0056 // Temperature8 (SInt8)
        case presentInputRippleVoltage = 0x0058 // Percent8 (UInt8)
        case presentOutdoorAmbientTemperature = 0x005B // Temperature8 (SInt8)
        case presentRelativeOutputRippleVoltage = 0x005F // Percent8 (UInt8)
        case timeSinceMotionSensed = 0x0068 // TimeSecond16
        case timeSincePresenceDetected = 0x0069 // TimeSecond16
        case totalDeviceOffOnCycles = 0x006B // Count24 (UInt24)
        case totalDevicePowerOnCycles = 0x006C // Count24 (UInt24)
        case totalDevicePowerOnTime = 0x006D // TimeHour24
        case totalDeviceRuntime = 0x006E // TimeHour24
        case totalLightExposureTime = 0x006F // TimeHour24
        case desiredAmbientTemperature = 0x0071 // Temperature8 (SInt8)
        case sensorGain = 0x0074 // Coefficient (Float IEEE 754)
        case precisePresentAmbientTemperature = 0x0075 // Temperature (UInt16)
        case presentAmbientRelativeHumidity = 0x0076 // Humidity (Uint16)
        case airPressure = 0x0082 // Pressure (UInt32)
        case lightSourceStartCounterResettable = 0x0093 // Count24 (UInt24)
        case lightSourceTotalPowerOnCycles = 0x0097 // Count24 (UInt24)
        case luminaireColor = 0x0099 // FixedString24
        case luminaireIdentificationNumber = 0x009A // FixedString24
        case luminaireTimeOfManufacture = 0x00A0 // DateUTC
        case presentIndoorRelativeHumidity = 0x00A7 // Humidity (Uint16)
        case presentOutdoorRelativeHumidity = 0x00A8 // Humidity (Uint16)
        case pressure = 0x00A9 // Pressure (UInt32)
        case ratedMedianUsefulLifeOfLuminaire = 0x00AB // TimeHour24
        case ratedMedianUsefulLightSourceStarts = 0x00AC // Count24 (UInt24)
        case totalDeviceStarts = 0x00AE // Count24 (UInt24)
        case luminaireIdentificationString = 0x00B4 // FixedString64
        case outputCurrentPercent = 0x00B7 // Percent8 (UInt8)
```