### PR TITLE
Bug fix: Possible crash when IV Index was 0 and IVI 1

### DIFF
--- a/nRFMeshProvision/Classes/Mesh Model/IvIndex.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/IvIndex.swift
@@ -58,7 +58,7 @@ internal struct IvIndex {
     /// - parameter ivi: The IVI bit of the received Network PDU.
     /// - returns: The IV Index to be used to decrypt the message.
     func index(for ivi: UInt8) -> UInt32 {
-        return ivi == index & 1 ? index : index - 1
+        return ivi == index & 1 ? index : max(1, index) - 1
     }
 }
 


### PR DESCRIPTION
This PR fixes a possible crash when a message was sent with IVI = 1 and IV Index was 0.