### PR TITLE
Custom Proxy Filter initialization

### DIFF
--- a/Example/nRFMeshProvision/View Controllers/Proxy/AddAddressViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Proxy/AddAddressViewController.swift
@@ -70,10 +70,10 @@ class AddAddressViewController: ProgressViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        MeshNetworkManager.instance.proxyFilter?.delegate = self
+        MeshNetworkManager.instance.proxyFilter.delegate = self
         
         let network = MeshNetworkManager.instance.meshNetwork!
-        let proxyFilter = MeshNetworkManager.instance.proxyFilter!
+        let proxyFilter = MeshNetworkManager.instance.proxyFilter
         
         elements = network.nodes.flatMap {
             $0.elements.filter({ !proxyFilter.addresses.contains($0.unicastAddress) })
@@ -185,11 +185,8 @@ class AddAddressViewController: ProgressViewController {
 private extension AddAddressViewController {
     
     func addAddress(_ addresses: Set<Address>) {
-        guard let proxyFilter = MeshNetworkManager.instance.proxyFilter else {
-            return
-        }
         start("Adding addresses...") {
-            proxyFilter.add(addresses: addresses)
+            MeshNetworkManager.instance.proxyFilter.add(addresses: addresses)
         }
     }
     

--- a/Example/nRFMeshProvision/View Controllers/Proxy/ProxyViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Proxy/ProxyViewController.swift
@@ -48,10 +48,10 @@ class ProxyViewController: ProgressViewController, Editable {
         super.viewDidAppear(animated)
         tableView.reloadData()
         
-        MeshNetworkManager.instance.proxyFilter?.delegate = self
+        MeshNetworkManager.instance.proxyFilter.delegate = self
         addButton.isEnabled = MeshNetworkManager.bearer.isOpen
         
-        if MeshNetworkManager.instance.proxyFilter?.addresses.isEmpty == false {
+        if MeshNetworkManager.instance.proxyFilter.addresses.isEmpty == false {
             hideEmptyView()
         }
     }
@@ -81,7 +81,7 @@ class ProxyViewController: ProgressViewController, Editable {
         case IndexPath.proxyTypeSection:
             return 1
         default:
-            return MeshNetworkManager.instance.proxyFilter?.addresses.count ?? 0
+            return MeshNetworkManager.instance.proxyFilter.addresses.count
         }
     }
     
@@ -94,7 +94,7 @@ class ProxyViewController: ProgressViewController, Editable {
     
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         if section == IndexPath.proxyTypeSection {
-            if MeshNetworkManager.instance.proxyFilter?.type == .exclusionList {
+            if MeshNetworkManager.instance.proxyFilter.type == .exclusionList {
                 return "The exclusion list filter accepts all destination addresses except those that have been added to the list."
             } else {
                 return "The inclusion list filter blocks all destination addresses except those that have been added to the list."
@@ -105,7 +105,7 @@ class ProxyViewController: ProgressViewController, Editable {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let manager = MeshNetworkManager.instance
-        let proxyFilter = manager.proxyFilter!
+        let proxyFilter = manager.proxyFilter
         
         if indexPath == .mode {
             let cell = tableView.dequeueReusableCell(withIdentifier: "mode", for: indexPath) as! ConnectionModeCell
@@ -157,7 +157,7 @@ class ProxyViewController: ProgressViewController, Editable {
     override func tableView(_ tableView: UITableView,
                             commit editingStyle: UITableViewCell.EditingStyle,
                             forRowAt indexPath: IndexPath) {
-        let proxyFilter = MeshNetworkManager.instance.proxyFilter!
+        let proxyFilter = MeshNetworkManager.instance.proxyFilter
         let address = proxyFilter.addresses.sorted()[indexPath.row]
         deleteAddress(address)
     }
@@ -167,7 +167,7 @@ class ProxyViewController: ProgressViewController, Editable {
 extension ProxyViewController: UIAdaptivePresentationControllerDelegate {
     
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        MeshNetworkManager.instance.proxyFilter?.delegate = self
+        MeshNetworkManager.instance.proxyFilter.delegate = self
         tableView.reloadSections(.addresses, with: .automatic)
     }
     
@@ -183,12 +183,12 @@ extension ProxyViewController: BearerDelegate {
     func bearer(_ bearer: Bearer, didClose error: Error?) {
         addButton.isEnabled = false
         // Make sure the ProxyFilter is not busy.
-        MeshNetworkManager.instance.proxyFilter?.proxyDidDisconnect()
+        MeshNetworkManager.instance.proxyFilter.proxyDidDisconnect()
         // The bearer has closed. Attempt to send a message
         // will fail, but the Proxy Filter will receive .bearerClosed
         // error, upon which it will clear the filter list and notify
         // the delegate.
-        MeshNetworkManager.instance.proxyFilter?.clear()
+        MeshNetworkManager.instance.proxyFilter.clear()
     }
     
 }
@@ -204,9 +204,6 @@ extension ProxyViewController: ConnectionModeDelegate {
 extension ProxyViewController: ProxyFilterTypeDelegate {
     
     func filterTypeDidChange(_ type: ProxyFilerType) {
-        guard let proxyFilter = MeshNetworkManager.instance.proxyFilter else {
-            return
-        }
         let footer = tableView.footerView(forSection: 0)?.textLabel
         switch type {
         case .exclusionList:
@@ -216,7 +213,7 @@ extension ProxyViewController: ProxyFilterTypeDelegate {
         }
         footer?.sizeToFit()
         start("Setting proxy filter...") {
-            proxyFilter.setType(type)
+            MeshNetworkManager.instance.proxyFilter.setType(type)
         }
     }
     
@@ -238,8 +235,8 @@ private extension ProxyViewController {
     ///
     /// - parameter address: The address to delete.
     func deleteAddress(_ address: Address) {
-        guard let proxyFilter = MeshNetworkManager.instance.proxyFilter,
-                  proxyFilter.addresses.contains(address) else {
+        let proxyFilter = MeshNetworkManager.instance.proxyFilter
+        guard proxyFilter.addresses.contains(address) else {
             return
         }
         start("Deleting address...") {

--- a/Example/nRFMeshProvision/View Controllers/Settings/Provisioners/EditProvisionerViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Settings/Provisioners/EditProvisionerViewController.swift
@@ -295,7 +295,7 @@ private extension EditProvisionerViewController {
                 try meshNetwork.add(provisioner: provisioner, withAddress: newAddress)
                 // If the local Provisioner was added, set up the Proxy Filter for it.
                 if provisioner.isLocal && provisioner.hasConfigurationCapabilities {
-                    manager.proxyFilter?.setup(for: provisioner)
+                    manager.proxyFilter.setup(for: provisioner)
                 }
             } else {
                 // First, check if the new ranges are not overlapping other Provisioners' ranges.
@@ -309,7 +309,7 @@ private extension EditProvisionerViewController {
                 // If the address is changing, remove the old addresses from the Proxy Filter.
                 if let node = provisioner.node, newAddress != nil || disableConfigCapabilities {
                     let unicastAddresses = node.elements.map { $0.unicastAddress }
-                    manager.proxyFilter?.remove(addresses: unicastAddresses)
+                    manager.proxyFilter.remove(addresses: unicastAddresses)
                 }
                 // Try assigning the new Unicast Address. Hopefully this will not throw,
                 // as ranges were already allocated.
@@ -317,7 +317,7 @@ private extension EditProvisionerViewController {
                     try meshNetwork.assign(unicastAddress: newAddress, for: provisioner)
                     // Add the new addresses to the Proxy Filter.
                     let unicastAddresses = provisioner.node!.elements.map { $0.unicastAddress }
-                    manager.proxyFilter?.add(addresses: unicastAddresses)
+                    manager.proxyFilter.add(addresses: unicastAddresses)
                 }
                 if disableConfigCapabilities {
                     meshNetwork.disableConfigurationCapabilities(for: provisioner)

--- a/Example/nRFMeshProvision/View Controllers/Settings/Provisioners/ProvisionersViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Settings/Provisioners/ProvisionersViewController.swift
@@ -153,10 +153,10 @@ class ProvisionersViewController: UITableViewController, Editable {
         // If the local Provisioner is changing, and the Proxy Filter was set to a whitelist,
         // reset the filter.
         if sourceIndexPath.isThisProvisioner || destinationIndexPath.isThisProvisioner,
-            let previousLocalProvisioner = network.localProvisioner,
-            previousLocalProvisioner.hasConfigurationCapabilities &&
-            manager.proxyFilter?.type == .inclusionList {
-                manager.proxyFilter?.reset()
+           let previousLocalProvisioner = network.localProvisioner,
+           previousLocalProvisioner.hasConfigurationCapabilities &&
+           manager.proxyFilter.type == .inclusionList {
+            manager.proxyFilter.reset()
         }
         // Make the required change in the data source.
         network.moveProvisioner(fromIndex: fromIndex, toIndex: toIndex)
@@ -185,9 +185,9 @@ class ProvisionersViewController: UITableViewController, Editable {
         
         // Update the Proxy Filter after the local Provisioner has changed.
         if sourceIndexPath.isThisProvisioner || destinationIndexPath.isThisProvisioner,
-            let newLocalProvisioner = network.localProvisioner,
-            manager.proxyFilter?.type == .inclusionList {
-                manager.proxyFilter?.setup(for: newLocalProvisioner)
+           let newLocalProvisioner = network.localProvisioner,
+           manager.proxyFilter.type == .inclusionList {
+            manager.proxyFilter.setup(for: newLocalProvisioner)
         }
     }
     
@@ -224,8 +224,8 @@ private extension ProvisionersViewController {
         // type was `.inclusionList`, clear the Proxy Filter.
         // Exclusion filter must have been set up by the user, so don't
         // modify it.
-        if indexPath.isThisProvisioner && manager.proxyFilter?.type == .inclusionList {
-            manager.proxyFilter?.reset()
+        if indexPath.isThisProvisioner && manager.proxyFilter.type == .inclusionList {
+            manager.proxyFilter.reset()
         }
         
         // Remove the Provisioner and its Node from the network configuration.
@@ -237,9 +237,9 @@ private extension ProvisionersViewController {
         // Filter type is a whitelist, set up the Proxy Filter with all
         // addresses the new Provisioner is subscribed to.
         if indexPath.isThisProvisioner,
-            let newLocalProvisioner = meshNetwork.localProvisioner,
-            manager.proxyFilter?.type == .inclusionList {
-            manager.proxyFilter?.setup(for: newLocalProvisioner)
+           let newLocalProvisioner = meshNetwork.localProvisioner,
+           manager.proxyFilter.type == .inclusionList {
+            manager.proxyFilter.setup(for: newLocalProvisioner)
         }
         
         tableView.beginUpdates()

--- a/nRFMeshProvision/Classes/Layers/Network Layer/NetworkLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/NetworkLayer.swift
@@ -209,7 +209,7 @@ internal class NetworkLayer {
     func send(proxyConfigurationMessage message: ProxyConfigurationMessage) {
         guard let networkKey = proxyNetworkKey else {
             // The Proxy Network Key is unknown.
-            networkManager.manager.proxyFilter?
+            networkManager.manager.proxyFilter
                 .managerFailedToDeliverMessage(message, error: BearerError.bearerClosed)
             return
         }
@@ -225,12 +225,12 @@ internal class NetworkLayer {
         logger?.i(.network, "Sending \(pdu)")
         do {
             try send(lowerTransportPdu: pdu, ofType: .proxyConfiguration, withTtl: pdu.ttl)
-            networkManager.manager.proxyFilter?.managerDidDeliverMessage(message)
+            networkManager.manager.proxyFilter.managerDidDeliverMessage(message)
         } catch {
             if case BearerError.bearerClosed = error {
                 proxyNetworkKey = nil
             }
-            networkManager.manager.proxyFilter?.managerFailedToDeliverMessage(message, error: error)
+            networkManager.manager.proxyFilter.managerFailedToDeliverMessage(message, error: error)
         }
     }
     
@@ -379,7 +379,7 @@ private extension NetworkLayer {
         proxyNetworkKey = networkKey
         
         if justConnected || !ivIndexChanged {
-            networkManager.manager.proxyFilter?.newProxyDidConnect()
+            networkManager.manager.proxyFilter.newProxyDidConnect()
         }
     }
     
@@ -415,7 +415,7 @@ private extension NetworkLayer {
             logger?.i(.proxy, "\(message) received from: \(proxyPdu.source.hex) to: \(proxyPdu.destination.hex)")
             // Look for the proxy Node.
             let proxyNode = meshNetwork.node(withAddress: proxyPdu.source)
-            networkManager.manager.proxyFilter?.handle(message, sentFrom: proxyNode)
+            networkManager.manager.proxyFilter.handle(message, sentFrom: proxyNode)
         } else {
             logger?.w(.proxy, "Unsupported proxy configuration message (opcode: \(controlMessage.opCode))")
         }

--- a/nRFMeshProvision/Classes/MeshNetworkManager.swift
+++ b/nRFMeshProvision/Classes/MeshNetworkManager.swift
@@ -44,7 +44,7 @@ public class MeshNetworkManager {
     internal let delegateQueue: DispatchQueue
     
     /// The Proxy Filter state.
-    public internal(set) var proxyFilter: ProxyFilter?
+    public internal(set) var proxyFilter: ProxyFilter
     
     /// The logger delegate will be called whenever a new log entry is created.
     public weak var logger: LoggerDelegate?
@@ -177,6 +177,9 @@ public class MeshNetworkManager {
         self.meshData = MeshData()
         self.queue = queue
         self.delegateQueue = delegateQueue
+        self.proxyFilter = ProxyFilter(delegateQueue)
+        // Only now self can be used.
+        self.proxyFilter.use(with: self)
     }
     
     /// Initializes the Mesh Network Manager. It will use the `LocalStorage`
@@ -226,7 +229,6 @@ public extension MeshNetworkManager {
         
         meshData.meshNetwork = network
         networkManager = NetworkManager(self)
-        proxyFilter = ProxyFilter(self)
         return network
     }
     
@@ -757,7 +759,7 @@ public extension MeshNetworkManager {
             }
             
             networkManager = NetworkManager(self)
-            proxyFilter = ProxyFilter(self)
+            proxyFilter.newNetworkCreated()
             return true
         } else if let legacyState = MeshStateManager.load() {
             // The app has been updated from version 1.0.x to 2.0.
@@ -796,7 +798,7 @@ public extension MeshNetworkManager {
             
             meshData.meshNetwork = network
             networkManager = NetworkManager(self)
-            proxyFilter = ProxyFilter(self)
+            proxyFilter.newNetworkCreated()
             return save()
         }
         return false
@@ -888,7 +890,7 @@ public extension MeshNetworkManager {
         }
         
         networkManager = NetworkManager(self)
-        proxyFilter = ProxyFilter(self)
+        proxyFilter.newNetworkCreated()
         return meshNetwork
     }
     


### PR DESCRIPTION
This PR tries to solve #386 in a way proposed in https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/issues/386#issuecomment-989706034. 

Alternative solution have been proposed in #387 and #388.

### Pros of proposed solution:
- Does not require extending `ProxyFilter` with own implementation, and still allows setting `.inclusionList` or `.exclusionList` with custom addresses.
- Comparing to original version, a custom init state of Proxy Filter can be set.

### Cons:
- I can imaging a custom implementation can have more features.

## Breaking change
- The `proxyFilter` member of `MeshNetworkManager` has been changed from Optional to Non-Optional.

## Other
- A bug has been fixed where network manager and proxy filter had strong references to each other.