### PR TITLE
Run incomplete segment timers on lower transport layer thread

### DIFF
--- a/nRFMeshProvision/Classes/Layers/Lower Transport Layer/LowerTransportLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Lower Transport Layer/LowerTransportLayer.swift
@@ -457,8 +457,8 @@ private extension LowerTransportLayer {
                 // timer is active, the timer shall be restarted.
                 incompleteTimers[key]?.invalidate()
                 incompleteTimers[key] = BackgroundTimer.scheduledTimer(
-                                            withTimeInterval: networkManager.incompleteMessageTimeout,
-                                            repeats: false) { [weak self] _ in
+                    withTimeInterval: networkManager.incompleteMessageTimeout, repeats: false, queue: self.mutex
+                ) { [weak self] _ in
                     guard let self = self else { return }
                     if let segments = self.incompleteSegments.removeValue(forKey: key) {
                         var marks: UInt32 = 0
@@ -479,8 +479,9 @@ private extension LowerTransportLayer {
                 if acknowledgmentTimers[key] == nil {
                     let ttl = provisionerNode.defaultTTL ?? networkManager.defaultTtl
                     let interval = networkManager.acknowledgmentTimerInterval(ttl)
-                    acknowledgmentTimers[key] = BackgroundTimer.scheduledTimer(withTimeInterval: interval,
-                                                                               repeats: false) { [weak self] _ in
+                    acknowledgmentTimers[key] = BackgroundTimer.scheduledTimer(
+                        withTimeInterval: interval, repeats: false, queue: self.mutex
+                    ) { [weak self] _ in
                         guard let self = self else { return }
                         if let segments = self.incompleteSegments[key] {
                             let ttl = networkPdu.ttl > 0 ? ttl : 0

--- a/nRFMeshProvision/Classes/Utils/BackgroundTimer.swift
+++ b/nRFMeshProvision/Classes/Utils/BackgroundTimer.swift
@@ -39,16 +39,17 @@ internal class BackgroundTimer {
     /// Schedules a timer that can be started from a background DispatchQueue.
     @discardableResult
     static func scheduledTimer(withTimeInterval interval: TimeInterval, repeats: Bool,
+                               queue: DispatchQueue = DispatchQueue.global(qos: .background),
                                block: @escaping  (BackgroundTimer) -> Void) -> BackgroundTimer {
-        return BackgroundTimer(withTimeInterval: interval, repeats: repeats, block: block)
+        return BackgroundTimer(withTimeInterval: interval, repeats: repeats, queue: queue, block: block)
     }
     
     private init(withTimeInterval interval: TimeInterval, repeats: Bool,
-                 block: @escaping  (BackgroundTimer) -> Void) {
+                 queue: DispatchQueue, block: @escaping  (BackgroundTimer) -> Void) {
         self.interval = interval
         self.repeats = repeats
         
-        timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global(qos: .background))
+        timer = DispatchSource.makeTimerSource(queue: queue)
         timer.setEventHandler {
             block(self)
             if !repeats {


### PR DESCRIPTION
Ref https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/issues/350

* Allows a `BackgroundTimer` to accept a non-default queue argument.
* Uses the lower transport layer mutex when scheduling incomplete message and ack timers in the lower transport layer.