### PR TITLE
Bug fix: Strong self in closure causes crash.

### DIFF
--- a/nRFMeshProvision/Classes/Layers/Access Layer/AccessLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Access Layer/AccessLayer.swift
@@ -594,12 +594,14 @@ private extension AccessLayer {
         
         let ack = AcknowledgmentContext(for: request,
             sentFrom: pdu.source, to: pdu.destination.address,
-            repeatAfter: initialDelay, repeatBlock: {
+            repeatAfter: initialDelay, repeatBlock: { [weak self] in
+                guard let self = self else { return }
                 if !self.networkManager.upperTransportLayer.isReceivingResponse(from: pdu.destination.address) {
                     self.logger?.d(.access, "Resending \(pdu)")
                     self.networkManager.upperTransportLayer.send(pdu, withTtl: initialTtl, using: keySet)
                 }
-            }, timeout: timeout, timeoutBlock: {
+            }, timeout: timeout, timeoutBlock: { [weak self] in
+                guard let self = self else { return }
                 self.logger?.w(.access, "Response to \(pdu) not received (timeout)")
                 let category: LogCategory = request is AcknowledgedConfigMessage ? .foundationModel : .model
                 self.logger?.w(category, "\(request) sent from: \(pdu.source.hex), to: \(pdu.destination.hex) timed out")


### PR DESCRIPTION
Strong self reference in access layer closure causes crash when loading a different mesh while a message is scheduled for resending.