### PR TITLE
Select proxy filter

### DIFF
--- a/Example/nRFMeshProvision/View Controllers/Settings/Provisioners/ProvisionersViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Settings/Provisioners/ProvisionersViewController.swift
@@ -156,7 +156,7 @@ class ProvisionersViewController: UITableViewController, Editable {
             let previousLocalProvisioner = network.localProvisioner,
             previousLocalProvisioner.hasConfigurationCapabilities &&
             manager.proxyFilter?.type == .inclusionList {
-                manager.proxyFilter?.reset()
+                manager.proxyFilter?.resetIfInclusionList()
         }
         // Make the required change in the data source.
         network.moveProvisioner(fromIndex: fromIndex, toIndex: toIndex)
@@ -225,7 +225,7 @@ private extension ProvisionersViewController {
         // Exclusion filter must have been set up by the user, so don't
         // modify it.
         if indexPath.isThisProvisioner && manager.proxyFilter?.type == .inclusionList {
-            manager.proxyFilter?.reset()
+            manager.proxyFilter?.resetIfInclusionList()
         }
         
         // Remove the Provisioner and its Node from the network configuration.

--- a/nRFMeshProvision/Classes/MeshNetworkManager.swift
+++ b/nRFMeshProvision/Classes/MeshNetworkManager.swift
@@ -45,6 +45,7 @@ public class MeshNetworkManager {
     
     /// The Proxy Filter state.
     public internal(set) var proxyFilter: ProxyFilter?
+    public internal(set) var proxyFilterType: ProxyFilerType
     
     /// The logger delegate will be called whenever a new log entry is created.
     public weak var logger: LoggerDelegate?
@@ -172,11 +173,13 @@ public class MeshNetworkManager {
     /// - seeAlso: `LowerTransportLayer.checkAgainstReplayAttack(_:NetworkPdu)`
     public init(using storage: Storage = LocalStorage(),
                 queue: DispatchQueue = DispatchQueue.global(qos: .background),
-                delegateQueue: DispatchQueue = DispatchQueue.main) {
+                delegateQueue: DispatchQueue = DispatchQueue.main,
+								proxyFilterType: ProxyFilerType = .inclusionList) {
         self.storage = storage
         self.meshData = MeshData()
         self.queue = queue
         self.delegateQueue = delegateQueue
+        self.proxyFilterType = proxyFilterType
     }
     
     /// Initializes the Mesh Network Manager. It will use the `LocalStorage`
@@ -218,7 +221,8 @@ public extension MeshNetworkManager {
     /// - parameters:
     ///   - name:      The user given network name.
     ///   - provisioner: The default Provisioner.
-    func createNewMeshNetwork(withName name: String, by provisioner: Provisioner) -> MeshNetwork {
+	func createNewMeshNetwork(withName name: String,
+												    by provisioner: Provisioner) -> MeshNetwork {
         let network = MeshNetwork(name: name)
         
         // Add a new default provisioner.

--- a/nRFMeshProvision/Classes/ProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter.swift
@@ -143,7 +143,7 @@ public extension ProxyFilter {
     }
     
     /// Resets the filter to an empty inclusion list filter.
-    func reset() {
+    func resetIfInclusionList() {
 			if type == .inclusionList {
 				send(SetFilterType(.inclusionList))
 			}
@@ -377,7 +377,7 @@ internal extension ProxyFilter {
                 // switch to exclusion list filter.
                 if status.listSize == 1 {
                     logger?.w(.proxy, "Limited Proxy Filter detected.")
-                    reset()
+										resetIfInclusionList()
                     if let address = manager.meshNetwork?.localProvisioner?.unicastAddress {
                         mutex.sync {
                             addresses = [address]
@@ -390,7 +390,7 @@ internal extension ProxyFilter {
                 } else {
                     logger?.w(.proxy, "Refreshing Proxy Filter...")
                     let addresses = self.addresses // reset() will erase addresses, store it.
-                    reset()
+										resetIfInclusionList()
                     add(addresses: addresses)
                 }
                 return

--- a/nRFMeshProvision/Classes/ProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter.swift
@@ -115,7 +115,11 @@ public class ProxyFilter {
     /// The active Proxy Filter type.
     ///
     /// By default the Proxy Filter is set to `.inclusionList`.
-		public internal(set) var type: ProxyFilerType = .exclusionList
+	public internal(set) var type: ProxyFilerType = .exclusionList {
+		didSet {
+			print("DidSet: \(type)")
+		}
+	}
     
     /// The connected Proxy Node. This may be `nil` if the connected Node is unknown
     /// to the provisioner, that is if a Node with the proxy Unicast Address was not found

--- a/nRFMeshProvision/Classes/ProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter.swift
@@ -144,7 +144,9 @@ public extension ProxyFilter {
     
     /// Resets the filter to an empty inclusion list filter.
     func reset() {
-        send(SetFilterType(.inclusionList))
+			if type == .inclusionList {
+				send(SetFilterType(.inclusionList))
+			}
     }
     
     /// Clears the current filter.

--- a/nRFMeshProvision/Classes/ProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter.swift
@@ -115,7 +115,7 @@ public class ProxyFilter {
     /// The active Proxy Filter type.
     ///
     /// By default the Proxy Filter is set to `.inclusionList`.
-    public internal(set) var type: ProxyFilerType = .inclusionList
+		public internal(set) var type: ProxyFilerType = .exclusionList
     
     /// The connected Proxy Node. This may be `nil` if the connected Node is unknown
     /// to the provisioner, that is if a Node with the proxy Unicast Address was not found

--- a/nRFMeshProvision/Classes/ProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter.swift
@@ -280,6 +280,7 @@ internal extension ProxyFilter {
         proxyDidDisconnect()
         logger?.i(.proxy, "New Proxy connected")
         clear()
+				resetIfInclusionList()
         if let localProvisioner = manager.meshNetwork?.localProvisioner {
             setup(for: localProvisioner)
         }

--- a/nRFMeshProvision/Classes/ProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter.swift
@@ -115,11 +115,7 @@ public class ProxyFilter {
     /// The active Proxy Filter type.
     ///
     /// By default the Proxy Filter is set to `.inclusionList`.
-	public internal(set) var type: ProxyFilerType = .exclusionList {
-		didSet {
-			print("DidSet: \(type)")
-		}
-	}
+	public internal(set) var type: ProxyFilerType = .exclusionList
     
     /// The connected Proxy Node. This may be `nil` if the connected Node is unknown
     /// to the provisioner, that is if a Node with the proxy Unicast Address was not found
@@ -276,7 +272,7 @@ internal extension ProxyFilter {
     func newProxyDidConnect() {
         proxyDidDisconnect()
         logger?.i(.proxy, "New Proxy connected")
-        reset()
+        clear()
         if let localProvisioner = manager.meshNetwork?.localProvisioner {
             setup(for: localProvisioner)
         }


### PR DESCRIPTION
https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/issues/386
This PR allows setting the `ProxyFilter` at `MeshNetworkManager` init time as so:

```swift
MeshNetworkManager(proxyFilterType: .inclusionList)
```

The default is `.inclusionList`.

Tested on live devices and it seems to work as it should:
i.e when `.inclusionList` is selected it also adds the all Node's element's addresses and group address with at least one subscribed model, plus all nodes group address while is `.exclusionList` is selected it adds nothing.

It should also reset all of that on new connection if the type is inclusion list.

This is a draft, if accepted, should be squashed before merging...
