### PR TITLE
Bug fix: Handing messages sent to All Nodes only on the Primary Element

### DIFF
--- a/nRFMeshProvision/Classes/Layers/Access Layer/AccessLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Access Layer/AccessLayer.swift
@@ -399,7 +399,14 @@ private extension AccessLayer {
                         // Application Key bound to this Model and the message is
                         // targeting this Element, or the Model is subscribed to the
                         // destination address.
-                        if accessPdu.destination.address == Address.allNodes ||
+                        //
+                        // Note:   Messages sent to .allNodes address shall be processed
+                        //         only by Models on the Primary Element.
+                        //         See Bluetooth Mesh Profile 1.0.1, chapter 3.4.2.4.
+                        // Note 2: As the iOS implementation does not support Relay, Proxy or Friend
+                        //         Features, the messages sent to those addresses shall only be
+                        //         processed if the Model is explicitly subscribed to these addresses.
+                        if(accessPdu.destination.address == Address.allNodes && element.isPrimary) ||
                            accessPdu.destination.address == element.unicastAddress ||
                            model.isSubscribed(to: accessPdu.destination) {
                             if model.isBoundTo(keySet.applicationKey) {

--- a/nRFMeshProvision/Classes/Layers/Access Layer/AccessLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Access Layer/AccessLayer.swift
@@ -430,15 +430,15 @@ private extension AccessLayer {
                     }
                 }
             }
-        } else if let firstElement = localNode.elements.first {
+        } else if let primaryElement = localNode.primaryElement {
             // Check Configuration Server Model.
-            if let configurationServerModel = firstElement.models
+            if let configurationServerModel = primaryElement.models
                    .first(where: { $0.isConfigurationServer }),
                let delegate = configurationServerModel.delegate,
                let configMessage = delegate.decode(accessPdu) {
                 newMessage = configMessage
                 // Is this message targeting the local Node?
-                if accessPdu.destination.address == firstElement.unicastAddress {
+                if accessPdu.destination.address == primaryElement.unicastAddress {
                     logger?.i(.foundationModel, "\(configMessage) received from: \(accessPdu.source.hex)")
                     if let response = delegate.model(configurationServerModel, didReceiveMessage: configMessage,
                                                      sentFrom: accessPdu.source, to: accessPdu.destination,
@@ -463,13 +463,13 @@ private extension AccessLayer {
                     // If not, it was received by adding another Node's address to the Proxy Filter.
                     logger?.i(.foundationModel, "\(configMessage) received from: \(accessPdu.source.hex), to: \(accessPdu.destination.hex)")
                 }
-            } else if let configurationClientModel = firstElement.models
+            } else if let configurationClientModel = primaryElement.models
                           .first(where: { $0.isConfigurationClient }),
                       let delegate = configurationClientModel.delegate,
                       let configMessage = delegate.decode(accessPdu) {
                 newMessage = configMessage
                 // Is this message targeting the local Node?
-                if accessPdu.destination.address == firstElement.unicastAddress {
+                if accessPdu.destination.address == primaryElement.unicastAddress {
                     logger?.i(.foundationModel, "\(configMessage) received from: \(accessPdu.source.hex)")
                     if let response = delegate.model(configurationClientModel, didReceiveMessage: configMessage,
                                                      sentFrom: accessPdu.source, to: accessPdu.destination,

--- a/nRFMeshProvision/Classes/Mesh API/Element+Address.swift
+++ b/nRFMeshProvision/Classes/Mesh API/Element+Address.swift
@@ -39,4 +39,10 @@ public extension Element {
         return (parentNode?.unicastAddress ?? 0) + Address(index)
     }
     
+    /// Returns whether the Element is a Primary Element on the Node,
+    /// that is its index is equal to 0.
+    var isPrimary: Bool {
+        return index == 0
+    }
+    
 }


### PR DESCRIPTION
This PR fixes #408.

### Handling messages sent to All Nodes address

Bluetooth Mesh Profile 1.0.1 says in 3.4.2.4:
> A message sent to the all-nodes address shall be processed by the primary element of all nodes.

This means, that all Models on a Primary Element are automatically subscribed to All Nodes address.

Moreover, as Config Model Subscription Add message says:
> The Address field shall contain the new address to be added to the Subscription List. The value of the Address field shall not be an unassigned address, unicast address, **all-nodes address** or virtual address.

it is not possible to subscribe any Model to All Nodes address. This excludes Models from all-but-primary Element.

### Handling messages sent to other fixed group addresses

The spec excludes only the All Nodes address from subscription list. That means, that it should be possible to subscribe any model to other fixed addresses: All Relays, All Proxies, All Friends.

Nodes with Relay, Proxy or Friend features enabled should automatically subscribe all models on the Primary Element to the supported addresses. However, as the iOS library does not support any of them, the automatic subscription only works for All Nodes address.

Users can manually subscribe any Model on any Element to any of those addresses, and they should be processed like any other Group address (so with no feature check, just the bound app key check). 