### PR TITLE
Fix: validation failure if database contains 10m publish resolution

### DIFF
--- a/nRFMeshProvision/Classes/Mesh Model/Publish.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Publish.swift
@@ -479,7 +479,7 @@ private extension Publish.Period {
             // If resolution or steps were set to 0, set resolution to
             // hundreds of milliseconds.
             return 100
-        case 100, 1000, 10000, 60000:
+        case 100, 1000, 10000, 600000:
             // Those are the valid values. Keep it as it is.
             return milliseconds
         case _ where milliseconds % Int(steps) == 0:


### PR DESCRIPTION
The nRF Mesh App will fail to validate database files containing models using a 10 minute publication resolution. This is a fairly serious issue, as the default behavior is to delete the database (in the case of a saved database) after a validation failure. Issue occurs on app startup – for example, after a device power cycle – or during import.

This pull request adds an all-important missing 0 to the problematic statement.