### PR TITLE
Add Generic OnPowerUp Get and Set to app

### DIFF
--- a/Example/nRFMeshProvision.xcodeproj/project.pbxproj
+++ b/Example/nRFMeshProvision.xcodeproj/project.pbxproj
@@ -156,6 +156,11 @@
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
+		A7A59BD5277225A70045A8ED /* GenericPowerOnOff.xib in Resources */ = {isa = PBXBuildFile; fileRef = A7A59BD4277225A70045A8ED /* GenericPowerOnOff.xib */; };
+		A7A59BD7277225E70045A8ED /* GenericPowerOnOffViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7A59BD6277225E70045A8ED /* GenericPowerOnOffViewCell.swift */; };
+		A7A59BD92773218C0045A8ED /* GenericPowerOnOffClientDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7A59BD82773218C0045A8ED /* GenericPowerOnOffClientDelegate.swift */; };
+		A7B526A7277B210000F5C60D /* GenericPowerOnOffSetupViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B526A5277B210000F5C60D /* GenericPowerOnOffSetupViewCell.swift */; };
+		A7B526A8277B210000F5C60D /* GenericPowerOnOffSetup.xib in Resources */ = {isa = PBXBuildFile; fileRef = A7B526A6277B210000F5C60D /* GenericPowerOnOffSetup.xib */; };
 		D484C4C6036F7130DAF9210C /* Pods_nRFMeshProvision_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 082BD0C5AF731FACD704C290 /* Pods_nRFMeshProvision_Tests.framework */; };
 /* End PBXBuildFile section */
 
@@ -330,6 +335,11 @@
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8BA6080D6D64DF472887CC10 /* Pods-nRFMeshProvision_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-nRFMeshProvision_Tests.release.xcconfig"; path = "Target Support Files/Pods-nRFMeshProvision_Tests/Pods-nRFMeshProvision_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		95314CBBCE25A1396EF93139 /* Pods-nRFMeshProvision_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-nRFMeshProvision_Example.release.xcconfig"; path = "Target Support Files/Pods-nRFMeshProvision_Example/Pods-nRFMeshProvision_Example.release.xcconfig"; sourceTree = "<group>"; };
+		A7A59BD4277225A70045A8ED /* GenericPowerOnOff.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = GenericPowerOnOff.xib; sourceTree = "<group>"; };
+		A7A59BD6277225E70045A8ED /* GenericPowerOnOffViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GenericPowerOnOffViewCell.swift; sourceTree = "<group>"; };
+		A7A59BD82773218C0045A8ED /* GenericPowerOnOffClientDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericPowerOnOffClientDelegate.swift; sourceTree = "<group>"; };
+		A7B526A5277B210000F5C60D /* GenericPowerOnOffSetupViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericPowerOnOffSetupViewCell.swift; sourceTree = "<group>"; };
+		A7B526A6277B210000F5C60D /* GenericPowerOnOffSetup.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GenericPowerOnOffSetup.xib; sourceTree = "<group>"; };
 		C775BBAAAC42952ED786BABF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		E7CB7DCE18F6E38D2240310F /* nRFMeshProvision.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = nRFMeshProvision.podspec; path = ../nRFMeshProvision.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		EA733BBB45B56B4142103F0F /* Pods-nRFMeshProvision_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-nRFMeshProvision_Example.debug.xcconfig"; path = "Target Support Files/Pods-nRFMeshProvision_Example/Pods-nRFMeshProvision_Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -442,6 +452,8 @@
 			children = (
 				5231403B22FDA8670074325A /* ConfigurationServer.xib */,
 				52A9C17C230EB9490036792A /* GenericOnOff.xib */,
+				A7A59BD4277225A70045A8ED /* GenericPowerOnOff.xib */,
+				A7B526A6277B210000F5C60D /* GenericPowerOnOffSetup.xib */,
 				52A9C1C42313D7D80036792A /* GenericLevel.xib */,
 				5217D2E4250F90D8004FDE79 /* GenericDefaultTransitionTime.xib */,
 				5231404C230AC4680074325A /* VendorModel.xib */,
@@ -455,6 +467,8 @@
 				52314040230192C50074325A /* ModelViewCell.swift */,
 				5231403E2301761C0074325A /* ConfigurationServerViewCell.swift */,
 				52A9C17B230EB9490036792A /* GenericOnOffViewCell.swift */,
+				A7A59BD6277225E70045A8ED /* GenericPowerOnOffViewCell.swift */,
+				A7B526A5277B210000F5C60D /* GenericPowerOnOffSetupViewCell.swift */,
 				52A9C1C32313D7D80036792A /* GenericLevelViewCell.swift */,
 				5217D2E3250F90D8004FDE79 /* GenericDefaultTransitionTimeViewCell.swift */,
 				5231404B230AC4680074325A /* VendorModelViewCell.swift */,
@@ -672,6 +686,7 @@
 				52E54CE02344974B00478F05 /* GenericLevelClientDelegate.swift */,
 				52E54CE22344978300478F05 /* GenericLevelServerDelegate.swift */,
 				52E54CE62345EDA700478F05 /* GenericState.swift */,
+				A7A59BD82773218C0045A8ED /* GenericPowerOnOffClientDelegate.swift */,
 			);
 			path = "Mesh Network";
 			sourceTree = "<group>";
@@ -895,10 +910,12 @@
 				523F778D22CCEA910030EA6A /* SetPublication.storyboard in Resources */,
 				52A9C17E230EB9490036792A /* GenericOnOff.xib in Resources */,
 				52CD0A5E2330C04700A9A181 /* Network.storyboard in Resources */,
+				A7A59BD5277225A70045A8ED /* GenericPowerOnOff.xib in Resources */,
 				52E54CDB2343878B00478F05 /* Control.storyboard in Resources */,
 				3089BCA02099CA4900E30192 /* LaunchScreen.storyboard in Resources */,
 				52CD0A5B2330BF4800A9A181 /* Proxy.storyboard in Resources */,
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
+				A7B526A8277B210000F5C60D /* GenericPowerOnOffSetup.xib in Resources */,
 				52A9C1C62313D7D80036792A /* GenericLevel.xib in Resources */,
 				5231404E230AC4680074325A /* VendorModel.xib in Resources */,
 				5231403C22FDA8670074325A /* ConfigurationServer.xib in Resources */,
@@ -1050,6 +1067,7 @@
 				525242E0225CBFEC0044CECB /* RangeObject+String.swift in Sources */,
 				529B7575224107A5008F1CE7 /* AppInfo.swift in Sources */,
 				52121526231528AC0059FB3D /* GenericOnOffGroupCell.swift in Sources */,
+				A7A59BD92773218C0045A8ED /* GenericPowerOnOffClientDelegate.swift in Sources */,
 				523F776622C609D90030EA6A /* NodeNetworkKeysViewController.swift in Sources */,
 				5211EAD5250777E100089FF2 /* SceneServerDelegate.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
@@ -1093,8 +1111,10 @@
 				5292F8A325021B8F00EA0F2A /* ModelIdentifiers.swift in Sources */,
 				52835258227AEDA30097B949 /* DeviceCell.swift in Sources */,
 				52E54CD82343876000478F05 /* GenericLevelServerCell.swift in Sources */,
+				A7B526A7277B210000F5C60D /* GenericPowerOnOffSetupViewCell.swift in Sources */,
 				5212152D231545D40059FB3D /* ModelGroupCell.swift in Sources */,
 				52A8EA8D24E6A470004C14C7 /* SetHeartbeatPublicationViewController.swift in Sources */,
+				A7A59BD7277225E70045A8ED /* GenericPowerOnOffViewCell.swift in Sources */,
 				52547F26232A3F470002AA7B /* ProvisionersViewController.swift in Sources */,
 				52518B3322E0B43200A1FD1E /* GroupCell.swift in Sources */,
 				529B7570223FF1AE008F1CE7 /* SettingsViewController.swift in Sources */,

--- a/Example/nRFMeshProvision/AppDelegate.swift
+++ b/Example/nRFMeshProvision/AppDelegate.swift
@@ -110,6 +110,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Model(sigModelId: .sceneSetupServerModelId, delegate: sceneSetupServer),
             // Sensor Client model:
             Model(sigModelId: .sensorClientModelId, delegate: SensorClientDelegate()),
+            // Generic Power OnOff Client model:
+            Model(sigModelId: .genericPowerOnOffClientModelId, delegate: GenericPowerOnOffClientDelegate()),
             // Generic Default Transition Time Server model:
             Model(sigModelId: .genericDefaultTransitionTimeServerModelId,
                   delegate: defaultTransitionTimeServerDelegate),

--- a/Example/nRFMeshProvision/Mesh Network/GenericPowerOnOffClientDelegate.swift
+++ b/Example/nRFMeshProvision/Mesh Network/GenericPowerOnOffClientDelegate.swift
@@ -1,3 +1,4 @@
+//
 /*
 * Copyright (c) 2019, Nordic Semiconductor
 * All rights reserved.
@@ -31,34 +32,29 @@
 import Foundation
 import nRFMeshProvision
 
-extension UInt16 {
+class GenericPowerOnOffClientDelegate: ModelDelegate {
     
-    // Bluetooth SIG Models
-    static let configurationServerModelId: UInt16 = 0x0000
-    static let configurationClientModelId: UInt16 = 0x0001
+    let messageTypes: [UInt32 : MeshMessage.Type]
+    let isSubscriptionSupported: Bool = true
     
-    static let genericOnOffServerModelId: UInt16 = 0x1000
-    static let genericOnOffClientModelId: UInt16 = 0x1001
-    static let genericLevelServerModelId: UInt16 = 0x1002
-    static let genericLevelClientModelId: UInt16 = 0x1003
+    // TODO: Implement Generic Power OnOff Client publications.
+    let publicationMessageComposer: MessageComposer? = nil
     
-    static let genericDefaultTransitionTimeServerModelId: UInt16 = 0x1004
-    static let genericDefaultTransitionTimeClientModelId: UInt16 = 0x1005
+    init() {
+        messageTypes = [GenericOnPowerUpStatus.self].toMap()
+    }
     
-    static let genericPowerOnOffServerModelId: UInt16 = 0x1006
-    static let genericPowerOnOffSetupServerModelId: UInt16 = 0x1007
-    static let genericPowerOnOffClientModelId: UInt16 = 0x1008
+    func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
+               from source: Address, sentTo destination: MeshAddress) -> MeshMessage {
+        fatalError("Message not supported: \(request)")
+    }
     
-    static let sceneServerModelId: UInt16 = 0x1203
-    static let sceneSetupServerModelId: UInt16 = 0x1204
-    static let sceneClientModelId: UInt16 = 0x1205
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+               from source: Address, sentTo destination: MeshAddress) {
+    }
     
-    static let sensorServerModelId: UInt16 = 0x1100
-    static let sensorServerSetupModelId: UInt16 = 0x1101
-    static let sensorClientModelId: UInt16 = 0x1102
-    
-    // Supported vendor models
-    static let simpleOnOffModelId: UInt16 = 0x0001
-    static let nordicSemiconductorCompanyId: UInt16 = 0x0059
-    
+    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+               toAcknowledgedMessage request: AcknowledgedMeshMessage,
+               from source: Address) {
+    }
 }

--- a/Example/nRFMeshProvision/UI/Model/GenericPowerOnOff.xib
+++ b/Example/nRFMeshProvision/UI/Model/GenericPowerOnOff.xib
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="121" id="B4P-wJ-v4L" customClass="GenericPowerOnOffViewCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="396" height="121"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="B4P-wJ-v4L" id="TF5-B3-KqO">
+                <rect key="frame" x="0.0" y="0.0" width="396" height="121"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="On Power Up" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qhb-a9-yuj">
+                        <rect key="frame" x="20" y="11" width="101" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Unknown" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gLq-q2-MiP">
+                        <rect key="frame" x="129" y="11" width="247" height="20"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="20" id="g1R-a2-MCz"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bdk-RI-pgy">
+                        <rect key="frame" x="20" y="44" width="376" height="0.5"/>
+                        <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="iXA-1v-jEk"/>
+                        </constraints>
+                    </view>
+                    <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jXV-9y-UJ0">
+                        <rect key="frame" x="326" y="52.5" width="70" height="60.5"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="70" id="UjK-R1-Ciu"/>
+                        </constraints>
+                        <state key="normal" title="Get">
+                            <color key="titleColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                        </state>
+                        <connections>
+                            <action selector="readTapped:" destination="B4P-wJ-v4L" eventType="touchUpInside" id="nB8-au-3sM"/>
+                        </connections>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailingMargin" secondItem="gLq-q2-MiP" secondAttribute="trailing" id="13d-m5-X16"/>
+                    <constraint firstItem="jXV-9y-UJ0" firstAttribute="top" secondItem="bdk-RI-pgy" secondAttribute="bottom" constant="8" id="2Hr-MI-VcW"/>
+                    <constraint firstItem="gLq-q2-MiP" firstAttribute="firstBaseline" secondItem="Qhb-a9-yuj" secondAttribute="firstBaseline" id="8aC-MP-T8f"/>
+                    <constraint firstItem="Qhb-a9-yuj" firstAttribute="top" secondItem="TF5-B3-KqO" secondAttribute="topMargin" id="ALG-Sp-xdU"/>
+                    <constraint firstItem="bdk-RI-pgy" firstAttribute="leading" secondItem="TF5-B3-KqO" secondAttribute="leadingMargin" id="AVO-sC-ucT"/>
+                    <constraint firstAttribute="trailing" secondItem="bdk-RI-pgy" secondAttribute="trailing" id="AYp-DZ-a5u"/>
+                    <constraint firstItem="gLq-q2-MiP" firstAttribute="leading" secondItem="Qhb-a9-yuj" secondAttribute="trailing" constant="8" id="QpQ-KX-TtW"/>
+                    <constraint firstItem="Qhb-a9-yuj" firstAttribute="leading" secondItem="TF5-B3-KqO" secondAttribute="leadingMargin" id="Tc1-1C-SFz"/>
+                    <constraint firstItem="bdk-RI-pgy" firstAttribute="top" secondItem="Qhb-a9-yuj" secondAttribute="bottom" constant="12" id="XVk-fi-BnM"/>
+                    <constraint firstAttribute="trailing" secondItem="jXV-9y-UJ0" secondAttribute="trailing" id="okd-lJ-4Ap"/>
+                    <constraint firstAttribute="bottom" secondItem="jXV-9y-UJ0" secondAttribute="bottom" constant="8" id="uTJ-do-TSK"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="DOs-Y9-WvR"/>
+            <connections>
+                <outlet property="currentStatusLabel" destination="gLq-q2-MiP" id="TJW-Wc-PCx"/>
+                <outlet property="readButton" destination="jXV-9y-UJ0" id="r7h-Cu-EjZ"/>
+            </connections>
+            <point key="canvasLocation" x="108.69565217391305" y="159.04017857142856"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="opaqueSeparatorColor">
+            <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Example/nRFMeshProvision/UI/Model/GenericPowerOnOffSetup.xib
+++ b/Example/nRFMeshProvision/UI/Model/GenericPowerOnOffSetup.xib
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="211" id="evn-P7-ZvA" customClass="GenericPowerOnOffSetupViewCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="439" height="211"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="evn-P7-ZvA" id="s1D-37-uVN">
+                <rect key="frame" x="0.0" y="0.0" width="439" height="211"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="On Power Up" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AEP-DG-gIe">
+                        <rect key="frame" x="20" y="16" width="191" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <segmentedControl opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="ugN-ye-qal">
+                        <rect key="frame" x="219" y="11" width="200" height="32"/>
+                        <segments>
+                            <segment title="Off"/>
+                            <segment title="Default"/>
+                            <segment title="Restore"/>
+                        </segments>
+                        <connections>
+                            <action selector="behaviorDidChange:" destination="evn-P7-ZvA" eventType="valueChanged" id="PRA-om-KNg"/>
+                        </connections>
+                    </segmentedControl>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j6d-oo-Zhp">
+                        <rect key="frame" x="20" y="49" width="419" height="0.5"/>
+                        <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="Ml5-LL-AfM"/>
+                        </constraints>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Acknowledged" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rfk-s6-qJx">
+                        <rect key="frame" x="20" y="61.5" width="113" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="T25-cb-5jt">
+                        <rect key="frame" x="370" y="56.5" width="51" height="31"/>
+                        <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                        <connections>
+                            <action selector="acknowledgeSwitchChanged:" destination="evn-P7-ZvA" eventType="valueChanged" id="bsC-MR-Pf2"/>
+                        </connections>
+                    </switch>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nI6-PT-MtX">
+                        <rect key="frame" x="10" y="94.5" width="409" height="0.0"/>
+                        <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="AYC-5o-6Tf"/>
+                        </constraints>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Current" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ltK-Wf-zbJ" userLabel="Current">
+                        <rect key="frame" x="20" y="106.5" width="58" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unknown" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mZB-BR-CZJ" userLabel="State">
+                        <rect key="frame" x="347.5" y="106.5" width="71.5" height="20.5"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="o1k-Fw-DO7">
+                        <rect key="frame" x="20" y="139.5" width="419" height="0.5"/>
+                        <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="z2p-fz-f8f"/>
+                        </constraints>
+                    </view>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hpm-79-5Go" userLabel="Send Button">
+                        <rect key="frame" x="379" y="147.5" width="60" height="55.5"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="60" id="81Y-LO-naD"/>
+                        </constraints>
+                        <state key="normal" title="Set">
+                            <color key="titleColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                        </state>
+                        <connections>
+                            <action selector="sendTapped:" destination="evn-P7-ZvA" eventType="touchUpInside" id="87a-1g-3GF"/>
+                        </connections>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="mZB-BR-CZJ" firstAttribute="firstBaseline" secondItem="ltK-Wf-zbJ" secondAttribute="firstBaseline" id="6RP-8I-hUY"/>
+                    <constraint firstItem="ugN-ye-qal" firstAttribute="leading" secondItem="AEP-DG-gIe" secondAttribute="trailing" constant="8" id="70g-W8-Q9G"/>
+                    <constraint firstAttribute="trailing" secondItem="hpm-79-5Go" secondAttribute="trailing" id="75u-TU-esJ"/>
+                    <constraint firstItem="o1k-Fw-DO7" firstAttribute="leading" secondItem="s1D-37-uVN" secondAttribute="leadingMargin" id="A9t-in-GVK"/>
+                    <constraint firstItem="T25-cb-5jt" firstAttribute="centerY" secondItem="Rfk-s6-qJx" secondAttribute="centerY" id="HPP-Uv-wXx"/>
+                    <constraint firstItem="Rfk-s6-qJx" firstAttribute="top" secondItem="j6d-oo-Zhp" secondAttribute="bottom" constant="12" id="Iub-c7-sNT"/>
+                    <constraint firstItem="Rfk-s6-qJx" firstAttribute="leading" secondItem="s1D-37-uVN" secondAttribute="leadingMargin" id="Ixv-WF-Q6k"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="T25-cb-5jt" secondAttribute="trailing" id="LMN-gu-6y3"/>
+                    <constraint firstItem="ugN-ye-qal" firstAttribute="centerY" secondItem="AEP-DG-gIe" secondAttribute="centerY" id="N1r-XZ-bP4"/>
+                    <constraint firstItem="j6d-oo-Zhp" firstAttribute="top" secondItem="AEP-DG-gIe" secondAttribute="bottom" constant="12" id="Poz-dh-i5K"/>
+                    <constraint firstItem="j6d-oo-Zhp" firstAttribute="leading" secondItem="s1D-37-uVN" secondAttribute="leadingMargin" id="Qmo-5p-pac"/>
+                    <constraint firstItem="nI6-PT-MtX" firstAttribute="leading" secondItem="s1D-37-uVN" secondAttribute="leadingMargin" constant="-10" id="UYs-Lg-0lI"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="ugN-ye-qal" secondAttribute="trailing" id="X6b-1g-B0S"/>
+                    <constraint firstItem="hpm-79-5Go" firstAttribute="top" secondItem="o1k-Fw-DO7" secondAttribute="top" constant="8" id="a0O-Cw-vZA"/>
+                    <constraint firstItem="nI6-PT-MtX" firstAttribute="top" secondItem="Rfk-s6-qJx" secondAttribute="bottom" constant="12" id="cC5-EP-uRd"/>
+                    <constraint firstItem="ltK-Wf-zbJ" firstAttribute="leading" secondItem="s1D-37-uVN" secondAttribute="leadingMargin" id="d3S-Ev-zVi"/>
+                    <constraint firstItem="ugN-ye-qal" firstAttribute="top" secondItem="s1D-37-uVN" secondAttribute="topMargin" id="fo0-gk-2T7"/>
+                    <constraint firstAttribute="bottom" secondItem="hpm-79-5Go" secondAttribute="bottom" constant="8" id="gH7-HM-nV6"/>
+                    <constraint firstAttribute="trailing" secondItem="j6d-oo-Zhp" secondAttribute="trailing" id="gog-vK-Q0Z"/>
+                    <constraint firstAttribute="trailing" secondItem="nI6-PT-MtX" secondAttribute="trailing" constant="20" symbolic="YES" id="jTb-YQ-Y2P"/>
+                    <constraint firstItem="AEP-DG-gIe" firstAttribute="leading" secondItem="s1D-37-uVN" secondAttribute="leadingMargin" id="mGU-m1-mNy"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="mZB-BR-CZJ" secondAttribute="trailing" id="pcH-od-RJq"/>
+                    <constraint firstItem="ltK-Wf-zbJ" firstAttribute="top" secondItem="nI6-PT-MtX" secondAttribute="bottom" constant="12" id="r7W-r2-FcY"/>
+                    <constraint firstItem="o1k-Fw-DO7" firstAttribute="top" secondItem="ltK-Wf-zbJ" secondAttribute="bottom" constant="12" id="rwi-4A-N4N"/>
+                    <constraint firstAttribute="trailing" secondItem="o1k-Fw-DO7" secondAttribute="trailing" id="y8S-nh-vzV"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="AFf-id-Dlr"/>
+            <connections>
+                <outlet property="acknowledgeSwitch" destination="T25-cb-5jt" id="o3r-XH-Gzu"/>
+                <outlet property="acknowledgedStateLabel" destination="mZB-BR-CZJ" id="7Qa-Iq-CNo"/>
+                <outlet property="behaviorControl" destination="ugN-ye-qal" id="AP4-xU-8qP"/>
+                <outlet property="sendButton" destination="hpm-79-5Go" id="oVe-aF-yNd"/>
+            </connections>
+            <point key="canvasLocation" x="89.130434782608702" y="42.522321428571423"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="opaqueSeparatorColor">
+            <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/GenericPowerOnOffSetupViewCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/GenericPowerOnOffSetupViewCell.swift
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2019, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this
+ *    list of conditions and the following disclaimer in the documentation and/or
+ *    other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import UIKit
+import nRFMeshProvision
+
+class GenericPowerOnOffSetupViewCell: ModelViewCell {
+    
+    // MARK: - Outlets and Actions
+    @IBOutlet weak var behaviorControl: UISegmentedControl!
+    @IBAction func behaviorDidChange(_ sender: UISegmentedControl) {
+        behavior = .init(rawValue: UInt8(sender.selectedSegmentIndex)) ?? .default
+    }
+    
+    @IBOutlet weak var acknowledgedStateLabel: UILabel!
+    
+    @IBOutlet weak var acknowledgeSwitch: UISwitch!
+    @IBAction func acknowledgeSwitchChanged(_ sender: UISwitch) {
+        acknowledgedStateLabel.text = "Unknown"
+    }
+    
+    @IBOutlet weak var sendButton: UIButton!
+    @IBAction func sendTapped(_ sender: UIButton) {
+        sendGenericOnPowerUpMessage()
+    }
+    
+    // MARK: - Properties
+    
+    private var behavior: OnPowerUp = .off {
+        didSet {
+            behaviorControl.selectedSegmentIndex = Int(behavior.rawValue)
+        }
+    }
+    
+    // MARK: - Implementation
+    
+    override func reload(using model: Model) {
+        let localProvisioner = MeshNetworkManager.instance.meshNetwork?.localProvisioner
+        let isEnabled = localProvisioner?.hasConfigurationCapabilities ?? false
+        
+        acknowledgeSwitch.isEnabled = isEnabled
+        sendButton.isEnabled = isEnabled
+    }
+    
+    override func meshNetworkManager(_ manager: MeshNetworkManager,
+                                     didReceiveMessage message: MeshMessage,
+                                     sentFrom source: Address, to destination: Address) -> Bool {
+        switch message {
+        case let status as GenericOnPowerUpStatus:
+            acknowledgedStateLabel.text = status.state.debugDescription
+        default:
+            break
+        }
+        return false
+    }
+    
+    override func meshNetworkManager(_ manager: MeshNetworkManager,
+                                     didSendMessage message: MeshMessage,
+                                     from localElement: Element, to destination: Address) -> Bool {
+        // For acknowledged messages wait for the Acknowledgement Message.
+        return message is AcknowledgedMeshMessage
+    }
+}
+
+private extension GenericPowerOnOffSetupViewCell {
+    
+    func sendGenericOnPowerUpMessage() {
+        guard !model.boundApplicationKeys.isEmpty else {
+            parentViewController?.presentAlert(
+                title: "Bound key required",
+                message: "Bind at least one Application Key before sending the message.")
+            return
+        }
+        
+        if acknowledgeSwitch.isOn {
+            acknowledgedStateLabel.text = ""
+        }
+
+        let message: MeshMessage
+        
+        if acknowledgeSwitch.isOn {
+            message = GenericOnPowerUpSet(state: behavior)
+        } else {
+            message = GenericOnPowerUpSetUnacknowledged(state: behavior)
+        }
+        
+        delegate?.send(message, description: "Sending...")
+    }
+    
+}

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/GenericPowerOnOffViewCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/Model/GenericPowerOnOffViewCell.swift
@@ -1,0 +1,86 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import UIKit
+import nRFMeshProvision
+
+class GenericPowerOnOffViewCell: ModelViewCell {
+    
+    // MARK: - Outlets and Actions
+    @IBOutlet weak var currentStatusLabel: UILabel!
+    
+    @IBOutlet weak var readButton: UIButton!
+    @IBAction func readTapped(_ sender: UIButton) {
+        readGenericOnPowerUpState()
+    }
+        
+    // MARK: - Implementation
+    
+    override func reload(using model: Model) {
+        let localProvisioner = MeshNetworkManager.instance.meshNetwork?.localProvisioner
+        let isEnabled = localProvisioner?.hasConfigurationCapabilities ?? false
+        
+        readButton.isEnabled = isEnabled
+    }
+    
+    override func meshNetworkManager(_ manager: MeshNetworkManager,
+                                     didReceiveMessage message: MeshMessage,
+                                     sentFrom source: Address, to destination: Address) -> Bool {
+        switch message {
+        case let status as GenericOnPowerUpStatus:
+            currentStatusLabel.text = status.state.debugDescription
+        default:
+            break
+        }
+        return false
+    }
+    
+    override func meshNetworkManager(_ manager: MeshNetworkManager,
+                                     didSendMessage message: MeshMessage,
+                                     from localElement: Element, to destination: Address) -> Bool {
+        // For acknowledged messages wait for the Acknowledgement Message.
+        return message is AcknowledgedMeshMessage
+    }
+}
+
+private extension GenericPowerOnOffViewCell {
+        
+    func readGenericOnPowerUpState() {
+        guard !model.boundApplicationKeys.isEmpty else {
+            parentViewController?.presentAlert(
+                title: "Bound key required",
+                message: "Bind at least one Application Key before sending the message.")
+            return
+        }
+
+        
+        delegate?.send(GenericOnPowerUpGet(), description: "Reading state...")
+    }
+}

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
@@ -65,6 +65,10 @@ class ModelViewController: ProgressViewController {
                            forCellReuseIdentifier: UInt16.genericLevelServerModelId.hex)
         tableView.register(UINib(nibName: "GenericDefaultTransitionTime", bundle: nil),
                            forCellReuseIdentifier: UInt16.genericDefaultTransitionTimeServerModelId.hex)
+        tableView.register(UINib(nibName: "GenericPowerOnOff", bundle: nil),
+                           forCellReuseIdentifier: UInt16.genericPowerOnOffServerModelId.hex)
+        tableView.register(UINib(nibName: "GenericPowerOnOffSetup", bundle: nil),
+                           forCellReuseIdentifier: UInt16.genericPowerOnOffSetupServerModelId.hex)
         tableView.register(UINib(nibName: "VendorModel", bundle: nil),
                            forCellReuseIdentifier: "vendor")
     }
@@ -956,6 +960,8 @@ private extension Model {
     var hasCustomUI: Bool {
         return !isBluetoothSIGAssigned   // Vendor Models.
             || modelIdentifier == .genericOnOffServerModelId
+            || modelIdentifier == .genericPowerOnOffServerModelId
+            || modelIdentifier == .genericPowerOnOffSetupServerModelId
             || modelIdentifier == .genericLevelServerModelId
             || modelIdentifier == .genericDefaultTransitionTimeServerModelId
             || modelIdentifier == .sensorServerModelId


### PR DESCRIPTION
This PR adds:

- `Get` UI for `Generic Power OnOff Server`
- `Set` UI for `Generic Power OnOff Setup Server`

| `Get` (initial) | `Get Restore` | `Set` (initial) | `Set Acked Restore` |
| --- | --- | --- | --- |
| ![power_onoff_get_initial](https://user-images.githubusercontent.com/36726279/149085199-3c749c99-3084-41cf-a55c-561dc418bb85.png) | ![power_onoff_get_restore](https://user-images.githubusercontent.com/36726279/149085206-a04fc4e7-8a36-4a30-a175-760b777472f6.png) | ![power_onoff_set_initial](https://user-images.githubusercontent.com/36726279/149085213-6cfe27a7-e93c-4b62-a480-fc4c032c00d4.png) | ![power_onoff_set_restore_ack](https://user-images.githubusercontent.com/36726279/149085215-63eb4daa-b821-4b3e-9c9b-fbd2889f7709.png) |

The implementation uses the standard pattern for clients in the app with a `GenericPowerOnOffClientDelegate` and xibs for UI.

**Note:** The `publicationMessageComposer` of the `ModelDelegate` protocol is not implemented as this an attempt to enable server testing through the app rather than making the app a complete `GenericPowerOnOffClient` (the same shortcut exists in `SensorClientDelegate` which was mimicked).
