### PR TITLE
Light LC

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -160,6 +160,10 @@
 		52B4930425DC57BA0096E75D /* LightLCModeStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4930325DC57BA0096E75D /* LightLCModeStatus.swift */; };
 		52B4930A25DC5AE30096E75D /* LightLCModeSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4930925DC5AE30096E75D /* LightLCModeSet.swift */; };
 		52B4931025DC5B380096E75D /* LightLCModeSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4930F25DC5B380096E75D /* LightLCModeSetUnacknowledged.swift */; };
+		52B4931625DC5D420096E75D /* LightLCOccupancyModeGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4931525DC5D420096E75D /* LightLCOccupancyModeGet.swift */; };
+		52B4931C25DC5D8E0096E75D /* LightLCOccupancyModeStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4931B25DC5D8E0096E75D /* LightLCOccupancyModeStatus.swift */; };
+		52B4932225DC5E350096E75D /* LightLCOccupancyModeSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4932125DC5E350096E75D /* LightLCOccupancyModeSetUnacknowledged.swift */; };
+		52B4932825DC5E7A0096E75D /* LightLCOccupancyModeSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4932725DC5E7A0096E75D /* LightLCOccupancyModeSet.swift */; };
 		5419D23A75236616FD9003BFEAB0A196 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C21C8E900A0E68E2325ECFEC2E7B92 /* Digest.swift */; };
 		543740C6C31D3637343F37FA099E11BD /* AEADChaCha20Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30CC9F96E86F25A65521BCC123D5014 /* AEADChaCha20Poly1305.swift */; };
 		54CA4CC2D9DDD32F559FEFE36DB31914 /* NoPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC17DD2135B8E43A2EBE41EE0F6DDB19 /* NoPadding.swift */; };
@@ -627,6 +631,10 @@
 		52B4930325DC57BA0096E75D /* LightLCModeStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCModeStatus.swift; sourceTree = "<group>"; };
 		52B4930925DC5AE30096E75D /* LightLCModeSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCModeSet.swift; sourceTree = "<group>"; };
 		52B4930F25DC5B380096E75D /* LightLCModeSetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCModeSetUnacknowledged.swift; sourceTree = "<group>"; };
+		52B4931525DC5D420096E75D /* LightLCOccupancyModeGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCOccupancyModeGet.swift; sourceTree = "<group>"; };
+		52B4931B25DC5D8E0096E75D /* LightLCOccupancyModeStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCOccupancyModeStatus.swift; sourceTree = "<group>"; };
+		52B4932125DC5E350096E75D /* LightLCOccupancyModeSetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCOccupancyModeSetUnacknowledged.swift; sourceTree = "<group>"; };
+		52B4932725DC5E7A0096E75D /* LightLCOccupancyModeSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCOccupancyModeSet.swift; sourceTree = "<group>"; };
 		531B9F2EF263CE4EA7065194384BE25F /* MeshStateManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MeshStateManager.swift; sourceTree = "<group>"; };
 		538806EF44671C282F414D17398F37EA /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		544BD2258E957BEB4A4E579D0107AF32 /* Provisioner+Node.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Provisioner+Node.swift"; sourceTree = "<group>"; };
@@ -1562,6 +1570,10 @@
 				52B4930925DC5AE30096E75D /* LightLCModeSet.swift */,
 				52B4930F25DC5B380096E75D /* LightLCModeSetUnacknowledged.swift */,
 				52B4930325DC57BA0096E75D /* LightLCModeStatus.swift */,
+				52B4931525DC5D420096E75D /* LightLCOccupancyModeGet.swift */,
+				52B4932725DC5E7A0096E75D /* LightLCOccupancyModeSet.swift */,
+				52B4932125DC5E350096E75D /* LightLCOccupancyModeSetUnacknowledged.swift */,
+				52B4931B25DC5D8E0096E75D /* LightLCOccupancyModeStatus.swift */,
 				D4D05ECB7CCB14F810CDEA019EBF4CB9 /* LightLightnessDefaultGet.swift */,
 				CF1EBD6989C65FAEB9EECE42CB3CFAB3 /* LightLightnessDefaultSet.swift */,
 				4C73DC3777C8924006546A7F137543A5 /* LightLightnessDefaultSetUnacknowledged.swift */,
@@ -2030,6 +2042,7 @@
 				712EBB5A12D22A4E3079DAFA47AA97C5 /* ConfigAppKeyStatus.swift in Sources */,
 				EDD4133A69733BFED864045E8F676ED2 /* ConfigAppKeyUpdate.swift in Sources */,
 				8C39914FB15478177B14C77292347208 /* ConfigBeaconGet.swift in Sources */,
+				52B4932825DC5E7A0096E75D /* LightLCOccupancyModeSet.swift in Sources */,
 				92D7431A641D2C4B1CC9C3FA784637BE /* ConfigBeaconSet.swift in Sources */,
 				FD89C155913EB4EDBF3D8C8AB5895CBA /* ConfigBeaconStatus.swift in Sources */,
 				E3A43416097967B662BC47359A808130 /* ConfigCompositionDataGet.swift in Sources */,
@@ -2083,6 +2096,7 @@
 				9DEF80A4241154D351B47407613E1BF4 /* ConfigNetworkTransmitStatus.swift in Sources */,
 				1071184185D982146FEE23EE2C902FEB /* ConfigNodeReset.swift in Sources */,
 				1D42799FCC93289CF4ADF30FB7428487 /* ConfigNodeResetStatus.swift in Sources */,
+				52B4931625DC5D420096E75D /* LightLCOccupancyModeGet.swift in Sources */,
 				B87ABDACBAB99DCC68CFFB4412F932A2 /* ConfigRelayGet.swift in Sources */,
 				3B7F683A14E3D9D1BEDA42A297184DB9 /* ConfigRelaySet.swift in Sources */,
 				747485C5F4D61A9854A00A5F30654591 /* ConfigRelayStatus.swift in Sources */,
@@ -2233,6 +2247,7 @@
 				913CBDE1C8359E0105D76F5669111792 /* MeshAddress.swift in Sources */,
 				1D90159FC5314F32FD15AA5962D68FB4 /* MeshConstants.swift in Sources */,
 				48D082B0B45CD77470355F90C7FF0D46 /* MeshData.swift in Sources */,
+				52B4931C25DC5D8E0096E75D /* LightLCOccupancyModeStatus.swift in Sources */,
 				31AF3FF3B0DF76DD7731AB32721CFFB4 /* MeshLoggerDelegate.swift in Sources */,
 				42E8000E0351046FCB1F6B85F9F89DF1 /* MeshMessage.swift in Sources */,
 				A4ADDBCC9ADE956382C5277E9145C5D9 /* MeshMessageError.swift in Sources */,
@@ -2267,6 +2282,7 @@
 				47F90A54905C73CD1FB109B916EDFAD4 /* NetworkLayer.swift in Sources */,
 				6A76FC33139BE4124E22F194D766AC14 /* NetworkManager.swift in Sources */,
 				B40670E717FBFB105D096BFE94BF4916 /* NetworkPdu.swift in Sources */,
+				52B4932225DC5E350096E75D /* LightLCOccupancyModeSetUnacknowledged.swift in Sources */,
 				6A37EB9E6D6D408AF027679529C6DB5A /* Node+Address.swift in Sources */,
 				29CB61A8AC54E225F98C04A49B965349 /* Node+Elements.swift in Sources */,
 				47DC6C225774AF8E91B163DAF64BC3BA /* Node+Keys.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -164,6 +164,10 @@
 		52B4931C25DC5D8E0096E75D /* LightLCOccupancyModeStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4931B25DC5D8E0096E75D /* LightLCOccupancyModeStatus.swift */; };
 		52B4932225DC5E350096E75D /* LightLCOccupancyModeSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4932125DC5E350096E75D /* LightLCOccupancyModeSetUnacknowledged.swift */; };
 		52B4932825DC5E7A0096E75D /* LightLCOccupancyModeSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4932725DC5E7A0096E75D /* LightLCOccupancyModeSet.swift */; };
+		52B4932E25DC5F5F0096E75D /* LightLCLightOnOffGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4932D25DC5F5F0096E75D /* LightLCLightOnOffGet.swift */; };
+		52B4933425DC60060096E75D /* LightLCLightOnOffStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4933325DC60060096E75D /* LightLCLightOnOffStatus.swift */; };
+		52B4933A25DC60F70096E75D /* LightLCLightOnOffSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4933925DC60F70096E75D /* LightLCLightOnOffSet.swift */; };
+		52B4934025DC61720096E75D /* LightLCLightOnOffSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4933F25DC61720096E75D /* LightLCLightOnOffSetUnacknowledged.swift */; };
 		5419D23A75236616FD9003BFEAB0A196 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C21C8E900A0E68E2325ECFEC2E7B92 /* Digest.swift */; };
 		543740C6C31D3637343F37FA099E11BD /* AEADChaCha20Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30CC9F96E86F25A65521BCC123D5014 /* AEADChaCha20Poly1305.swift */; };
 		54CA4CC2D9DDD32F559FEFE36DB31914 /* NoPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC17DD2135B8E43A2EBE41EE0F6DDB19 /* NoPadding.swift */; };
@@ -635,6 +639,10 @@
 		52B4931B25DC5D8E0096E75D /* LightLCOccupancyModeStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCOccupancyModeStatus.swift; sourceTree = "<group>"; };
 		52B4932125DC5E350096E75D /* LightLCOccupancyModeSetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCOccupancyModeSetUnacknowledged.swift; sourceTree = "<group>"; };
 		52B4932725DC5E7A0096E75D /* LightLCOccupancyModeSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCOccupancyModeSet.swift; sourceTree = "<group>"; };
+		52B4932D25DC5F5F0096E75D /* LightLCLightOnOffGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCLightOnOffGet.swift; sourceTree = "<group>"; };
+		52B4933325DC60060096E75D /* LightLCLightOnOffStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCLightOnOffStatus.swift; sourceTree = "<group>"; };
+		52B4933925DC60F70096E75D /* LightLCLightOnOffSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCLightOnOffSet.swift; sourceTree = "<group>"; };
+		52B4933F25DC61720096E75D /* LightLCLightOnOffSetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCLightOnOffSetUnacknowledged.swift; sourceTree = "<group>"; };
 		531B9F2EF263CE4EA7065194384BE25F /* MeshStateManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MeshStateManager.swift; sourceTree = "<group>"; };
 		538806EF44671C282F414D17398F37EA /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		544BD2258E957BEB4A4E579D0107AF32 /* Provisioner+Node.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Provisioner+Node.swift"; sourceTree = "<group>"; };
@@ -1574,6 +1582,10 @@
 				52B4932725DC5E7A0096E75D /* LightLCOccupancyModeSet.swift */,
 				52B4932125DC5E350096E75D /* LightLCOccupancyModeSetUnacknowledged.swift */,
 				52B4931B25DC5D8E0096E75D /* LightLCOccupancyModeStatus.swift */,
+				52B4932D25DC5F5F0096E75D /* LightLCLightOnOffGet.swift */,
+				52B4933925DC60F70096E75D /* LightLCLightOnOffSet.swift */,
+				52B4933F25DC61720096E75D /* LightLCLightOnOffSetUnacknowledged.swift */,
+				52B4933325DC60060096E75D /* LightLCLightOnOffStatus.swift */,
 				D4D05ECB7CCB14F810CDEA019EBF4CB9 /* LightLightnessDefaultGet.swift */,
 				CF1EBD6989C65FAEB9EECE42CB3CFAB3 /* LightLightnessDefaultSet.swift */,
 				4C73DC3777C8924006546A7F137543A5 /* LightLightnessDefaultSetUnacknowledged.swift */,
@@ -2060,6 +2072,7 @@
 				E80FE6A7999C5E97C536C8653BE27436 /* ConfigHeartbeatPublicationGet.swift in Sources */,
 				5215997725DFE3A100F602FA /* SensorGet.swift in Sources */,
 				DF80134B5A11603DD6C4298483CA6C40 /* ConfigHeartbeatPublicationSet.swift in Sources */,
+				52B4933A25DC60F70096E75D /* LightLCLightOnOffSet.swift in Sources */,
 				BC275BA1B61602362E50F60898C5CC87 /* ConfigHeartbeatPublicationStatus.swift in Sources */,
 				99F1EE9FA57FE8934A89E30456282776 /* ConfigHeartbeatSubscriptionGet.swift in Sources */,
 				16AA9FD5BD8419E48F98FDDB1BC07F07 /* ConfigHeartbeatSubscriptionSet.swift in Sources */,
@@ -2072,6 +2085,7 @@
 				B322F146E726A5491AB8FDA3D4B3BF15 /* ConfigMessage.swift in Sources */,
 				DE237F0CD1431F6FECE87B1A80D90FEA /* ConfigModelAppBind.swift in Sources */,
 				A51FE64406C9A5113F5B60E1473C1DBC /* ConfigModelAppStatus.swift in Sources */,
+				52B4932E25DC5F5F0096E75D /* LightLCLightOnOffGet.swift in Sources */,
 				20A7584DC938A871377EF1EF542E21EC /* ConfigModelAppUnbind.swift in Sources */,
 				D2B666C3EB1E7191F4E07C25ACCD8855 /* ConfigModelPublicationGet.swift in Sources */,
 				27343F8DB81BE4D55C58B1F669E204BC /* ConfigModelPublicationSet.swift in Sources */,
@@ -2105,6 +2119,7 @@
 				8C4ABACB9815728B43FEBE9EB58D0CA1 /* ConfigSIGModelSubscriptionGet.swift in Sources */,
 				6268480314CBF6A9661177DB5295FADB /* ConfigSIGModelSubscriptionList.swift in Sources */,
 				8BF9154CCE75155314503EB126764497 /* ConfigurationClientHandler.swift in Sources */,
+				52B4933425DC60060096E75D /* LightLCLightOnOffStatus.swift in Sources */,
 				951549D6E57553A1253BC5BA0660D22B /* ConfigurationServerHandler.swift in Sources */,
 				92DB23AAAE46942FD21674EF054B2329 /* ConfigVendorModelAppGet.swift in Sources */,
 				55CE8FA0F27FF2DF90E4AA61EA842C55 /* ConfigVendorModelAppList.swift in Sources */,
@@ -2125,6 +2140,7 @@
 				A0F95080F5D38BA628A4E20F5A3859E4 /* GattBearer.swift in Sources */,
 				A85AD97788323F6980E69F855FD375C6 /* GattBearerDelegate.swift in Sources */,
 				4E2B1128D4B69C183F9D8CFAD53E0352 /* GattBearerError.swift in Sources */,
+				52B4934025DC61720096E75D /* LightLCLightOnOffSetUnacknowledged.swift in Sources */,
 				ED4A457E11C9172F50CAD9A829DD9982 /* GenericBatteryGet.swift in Sources */,
 				5215994925DE96EB00F602FA /* SensorSettingsStatus.swift in Sources */,
 				715BF39B0C141A786D6FA5A1581068B7 /* GenericBatteryStatus.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -152,10 +152,11 @@
 		5215998D25E8E85100F602FA /* SensorColumnStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215998C25E8E85100F602FA /* SensorColumnStatus.swift */; };
 		5215999325E8EC8F00F602FA /* SensorSeriesGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215999225E8EC8F00F602FA /* SensorSeriesGet.swift */; };
 		5215999925E8EDA800F602FA /* SensorSeriesStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5215999825E8EDA800F602FA /* SensorSeriesStatus.swift */; };
+		521599B925E8FD3100F602FA /* LightLCPropertyGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521599B825E8FD3100F602FA /* LightLCPropertyGet.swift */; };
+		521599BF25E8FDE400F602FA /* LightLCPropertyStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521599BE25E8FDE400F602FA /* LightLCPropertyStatus.swift */; };
+		521599C525E8FF4700F602FA /* LightLCPropertySetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521599C425E8FF4700F602FA /* LightLCPropertySetUnacknowledged.swift */; };
+		521599CB25E8FF9D00F602FA /* LightLCPropertySet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 521599CA25E8FF9D00F602FA /* LightLCPropertySet.swift */; };
 		523C6B1F33DB2E96993439A057BDF4D8 /* ConfigAppKeyAdd.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9ED7E9A1A76137851290A8E7D4B828 /* ConfigAppKeyAdd.swift */; };
-		52DE3A9E25D5640900268D7D /* SensorDescriptorGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */; };
-		52DE3AA425D5649400268D7D /* SensorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3AA325D5649400268D7D /* SensorMessage.swift */; };
-		52DE3AAA25D6A2CA00268D7D /* SensorDescriptorStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */; };
 		52B492FE25DC56130096E75D /* LightLCModeGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B492FD25DC56130096E75D /* LightLCModeGet.swift */; };
 		52B4930425DC57BA0096E75D /* LightLCModeStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4930325DC57BA0096E75D /* LightLCModeStatus.swift */; };
 		52B4930A25DC5AE30096E75D /* LightLCModeSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4930925DC5AE30096E75D /* LightLCModeSet.swift */; };
@@ -168,6 +169,9 @@
 		52B4933425DC60060096E75D /* LightLCLightOnOffStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4933325DC60060096E75D /* LightLCLightOnOffStatus.swift */; };
 		52B4933A25DC60F70096E75D /* LightLCLightOnOffSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4933925DC60F70096E75D /* LightLCLightOnOffSet.swift */; };
 		52B4934025DC61720096E75D /* LightLCLightOnOffSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4933F25DC61720096E75D /* LightLCLightOnOffSetUnacknowledged.swift */; };
+		52DE3A9E25D5640900268D7D /* SensorDescriptorGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */; };
+		52DE3AA425D5649400268D7D /* SensorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3AA325D5649400268D7D /* SensorMessage.swift */; };
+		52DE3AAA25D6A2CA00268D7D /* SensorDescriptorStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */; };
 		5419D23A75236616FD9003BFEAB0A196 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C21C8E900A0E68E2325ECFEC2E7B92 /* Digest.swift */; };
 		543740C6C31D3637343F37FA099E11BD /* AEADChaCha20Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30CC9F96E86F25A65521BCC123D5014 /* AEADChaCha20Poly1305.swift */; };
 		54CA4CC2D9DDD32F559FEFE36DB31914 /* NoPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC17DD2135B8E43A2EBE41EE0F6DDB19 /* NoPadding.swift */; };
@@ -628,9 +632,10 @@
 		5215998C25E8E85100F602FA /* SensorColumnStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorColumnStatus.swift; sourceTree = "<group>"; };
 		5215999225E8EC8F00F602FA /* SensorSeriesGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSeriesGet.swift; sourceTree = "<group>"; };
 		5215999825E8EDA800F602FA /* SensorSeriesStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorSeriesStatus.swift; sourceTree = "<group>"; };
-		52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SensorDescriptorGet.swift; sourceTree = "<group>"; };
-		52DE3AA325D5649400268D7D /* SensorMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorMessage.swift; sourceTree = "<group>"; };
-		52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorDescriptorStatus.swift; sourceTree = "<group>"; };
+		521599B825E8FD3100F602FA /* LightLCPropertyGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCPropertyGet.swift; sourceTree = "<group>"; };
+		521599BE25E8FDE400F602FA /* LightLCPropertyStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCPropertyStatus.swift; sourceTree = "<group>"; };
+		521599C425E8FF4700F602FA /* LightLCPropertySetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCPropertySetUnacknowledged.swift; sourceTree = "<group>"; };
+		521599CA25E8FF9D00F602FA /* LightLCPropertySet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCPropertySet.swift; sourceTree = "<group>"; };
 		52B492FD25DC56130096E75D /* LightLCModeGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCModeGet.swift; sourceTree = "<group>"; };
 		52B4930325DC57BA0096E75D /* LightLCModeStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCModeStatus.swift; sourceTree = "<group>"; };
 		52B4930925DC5AE30096E75D /* LightLCModeSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCModeSet.swift; sourceTree = "<group>"; };
@@ -643,6 +648,9 @@
 		52B4933325DC60060096E75D /* LightLCLightOnOffStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCLightOnOffStatus.swift; sourceTree = "<group>"; };
 		52B4933925DC60F70096E75D /* LightLCLightOnOffSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCLightOnOffSet.swift; sourceTree = "<group>"; };
 		52B4933F25DC61720096E75D /* LightLCLightOnOffSetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCLightOnOffSetUnacknowledged.swift; sourceTree = "<group>"; };
+		52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SensorDescriptorGet.swift; sourceTree = "<group>"; };
+		52DE3AA325D5649400268D7D /* SensorMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorMessage.swift; sourceTree = "<group>"; };
+		52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorDescriptorStatus.swift; sourceTree = "<group>"; };
 		531B9F2EF263CE4EA7065194384BE25F /* MeshStateManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MeshStateManager.swift; sourceTree = "<group>"; };
 		538806EF44671C282F414D17398F37EA /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		544BD2258E957BEB4A4E579D0107AF32 /* Provisioner+Node.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Provisioner+Node.swift"; sourceTree = "<group>"; };
@@ -1586,6 +1594,10 @@
 				52B4933925DC60F70096E75D /* LightLCLightOnOffSet.swift */,
 				52B4933F25DC61720096E75D /* LightLCLightOnOffSetUnacknowledged.swift */,
 				52B4933325DC60060096E75D /* LightLCLightOnOffStatus.swift */,
+				521599B825E8FD3100F602FA /* LightLCPropertyGet.swift */,
+				521599CA25E8FF9D00F602FA /* LightLCPropertySet.swift */,
+				521599C425E8FF4700F602FA /* LightLCPropertySetUnacknowledged.swift */,
+				521599BE25E8FDE400F602FA /* LightLCPropertyStatus.swift */,
 				D4D05ECB7CCB14F810CDEA019EBF4CB9 /* LightLightnessDefaultGet.swift */,
 				CF1EBD6989C65FAEB9EECE42CB3CFAB3 /* LightLightnessDefaultSet.swift */,
 				4C73DC3777C8924006546A7F137543A5 /* LightLightnessDefaultSetUnacknowledged.swift */,
@@ -2279,6 +2291,7 @@
 				5C7FA345C4F4A3C7A5753E27F29A2F96 /* MeshNetwork+Scenes.swift in Sources */,
 				C71AF6E6373A791020F1C2A86891370E /* MeshNetwork.swift in Sources */,
 				6E15FB31D53D45258BCA2AB6FE2F0617 /* MeshNetworkDelegate.swift in Sources */,
+				521599C525E8FF4700F602FA /* LightLCPropertySetUnacknowledged.swift in Sources */,
 				C4E0B4FA88E6DF5BB57B7E0AF8E7006D /* MeshNetworkError.swift in Sources */,
 				F2DE17B8EB7880679E34405066FA0426 /* MeshNetworkManager.swift in Sources */,
 				8E85B694EDCFE904A3D9F79776A1C826 /* MeshNodeEntry.swift in Sources */,
@@ -2293,6 +2306,7 @@
 				52B4930425DC57BA0096E75D /* LightLCModeStatus.swift in Sources */,
 				3F2E21E0DBFBF8F577236EFDCF134795 /* Models.swift in Sources */,
 				95C027BBBEBE1059A1B68A0DC0166CB3 /* NetworkKey+MeshNetwork.swift in Sources */,
+				521599BF25E8FDE400F602FA /* LightLCPropertyStatus.swift in Sources */,
 				656982986010F987C5938616EA2AB546 /* NetworkKey.swift in Sources */,
 				C3711CCE75C0EBB72934DFA9D5FE6B76 /* NetworkKeys.swift in Sources */,
 				47F90A54905C73CD1FB109B916EDFAD4 /* NetworkLayer.swift in Sources */,
@@ -2312,6 +2326,7 @@
 				A48D6A829A7E784AF51EFE0C42C1E1ED /* OnPowerUp.swift in Sources */,
 				ED738CDD3E4F2E9F720EB1C47D692117 /* Oob.swift in Sources */,
 				3A49FCF5D38399C1DF412CCEE1E0DDD1 /* OptionSet+Data.swift in Sources */,
+				521599CB25E8FF9D00F602FA /* LightLCPropertySet.swift in Sources */,
 				766C89EBE0BFFCB03EAA3B6E3EC25A91 /* PBGattBearer.swift in Sources */,
 				5E3FF4C65D9E740D044B817043731E4A /* Provisioner+Node.swift in Sources */,
 				CD41B5A67A7F8D15DADED37DF6BB52EF /* Provisioner+Ranges.swift in Sources */,
@@ -2355,6 +2370,7 @@
 				1ECE9A8535C61217B9152DF0213E7E8F /* SegmentedControlMessage.swift in Sources */,
 				328E57F14D3517AC451DAB9E311E098B /* SegmentedMessage.swift in Sources */,
 				68964BB1E2A9B9D6BFF0C94F2893AA7E /* SetFilterType.swift in Sources */,
+				521599B925E8FD3100F602FA /* LightLCPropertyGet.swift in Sources */,
 				7667056B878D1639F066D663211420AF /* StepResolution.swift in Sources */,
 				97568653B92D163EA7A18B64585FBD17 /* Storage.swift in Sources */,
 				19A5DD8043D0A928C9DE4EB017B2F2E1 /* TransitionTime.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -156,6 +156,10 @@
 		52DE3A9E25D5640900268D7D /* SensorDescriptorGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */; };
 		52DE3AA425D5649400268D7D /* SensorMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3AA325D5649400268D7D /* SensorMessage.swift */; };
 		52DE3AAA25D6A2CA00268D7D /* SensorDescriptorStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */; };
+		52B492FE25DC56130096E75D /* LightLCModeGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B492FD25DC56130096E75D /* LightLCModeGet.swift */; };
+		52B4930425DC57BA0096E75D /* LightLCModeStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4930325DC57BA0096E75D /* LightLCModeStatus.swift */; };
+		52B4930A25DC5AE30096E75D /* LightLCModeSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4930925DC5AE30096E75D /* LightLCModeSet.swift */; };
+		52B4931025DC5B380096E75D /* LightLCModeSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B4930F25DC5B380096E75D /* LightLCModeSetUnacknowledged.swift */; };
 		5419D23A75236616FD9003BFEAB0A196 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C21C8E900A0E68E2325ECFEC2E7B92 /* Digest.swift */; };
 		543740C6C31D3637343F37FA099E11BD /* AEADChaCha20Poly1305.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30CC9F96E86F25A65521BCC123D5014 /* AEADChaCha20Poly1305.swift */; };
 		54CA4CC2D9DDD32F559FEFE36DB31914 /* NoPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC17DD2135B8E43A2EBE41EE0F6DDB19 /* NoPadding.swift */; };
@@ -619,6 +623,10 @@
 		52DE3A9425D563F100268D7D /* SensorDescriptorGet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SensorDescriptorGet.swift; sourceTree = "<group>"; };
 		52DE3AA325D5649400268D7D /* SensorMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorMessage.swift; sourceTree = "<group>"; };
 		52DE3AA925D6A2CA00268D7D /* SensorDescriptorStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SensorDescriptorStatus.swift; sourceTree = "<group>"; };
+		52B492FD25DC56130096E75D /* LightLCModeGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCModeGet.swift; sourceTree = "<group>"; };
+		52B4930325DC57BA0096E75D /* LightLCModeStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCModeStatus.swift; sourceTree = "<group>"; };
+		52B4930925DC5AE30096E75D /* LightLCModeSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCModeSet.swift; sourceTree = "<group>"; };
+		52B4930F25DC5B380096E75D /* LightLCModeSetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCModeSetUnacknowledged.swift; sourceTree = "<group>"; };
 		531B9F2EF263CE4EA7065194384BE25F /* MeshStateManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MeshStateManager.swift; sourceTree = "<group>"; };
 		538806EF44671C282F414D17398F37EA /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		544BD2258E957BEB4A4E579D0107AF32 /* Provisioner+Node.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Provisioner+Node.swift"; sourceTree = "<group>"; };
@@ -1550,6 +1558,10 @@
 				BC9D7E94DDDEF59CDEFF831AA3A5C3BD /* LightHSLStatus.swift */,
 				D94C5284E6D9EA6752785852ABBB1A12 /* LightHSLTargetGet.swift */,
 				3A912DE5CF9125EFB8CC259380FCB405 /* LightHSLTargetStatus.swift */,
+				52B492FD25DC56130096E75D /* LightLCModeGet.swift */,
+				52B4930925DC5AE30096E75D /* LightLCModeSet.swift */,
+				52B4930F25DC5B380096E75D /* LightLCModeSetUnacknowledged.swift */,
+				52B4930325DC57BA0096E75D /* LightLCModeStatus.swift */,
 				D4D05ECB7CCB14F810CDEA019EBF4CB9 /* LightLightnessDefaultGet.swift */,
 				CF1EBD6989C65FAEB9EECE42CB3CFAB3 /* LightLightnessDefaultSet.swift */,
 				4C73DC3777C8924006546A7F137543A5 /* LightLightnessDefaultSetUnacknowledged.swift */,
@@ -2118,6 +2130,7 @@
 				25C53DED41C66A4C7F0B1EA616A177CF /* GenericOnOffGet.swift in Sources */,
 				F4246095247A200CD046E4F870B9F2FE /* GenericOnOffSet.swift in Sources */,
 				E7038DB76E7E116D4087010E175709F4 /* GenericOnOffSetUnacknowledged.swift in Sources */,
+				52B492FE25DC56130096E75D /* LightLCModeGet.swift in Sources */,
 				DE2CDD9360AD4BEC8D4D81A71355951E /* GenericOnOffStatus.swift in Sources */,
 				CC4E565C2ADB9F9991C11055F48C3893 /* GenericOnPowerUpGet.swift in Sources */,
 				783B4600D0619E3C51F213F67F1A950C /* GenericOnPowerUpSet.swift in Sources */,
@@ -2196,6 +2209,7 @@
 				5215999325E8EC8F00F602FA /* SensorSeriesGet.swift in Sources */,
 				E9C07D36EF99C54022E52EA2E8E2800A /* LightLightnessDefaultSet.swift in Sources */,
 				B0631254516BB821ABD87674AA001CD9 /* LightLightnessDefaultSetUnacknowledged.swift in Sources */,
+				52B4931025DC5B380096E75D /* LightLCModeSetUnacknowledged.swift in Sources */,
 				561D6EBBC0C06FAE63B50A2AEC353311 /* LightLightnessDefaultStatus.swift in Sources */,
 				5215995B25DFD2D800F602FA /* SensorSettingSetUnacknowledged.swift in Sources */,
 				E440419447C210C4ECB029D8929E9227 /* LightLightnessGet.swift in Sources */,
@@ -2245,6 +2259,7 @@
 				5E41762BB0DDDDACD39E28EDD2A37469 /* Model+Name.swift in Sources */,
 				16E1B268BF2C664E88016F6254576406 /* Model.swift in Sources */,
 				C06226B02D760ECB67F8A433725D367C /* ModelDelegate.swift in Sources */,
+				52B4930425DC57BA0096E75D /* LightLCModeStatus.swift in Sources */,
 				3F2E21E0DBFBF8F577236EFDCF134795 /* Models.swift in Sources */,
 				95C027BBBEBE1059A1B68A0DC0166CB3 /* NetworkKey+MeshNetwork.swift in Sources */,
 				656982986010F987C5938616EA2AB546 /* NetworkKey.swift in Sources */,
@@ -2298,6 +2313,7 @@
 				DA57BB74261C0D63A3C0CF20FB139268 /* SceneRegisterStatus.swift in Sources */,
 				EF49235553B6EF2084258BD63DAAE137 /* Scenes.swift in Sources */,
 				F87EFDBBD04E6AF0F707B3C0F2F45630 /* SceneStatus.swift in Sources */,
+				52B4930A25DC5AE30096E75D /* LightLCModeSet.swift in Sources */,
 				26CE300177DB045792646F6E2BD58C1C /* SceneStore.swift in Sources */,
 				A2773248FCA9320E089F0D2B2C7E872F /* SceneStoreUnacknowledged.swift in Sources */,
 				D5C1560CE9D61908C87419B6CC6C74FC /* SecureNetworkBeacon.swift in Sources */,

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightHSLTargetGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightHSLTargetGet.swift
@@ -48,5 +48,4 @@ public struct LightHSLTargetGet: AcknowledgedGenericMessage {
         }
     }
     
-    
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCLightOnOffGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCLightOnOffGet.swift
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCLightOnOffGet: AcknowledgedGenericMessage {
+    public static let opCode: UInt32 = 0x8299
+    public static let responseType: StaticMeshMessage.Type = LightLCLightOnOffStatus.self
+    
+    public var parameters: Data? {
+        return nil
+    }
+    
+    public init() {
+        // Empty
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.isEmpty else {
+            return nil
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCLightOnOffSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCLightOnOffSet.swift
@@ -1,0 +1,90 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCLightOnOffSet: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+    public static let opCode: UInt32 = 0x829A
+    public static let responseType: StaticMeshMessage.Type = LightLCLightOnOffStatus.self
+    
+    public var tid: UInt8!
+    public var parameters: Data? {
+        let data = Data([isOn ? 0x01 : 0x00, tid])
+        if let transitionTime = transitionTime, let delay = delay {
+            return data + transitionTime.rawValue + delay
+        } else {
+            return data
+        }
+    }
+    
+    /// The target value of the Light LC Light OnOff state.
+    public let isOn: Bool
+    
+    public let transitionTime: TransitionTime?
+    public let delay: UInt8?
+    
+    /// Creates the Light LC Light OnOff Set message.
+    ///
+    /// - parameter isOn: The target value of the Light LC Light OnOff state.
+    public init(_ isOn: Bool) {
+        self.isOn = isOn
+        self.transitionTime = nil
+        self.delay = nil
+    }
+    
+    /// Creates the Light LC Light OnOff Set message.
+    ///
+    /// - parameters:
+    ///   - isOn: The target value of the Light LC Light OnOff state.
+    ///   - transitionTime: The time that an element will take to transition
+    ///                     to the target state from the present state.
+    ///   - delay: Message execution delay in 5 millisecond steps.
+    public init(_ isOn: Bool, transitionTime: TransitionTime, delay: UInt8) {
+        self.isOn = isOn
+        self.transitionTime = transitionTime
+        self.delay = delay
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 2 || parameters.count == 4 else {
+            return nil
+        }
+        isOn = parameters[0] == 0x01
+        tid = parameters[1]
+        if parameters.count == 4 {
+            transitionTime = TransitionTime(rawValue: parameters[2])
+            delay = parameters[3]
+        } else {
+            transitionTime = nil
+            delay = nil
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCLightOnOffSetUnacknowledged.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCLightOnOffSetUnacknowledged.swift
@@ -1,0 +1,89 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCLightOnOffSetUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+    public static let opCode: UInt32 = 0x829B
+    
+    public var tid: UInt8!
+    public var parameters: Data? {
+        let data = Data([isOn ? 0x01 : 0x00, tid])
+        if let transitionTime = transitionTime, let delay = delay {
+            return data + transitionTime.rawValue + delay
+        } else {
+            return data
+        }
+    }
+    
+    /// The target value of the Light LC Light OnOff state.
+    public let isOn: Bool
+    
+    public let transitionTime: TransitionTime?
+    public let delay: UInt8?
+    
+    /// Creates the Light LC Light OnOff Set Unacknowledged message.
+    ///
+    /// - parameter isOn: The target value of the Light LC Light OnOff state.
+    public init(_ isOn: Bool) {
+        self.isOn = isOn
+        self.transitionTime = nil
+        self.delay = nil
+    }
+    
+    /// Creates the Light LC Light OnOff Set Unacknowledged message.
+    ///
+    /// - parameters:
+    ///   - isOn: The target value of the Light LC Light OnOff state.
+    ///   - transitionTime: The time that an element will take to transition
+    ///                     to the target state from the present state.
+    ///   - delay: Message execution delay in 5 millisecond steps.
+    public init(_ isOn: Bool, transitionTime: TransitionTime, delay: UInt8) {
+        self.isOn = isOn
+        self.transitionTime = transitionTime
+        self.delay = delay
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 2 || parameters.count == 4 else {
+            return nil
+        }
+        isOn = parameters[0] == 0x01
+        tid = parameters[1]
+        if parameters.count == 4 {
+            transitionTime = TransitionTime(rawValue: parameters[2])
+            delay = parameters[3]
+        } else {
+            transitionTime = nil
+            delay = nil
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCLightOnOffStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCLightOnOffStatus.swift
@@ -1,0 +1,87 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCLightOnOffStatus: GenericMessage, TransitionStatusMessage {
+    public static var opCode: UInt32 = 0x829C
+    
+    public var parameters: Data? {
+        let data = Data([isOn ? 0x01 : 0x00])
+        if let targetState = targetState, let remainingTime = remainingTime {
+            return data + UInt8(targetState ? 0x01 : 0x00) + remainingTime.rawValue
+        } else {
+            return data
+        }
+    }
+    
+    /// The present value of the Light LC Light OnOff state.
+    public let isOn: Bool
+    /// The target value of the Light LC Light OnOff state.
+    public let targetState: Bool?
+    
+    public let remainingTime: TransitionTime?
+    
+    /// Creates the Light LC Light OnOff Status message.
+    ///
+    /// - parameter isOn: The present value of the Light LC Light OnOff state.
+    public init(_ isOn: Bool) {
+        self.isOn = isOn
+        self.targetState = nil
+        self.remainingTime = nil
+    }
+    
+    /// Creates the Light LC Light OnOff Status message.
+    ///
+    /// - parameters:
+    ///   - isOn: The present value of the Light LC Light OnOff state.
+    ///   - targetState: The target value of the Light LC Light OnOff state.
+    ///   - remainingTime: The time that an element will take to transition
+    ///                    to the target state from the present state.
+    public init(_ isOn: Bool, targetState: Bool, remainingTime: TransitionTime) {
+        self.isOn = isOn
+        self.targetState = targetState
+        self.remainingTime = remainingTime
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 1 || parameters.count == 3 else {
+            return nil
+        }
+        isOn = parameters[0] == 0x01
+        if parameters.count == 3 {
+            targetState = parameters[1] == 0x01
+            remainingTime = TransitionTime(rawValue: parameters[2])
+        } else {
+            targetState = nil
+            remainingTime = nil
+        }
+    }
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeGet.swift
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCModeGet: AcknowledgedGenericMessage {
+    public static let opCode: UInt32 = 0x8291
+    public static let responseType: StaticMeshMessage.Type = LightLCModeStatus.self
+    
+    public var parameters: Data? {
+        return nil
+    }
+    
+    public init() {
+        // Empty
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.isEmpty else {
+            return nil
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeSet.swift
@@ -53,10 +53,7 @@ public struct LightLCModeSet: AcknowledgedGenericMessage {
         guard parameters.count == 1 else {
             return nil
         }
-        guard parameters[0] == 0 || parameters[0] == 1 else {
-            return nil
-        }
-        self.controllerStatus == parameters[0] == 1
+        self.controllerStatus = parameters[0] == 0x01
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeSet.swift
@@ -1,0 +1,62 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCModeSet: AcknowledgedGenericMessage {
+    public static let opCode: UInt32 = 0x8292
+    public static let responseType: StaticMeshMessage.Type = LightLCModeStatus.self
+    
+    /// Whether the controller is turned on and the binding with the Light Lightness
+    /// state is enabled.
+    let controllerStatus: Bool
+    
+    public var parameters: Data? {
+        return Data() + controllerStatus
+    }
+    
+    /// Creates the Light LC Mode Set message.
+    ///
+    /// - parameter status: The present value of the Light LC Mode state.
+    public init(_ status: Bool) {
+        self.controllerStatus = status
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        guard parameters[0] == 0 || parameters[0] == 1 else {
+            return nil
+        }
+        self.controllerStatus == parameters[0] == 1
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeSetUnacknowledged.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeSetUnacknowledged.swift
@@ -1,0 +1,61 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCModeSetUnacknowledged: GenericMessage {
+    public static let opCode: UInt32 = 0x8293
+    
+    /// Whether the controller is turned on and the binding with the Light Lightness
+    /// state is enabled.
+    let controllerStatus: Bool
+    
+    public var parameters: Data? {
+        return Data() + controllerStatus
+    }
+    
+    /// Creates the Light LC Mode Set Unacknowledged message.
+    ///
+    /// - parameter status: The present value of the Light LC Mode state.
+    public init(_ status: Bool) {
+        self.controllerStatus = status
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        guard parameters[0] == 0 || parameters[0] == 1 else {
+            return nil
+        }
+        self.controllerStatus == parameters[0] == 1
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeSetUnacknowledged.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeSetUnacknowledged.swift
@@ -52,10 +52,7 @@ public struct LightLCModeSetUnacknowledged: GenericMessage {
         guard parameters.count == 1 else {
             return nil
         }
-        guard parameters[0] == 0 || parameters[0] == 1 else {
-            return nil
-        }
-        self.controllerStatus == parameters[0] == 1
+        self.controllerStatus = parameters[0] == 0x01
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeStatus.swift
@@ -1,0 +1,61 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCModeStatus: GenericMessage {
+    public static let opCode: UInt32 = 0x8294
+    
+    /// Whether the controller is turned on and the binding with the Light Lightness
+    /// state is enabled.
+    let controllerStatus: Bool
+    
+    public var parameters: Data? {
+        return Data() + controllerStatus
+    }
+    
+    /// Creates the Light LC Mode Status message.
+    ///
+    /// - parameter status: The present value of the Light LC Mode state.
+    public init(_ status: Bool) {
+        self.controllerStatus = status
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        guard parameters[0] == 0 || parameters[0] == 1 else {
+            return nil
+        }
+        self.controllerStatus == parameters[0] == 1
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeStatus.swift
@@ -52,10 +52,7 @@ public struct LightLCModeStatus: GenericMessage {
         guard parameters.count == 1 else {
             return nil
         }
-        guard parameters[0] == 0 || parameters[0] == 1 else {
-            return nil
-        }
-        self.controllerStatus == parameters[0] == 1
+        self.controllerStatus = parameters[0] == 0x01
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeGet.swift
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCOccupancyModeGet: AcknowledgedGenericMessage {
+    public static let opCode: UInt32 = 0x8295
+    public static let responseType: StaticMeshMessage.Type = LightLCOccupancyModeStatus.self
+    
+    public var parameters: Data? {
+        return nil
+    }
+    
+    public init() {
+        // Empty
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.isEmpty else {
+            return nil
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeSet.swift
@@ -1,0 +1,62 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCOccupancyModeSet: AcknowledgedGenericMessage {
+    public static let opCode: UInt32 = 0x8296
+    public static let responseType: StaticMeshMessage.Type = LightLCOccupancyModeStatus.self
+    
+    /// Whether the controller may transition from a standby state when occupancy
+    /// is reported.
+    let occupancyMode: Bool
+    
+    public var parameters: Data? {
+        return Data() + occupancyMode
+    }
+    
+    /// Creates the Light LC Occupancy Mode Set Unacknowledged message.
+    ///
+    /// - parameter mode: The present value of the Light LC Occupancy Mode state.
+    public init(_ mode: Bool) {
+        self.occupancyMode = status
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        guard parameters[0] == 0 || parameters[0] == 1 else {
+            return nil
+        }
+        self.occupancyMode == parameters[0] == 1
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeSet.swift
@@ -46,17 +46,14 @@ public struct LightLCOccupancyModeSet: AcknowledgedGenericMessage {
     ///
     /// - parameter mode: The present value of the Light LC Occupancy Mode state.
     public init(_ mode: Bool) {
-        self.occupancyMode = status
+        self.occupancyMode = mode
     }
     
     public init?(parameters: Data) {
         guard parameters.count == 1 else {
             return nil
         }
-        guard parameters[0] == 0 || parameters[0] == 1 else {
-            return nil
-        }
-        self.occupancyMode == parameters[0] == 1
+        self.occupancyMode = parameters[0] == 0x01
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeSetUnacknowledged.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeSetUnacknowledged.swift
@@ -45,17 +45,14 @@ public struct LightLCOccupancyModeSetUnacknowledged: GenericMessage {
     ///
     /// - parameter mode: The present value of the Light LC Occupancy Mode state.
     public init(_ mode: Bool) {
-        self.occupancyMode = status
+        self.occupancyMode = mode
     }
     
     public init?(parameters: Data) {
         guard parameters.count == 1 else {
             return nil
         }
-        guard parameters[0] == 0 || parameters[0] == 1 else {
-            return nil
-        }
-        self.occupancyMode == parameters[0] == 1
+        self.occupancyMode = parameters[0] == 0x01
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeSetUnacknowledged.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeSetUnacknowledged.swift
@@ -1,0 +1,61 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCOccupancyModeSetUnacknowledged: GenericMessage {
+    public static let opCode: UInt32 = 0x8297
+    
+    /// Whether the controller may transition from a standby state when occupancy
+    /// is reported.
+    let occupancyMode: Bool
+    
+    public var parameters: Data? {
+        return Data() + occupancyMode
+    }
+    
+    /// Creates the Light LC Occupancy Mode Set Unacknowledged message.
+    ///
+    /// - parameter mode: The present value of the Light LC Occupancy Mode state.
+    public init(_ mode: Bool) {
+        self.occupancyMode = status
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        guard parameters[0] == 0 || parameters[0] == 1 else {
+            return nil
+        }
+        self.occupancyMode == parameters[0] == 1
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeStatus.swift
@@ -1,0 +1,61 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCOccupancyModeStatus: GenericMessage {
+    public static let opCode: UInt32 = 0x8298
+    
+    /// Whether the controller may transition from a standby state when occupancy
+    /// is reported.
+    let occupancyMode: Bool
+    
+    public var parameters: Data? {
+        return Data() + occupancyMode
+    }
+    
+    /// Creates the Light LC Occupancy Mode Status message.
+    ///
+    /// - parameter mode: The present value of the Light LC Occupancy Mode state.
+    public init(_ mode: Bool) {
+        self.occupancyMode = status
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        guard parameters[0] == 0 || parameters[0] == 1 else {
+            return nil
+        }
+        self.occupancyMode == parameters[0] == 1
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeStatus.swift
@@ -45,17 +45,14 @@ public struct LightLCOccupancyModeStatus: GenericMessage {
     ///
     /// - parameter mode: The present value of the Light LC Occupancy Mode state.
     public init(_ mode: Bool) {
-        self.occupancyMode = status
+        self.occupancyMode = mode
     }
     
     public init?(parameters: Data) {
         guard parameters.count == 1 else {
             return nil
         }
-        guard parameters[0] == 0 || parameters[0] == 1 else {
-            return nil
-        }
-        self.occupancyMode == parameters[0] == 1
+        self.occupancyMode = parameters[0] == 0x01
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCPropertyGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCPropertyGet.swift
@@ -1,0 +1,55 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCPropertyGet: AcknowledgedSensorPropertyMessage {
+    public static let opCode: UInt32 = 0x829D
+    public static let responseType: StaticMeshMessage.Type = LightLCPropertyStatus.self
+    
+    public let property: DeviceProperty
+    
+    public var parameters: Data? {
+        return Data() + property.id
+    }
+    
+    public init(_ property: DeviceProperty) {
+        self.property = property
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 2 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        self.property = DeviceProperty(propertyId)
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCPropertySet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCPropertySet.swift
@@ -1,0 +1,64 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCPropertySet: AcknowledgedSensorPropertyMessage {
+    public static let opCode: UInt32 = 0x62
+    public static let responseType: StaticMeshMessage.Type = LightLCPropertyStatus.self
+    
+    public let property: DeviceProperty
+    /// Value of the Light LC Property.
+    public let propertyValue: DevicePropertyCharacteristic
+    
+    public var parameters: Data? {
+        return Data() + property.id + propertyValue.data
+    }
+    
+    /// Creates a Light LC Property Set message.
+    ///
+    /// - parameters:
+    ///   - property: The Light LC Property.
+    ///   - value: The new value of the property.
+    public init(of property: DeviceProperty, value: DevicePropertyCharacteristic) {
+        self.property = property
+        self.propertyValue = value
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count >= 2 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        self.property = DeviceProperty(propertyId)
+        self.propertyValue = property.read(from: parameters, at: 2, length: parameters.count - 2)
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCPropertySetUnacknowledged.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCPropertySetUnacknowledged.swift
@@ -1,0 +1,63 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCPropertySetUnacknowledged: SensorPropertyMessage {
+    public static let opCode: UInt32 = 0x63
+    
+    public let property: DeviceProperty
+    /// Value of the Light LC Property.
+    public let propertyValue: DevicePropertyCharacteristic
+    
+    public var parameters: Data? {
+        return Data() + property.id + propertyValue.data
+    }
+    
+    /// Creates a Light LC Property Set Unacknowledged message.
+    ///
+    /// - parameters:
+    ///   - property: The Light LC Property.
+    ///   - value: The new value of the property.
+    public init(of property: DeviceProperty, value: DevicePropertyCharacteristic) {
+        self.property = property
+        self.propertyValue = value
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count >= 2 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        self.property = DeviceProperty(propertyId)
+        self.propertyValue = property.read(from: parameters, at: 2, length: parameters.count - 2)
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCPropertyStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCPropertyStatus.swift
@@ -1,0 +1,63 @@
+/*
+* Copyright (c) 2021, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct LightLCPropertyStatus: SensorPropertyMessage {
+    public static let opCode: UInt32 = 0x64
+    
+    public let property: DeviceProperty
+    /// Value of the Light LC Property.
+    public let propertyValue: DevicePropertyCharacteristic
+    
+    public var parameters: Data? {
+        return Data() + property.id + propertyValue.data
+    }
+    
+    /// Creates a Light LC Property Status message.
+    ///
+    /// - parameters:
+    ///   - property: The Light LC Property.
+    ///   - value: The value of the property.
+    public init(of property: DeviceProperty, value: DevicePropertyCharacteristic) {
+        self.property = property
+        self.propertyValue = value
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count >= 2 else {
+            return nil
+        }
+        let propertyId: UInt16 = parameters.read(fromOffset: 0)
+        self.property = DeviceProperty(propertyId)
+        self.propertyValue = property.read(from: parameters, at: 2, length: parameters.count - 2)
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Type Extensions/Data.swift
+++ b/nRFMeshProvision/Classes/Type Extensions/Data.swift
@@ -128,3 +128,15 @@ extension Data : DataConvertible {
     }
     
 }
+
+extension Bool : DataConvertible {
+    
+    static func + (lhs: Data, rhs: Bool) -> Data {
+        if rhs {
+            return lhs + UInt8(0x01)
+        } else {
+            return lhs + UInt8(0x00)
+        }
+    }
+    
+}


### PR DESCRIPTION
This PR adds support for Light LC and adds 16 new messages in 4 groups:
* Light LC Mode, 
* Light LC Occupancy, 
* Light LC Light OnOff,
* Light LC Property.

The last group takes advantage of `DeviceProperty` type created in #327 and should only be used with Light LC Properties.