### PR TITLE
Allow custom proxyfilter implementations

### DIFF
--- a/nRFMeshProvision/Classes/Layers/Network Layer/NetworkLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/NetworkLayer.swift
@@ -446,8 +446,35 @@ private extension NetworkLayer {
 
 /// NetworkLayer passes network events for proxy settings directly to delegate.
 public protocol NetworkLayerProxyFilterDelegate {
+    /// Callback called when a possible change of Proxy Node have been discovered.
+    ///
+    /// This method is called in two cases: when the first Secure Network
+    /// beacon was received (which indicates the first successful connection
+    /// to a Proxy since app was started) or when the received Secure Network
+    /// beacon contained information about the same Network Key as one
+    /// received before. This happens during a reconnection to the same
+    /// or a different Proxy on the same subnetwork, but may also happen
+    /// in other Circumstances, for example when the IV Update or Key Refresh
+    /// Procedure is in progress, or a Network Key was removed and added again.
     func newProxyDidConnect()
+
+    /// Callback called when a Proxy Configuration Message has been sent.
+    ///
+    /// - parameter message: The message sent.
     func managerDidDeliverMessage(_ message: ProxyConfigurationMessage)
+
+    /// Callback called when the manager failed to send the Proxy
+    /// Configuration Message.
+    ///
+    /// - parameters:
+    ///   - message: The message that has not been sent.
+    ///   - error: The error received.
     func managerFailedToDeliverMessage(_ message: ProxyConfigurationMessage, error: Error)
+
+    /// Handler for the received Proxy Configuration Messages.
+    ///
+    /// - parameters:
+    ///   - message: The message received.
+    ///   - proxy: The connected Proxy Node, or `nil` if the Node is unknown.
     func handle(_ message: ProxyConfigurationMessage, sentFrom proxy: Node?)
 }

--- a/nRFMeshProvision/Classes/Layers/Network Layer/NetworkLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/NetworkLayer.swift
@@ -444,7 +444,8 @@ private extension NetworkLayer {
     
 }
 
-public protocol NetworkLayerProxyDelegate {
+/// NetworkLayer passes network events for proxy settings directly to delegate.
+public protocol NetworkLayerProxyFilterDelegate {
     func newProxyDidConnect()
     func managerDidDeliverMessage(_ message: ProxyConfigurationMessage)
     func managerFailedToDeliverMessage(_ message: ProxyConfigurationMessage, error: Error)

--- a/nRFMeshProvision/Classes/MeshNetworkManager.swift
+++ b/nRFMeshProvision/Classes/MeshNetworkManager.swift
@@ -38,7 +38,7 @@ public class MeshNetworkManager {
     /// Storage to keep the app data.
     private let storage: Storage
     /// ProxyFilter implementation to use
-    private let proxyFilterFactory: (MeshNetworkManager) -> (ProxyFilter & NetworkLayerProxyDelegate)?
+    private let proxyFilterFactory: (MeshNetworkManager) -> (ProxyFilter & NetworkLayerProxyFilterDelegate)?
     
     /// A queue to handle incoming and outgoing messages.
     internal let queue: DispatchQueue
@@ -46,7 +46,7 @@ public class MeshNetworkManager {
     internal let delegateQueue: DispatchQueue
     
     /// The Proxy Filter state.
-    internal var proxyFilterAndDelegate: (ProxyFilter & NetworkLayerProxyDelegate)?
+    internal var proxyFilterAndDelegate: (ProxyFilter & NetworkLayerProxyFilterDelegate)?
 
     public var proxyFilter: ProxyFilter? { proxyFilterAndDelegate }
     
@@ -181,7 +181,7 @@ public class MeshNetworkManager {
     public init(using storage: Storage = LocalStorage(),
                 queue: DispatchQueue = DispatchQueue.global(qos: .background),
                 delegateQueue: DispatchQueue = DispatchQueue.main,
-                proxyFilterFactory: @escaping ((MeshNetworkManager) -> (ProxyFilter & NetworkLayerProxyDelegate)?) =
+                proxyFilterFactory: @escaping ((MeshNetworkManager) -> (ProxyFilter & NetworkLayerProxyFilterDelegate)?) =
                 { meshNetworkManager in DefaultProxyFilter(meshNetworkManager) }) {
         self.storage = storage
         self.meshData = MeshData()

--- a/nRFMeshProvision/Classes/ProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter.swift
@@ -71,8 +71,6 @@ public extension ProxyFilterDelegate {
 }
 
 public protocol ProxyFilter {
-    init(_ manager: MeshNetworkManager)
-
     /// Sets the Filter Type on the connected GATT Proxy Node.
     /// The filter will be emptied.
     ///

--- a/nRFMeshProvision/Classes/ProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter.swift
@@ -329,7 +329,7 @@ public extension DefaultProxyFilter {
 
 // MARK: - Callbacks
 
-extension DefaultProxyFilter: NetworkLayerProxyDelegate {
+extension DefaultProxyFilter: NetworkLayerProxyFilterDelegate {
     
     /// Callback called when a possible change of Proxy Node have been discovered.
     ///

--- a/nRFMeshProvision/Classes/ProxyFilter/DefaultProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter/DefaultProxyFilter.swift
@@ -286,6 +286,8 @@ extension DefaultProxyFilter: NetworkLayerProxyFilterDelegate {
                 busy = false
             }
 
+            let type = type
+            let addresses = addresses
             // Ensure the current information about the filter is up to date.
             guard type == status.filterType && addresses.count == status.listSize else {
                 // The counter is used to prevent from refreshing the
@@ -294,6 +296,7 @@ extension DefaultProxyFilter: NetworkLayerProxyFilterDelegate {
                 guard counter == 0 else {
                     logger?.e(.proxy, "Proxy Filter lost track of devices")
                     counter = 0
+                    self.delegate?.filterSettingsUpdatedOnProxy(type: type, addresses: addresses)
                     return
                 }
                 counter += 1
@@ -310,8 +313,9 @@ extension DefaultProxyFilter: NetworkLayerProxyFilterDelegate {
                     logger?.w(.proxy, "Limited Proxy Filter detected.")
                     setType(.inclusionList)
                     if let address = manager.meshNetwork?.localProvisioner?.unicastAddress {
+                        let addresses: Set<Address> = [address]
                         mutex.sync {
-                            addresses = [address]
+                            self.addresses = addresses
                         }
                         add(addresses: addresses)
                     }
@@ -327,6 +331,7 @@ extension DefaultProxyFilter: NetworkLayerProxyFilterDelegate {
                 return
             }
             counter = 0
+            self.delegate?.filterSettingsUpdatedOnProxy(type: type, addresses: addresses)
         default:
             // Ignore.
             break

--- a/nRFMeshProvision/Classes/ProxyFilter/DefaultProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter/DefaultProxyFilter.swift
@@ -43,7 +43,7 @@ import Foundation
 ///              subscribed to, the proxy filter needs to be modified manually
 ///              by calling proper `add` or `remove` method.
 open class DefaultProxyFilter: ProxyFilter {
-    internal var manager: MeshNetworkManager
+    internal let manager: MeshNetworkManager
     
     private let mutex = DispatchQueue(label: "ProxyFilterMutex")
     /// The counter is used to prevent from refreshing the filter in a loop when the Proxy Server

--- a/nRFMeshProvision/Classes/ProxyFilter/DefaultProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter/DefaultProxyFilter.swift
@@ -308,7 +308,7 @@ extension DefaultProxyFilter: NetworkLayerProxyFilterDelegate {
                 // switch to exclusion list filter.
                 if status.listSize == 1 {
                     logger?.w(.proxy, "Limited Proxy Filter detected.")
-                    reset()
+                    setType(.inclusionList)
                     if let address = manager.meshNetwork?.localProvisioner?.unicastAddress {
                         mutex.sync {
                             addresses = [address]

--- a/nRFMeshProvision/Classes/ProxyFilter/DefaultProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter/DefaultProxyFilter.swift
@@ -88,7 +88,7 @@ open class DefaultProxyFilter: ProxyFilter {
 
     // MARK: - Implementation
 
-    public required init(_ manager: MeshNetworkManager) {
+    public init(_ manager: MeshNetworkManager) {
         self.manager = manager
         self.delegateQueue = manager.delegateQueue
     }

--- a/nRFMeshProvision/Classes/ProxyFilter/DefaultProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter/DefaultProxyFilter.swift
@@ -60,7 +60,7 @@ open class DefaultProxyFilter: ProxyFilter {
     }
 
     // MARK: - Proxy Filter properties
-    
+
     /// A queue to call delegate methods on.
     ///
     /// The value is set in the `MeshNetworkManager` initializer.
@@ -122,27 +122,12 @@ public extension DefaultProxyFilter {
     /// Adds the given Addresses to the active filter.
     ///
     /// - parameter addresses: The addresses to add to the filter.
-    func add(addresses: [Address]) {
-        add(addresses: Set(addresses))
-    }
-
-    /// Adds the given Addresses to the active filter.
-    ///
-    /// - parameter addresses: The addresses to add to the filter.
     func add(addresses: Set<Address>) {
         // Proxy message must fit in a single Network PDU,
         // therefore may contain maximum 5 addresses.
         for set in addresses.chunked(maxSize: 5) {
             send(AddAddressesToFilter(set))
         }
-    }
-
-    /// Adds the given Groups to the active filter.
-    ///
-    /// - parameter groups: The groups to add to the filter.
-    func add(groups: [Group]) {
-        let addresses = groups.map { $0.address.address }
-        add(addresses: addresses)
     }
 
     /// Removes the given Address from the active filter.
@@ -155,27 +140,12 @@ public extension DefaultProxyFilter {
     /// Removes the given Addresses from the active filter.
     ///
     /// - parameter addresses: The addresses to remove from the filter.
-    func remove(addresses: [Address]) {
-        remove(addresses: Set(addresses))
-    }
-
-    /// Removes the given Addresses from the active filter.
-    ///
-    /// - parameter addresses: The addresses to remove from the filter.
     func remove(addresses: Set<Address>) {
         // Proxy message must fit in a single Network PDU,
         // therefore may contain maximum 5 addresses.
         for set in addresses.chunked(maxSize: 5) {
             send(RemoveAddressesFromFilter(set))
         }
-    }
-
-    /// Removes the given Groups from the active filter.
-    ///
-    /// - parameter groups: The groups to remove from the filter.
-    func remove(groups: [Group]) {
-        let addresses = groups.map { $0.address.address }
-        remove(addresses: addresses)
     }
 
     /// Adds all the addresses the Provisioner is subscribed to to the

--- a/nRFMeshProvision/Classes/ProxyFilter/ProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter/ProxyFilter.swift
@@ -71,6 +71,27 @@ public extension ProxyFilterDelegate {
 }
 
 public protocol ProxyFilter {
+    // MARK: - Proxy Filter properties
+    
+    /// The delegate to be informed about Proxy Filter changes.
+    var delegate: ProxyFilterDelegate? { get set }
+
+    /// List of addresses currently added to the Proxy Filter.
+    var addresses: Set<Address> { get }
+
+    /// The active Proxy Filter type.
+    ///
+    /// According to Bluetooth Mesh Profile 1.0.1, section 6.6,
+    /// by default the Proxy Filter is set to `.inclusionList`.
+    var type: ProxyFilerType { get }
+
+    /// The connected Proxy Node. This may be `nil` if the connected Node is unknown
+    /// to the provisioner, that is if a Node with the proxy Unicast Address was not found
+    /// in the local mesh network database. It is also `nil` if no proxy is connected.
+    var proxy: Node? { get }
+
+    // MARK: - Proxy Filter functions
+
     /// Sets the Filter Type on the connected GATT Proxy Node.
     /// The filter will be emptied.
     ///

--- a/nRFMeshProvision/Classes/ProxyFilter/ProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter/ProxyFilter.swift
@@ -1,0 +1,159 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public enum ProxyFilerType: UInt8 {
+    /// An inclusion list filter has an associated inclusion list, which is
+    /// a list of destination addresses that are of interest for the Proxy Client.
+    /// The inclusion list filter blocks all messages except those targeting
+    /// addresses added to the list.
+    case inclusionList = 0x00
+    /// An exclusion list filter has an associated exclusion list, which is
+    /// a list of destination addresses that the Proxy Client does not want to receive.
+    /// The exclusion list filter forwards all messages except those targeting
+    /// addresses added to the list.
+    case exclusionList = 0x01
+}
+
+public protocol ProxyFilterDelegate: AnyObject {
+    /// Method called when the Proxy Filter has been updated.
+    ///
+    /// - parameters:
+    ///   - type: The current Proxy Filter type.
+    ///   - addresses: The addresses in the filter.
+    func proxyFilterUpdated(type: ProxyFilerType, addresses: Set<Address>)
+    
+    /// This method is called when the connected Proxy device supports
+    /// only a single address in the Proxy Filter list.
+    ///
+    /// The delegate can switch to `.blacklist` filter type at that point
+    /// to receive messages sent to other addresses than 0th Element
+    /// Unicast Address.
+    ///
+    /// - parameter maxSize: The maximum Proxy Filter list size.
+    func limitedProxyFilterDetected(maxSize: Int)
+}
+
+public extension ProxyFilterDelegate {
+    
+    func limitedProxyFilterDetected(maxSize: Int) {
+        // Do nothing.
+    }
+    
+}
+
+public protocol ProxyFilter {
+    /// Sets the Filter Type on the connected GATT Proxy Node.
+    /// The filter will be emptied.
+    ///
+    /// - parameter type: The new proxy filter type.
+    func setType(_ type: ProxyFilerType)
+
+    /// Resets the filter to an empty inclusion list filter.
+    func reset()
+
+    /// Clears the current filter.
+    func clear()
+
+    /// Adds the given Address to the active filter.
+    ///
+    /// - parameter address: The address to add to the filter.
+    func add(address: Address)
+
+    /// Adds the given Addresses to the active filter.
+    ///
+    /// - parameter addresses: The addresses to add to the filter.
+    func add(addresses: Set<Address>)
+
+    /// Removes the given Address from the active filter.
+    ///
+    /// - parameter address: The address to remove from the filter.
+    func remove(address: Address)
+
+    /// Removes the given Addresses from the active filter.
+    ///
+    /// - parameter addresses: The addresses to remove from the filter.
+    func remove(addresses: Set<Address>)
+
+    /// Adds all the addresses the Provisioner is subscribed to to the
+    /// Proxy Filter.
+    func setup(for provisioner: Provisioner)
+
+    /// Notifies the Proxy Filter that the connection to GATT Proxy is closed.
+    ///
+    /// This method will unset the `busy` flag.
+    func proxyDidDisconnect()
+}
+
+public extension ProxyFilter {
+    /// Adds the given Addresses to the active filter.
+    ///
+    /// - parameter addresses: The addresses to add to the filter.
+    func add(addresses: [Address]) {
+        add(addresses: Set(addresses))
+    }
+
+    /// Adds the given Groups to the active filter.
+    ///
+    /// - parameter groups: The groups to add to the filter.
+    func add(groups: [Group]) {
+        let addresses = groups.map { $0.address.address }
+        add(addresses: addresses)
+    }
+
+    /// Removes the given Addresses from the active filter.
+    ///
+    /// - parameter addresses: The addresses to remove from the filter.
+    func remove(addresses: [Address]) {
+        remove(addresses: Set(addresses))
+    }
+
+    /// Removes the given Groups from the active filter.
+    ///
+    /// - parameter groups: The groups to remove from the filter.
+    func remove(groups: [Group]) {
+        let addresses = groups.map { $0.address.address }
+        remove(addresses: addresses)
+    }
+}
+
+// MARK: - Other
+
+extension ProxyFilerType: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        switch self {
+        case .inclusionList: return "Inclusion List"
+        case .exclusionList: return "Exclusion List"
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/ProxyFilter/ProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter/ProxyFilter.swift
@@ -60,6 +60,10 @@ public protocol ProxyFilterDelegate: AnyObject {
     ///
     /// - parameter maxSize: The maximum Proxy Filter list size.
     func limitedProxyFilterDetected(maxSize: Int)
+
+    /// This method is called when the connected Proxy device has been
+    /// configured successfully.
+    func filterSettingsUpdatedOnProxy(type: ProxyFilerType, addresses: Set<Address>)
 }
 
 public extension ProxyFilterDelegate {


### PR DESCRIPTION
We need custom behaviour in different situations.
The easiest to allow for this are custom ProxyFilter-implementations.

Therefore I added a `ProxyFilter` protocol and renamed the existing implementation to `DefaultProxyFilter`.
