### PR TITLE
Added an option to subscribe to All Relays, All Friends or All Proxies

### DIFF
--- a/Example/nRFMeshProvision.xcodeproj/project.pbxproj
+++ b/Example/nRFMeshProvision.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		52A9C1C52313D7D80036792A /* GenericLevelViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A9C1C32313D7D80036792A /* GenericLevelViewCell.swift */; };
 		52A9C1C62313D7D80036792A /* GenericLevel.xib in Resources */ = {isa = PBXBuildFile; fileRef = 52A9C1C42313D7D80036792A /* GenericLevel.xib */; };
 		52B492DB25C8A32E0096E75D /* KeyRefreshProcedure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B492DA25C8A32E0096E75D /* KeyRefreshProcedure.swift */; };
+		52B6C50F2811712D00F6E0F3 /* UITableViewCell+Disabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6C50E2811712D00F6E0F3 /* UITableViewCell+Disabled.swift */; };
 		52B7F67D229829F200B0A42F /* Addresses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7F67C229829F200B0A42F /* Addresses.swift */; };
 		52B7FD6D2525B40300308673 /* NodeSceneRecallViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7FD6C2525B40300308673 /* NodeSceneRecallViewController.swift */; };
 		52BC6F4824507A5400EBEEA4 /* DisconnectCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BC6F4724507A5400EBEEA4 /* DisconnectCell.swift */; };
@@ -292,6 +293,7 @@
 		52A9C1C32313D7D80036792A /* GenericLevelViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericLevelViewCell.swift; sourceTree = "<group>"; };
 		52A9C1C42313D7D80036792A /* GenericLevel.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GenericLevel.xib; sourceTree = "<group>"; };
 		52B492DA25C8A32E0096E75D /* KeyRefreshProcedure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyRefreshProcedure.swift; sourceTree = "<group>"; };
+		52B6C50E2811712D00F6E0F3 /* UITableViewCell+Disabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Disabled.swift"; sourceTree = "<group>"; };
 		52B7F67C229829F200B0A42F /* Addresses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Addresses.swift; sourceTree = "<group>"; };
 		52B7FD6C2525B40300308673 /* NodeSceneRecallViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeSceneRecallViewController.swift; sourceTree = "<group>"; };
 		52BC6F4724507A5400EBEEA4 /* DisconnectCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectCell.swift; sourceTree = "<group>"; };
@@ -617,6 +619,7 @@
 				525242DF225CBFEC0044CECB /* RangeObject+String.swift */,
 				52DA9D7124F6765C0051795B /* UInt16+Time.swift */,
 				5292F8A225021B8F00EA0F2A /* ModelIdentifiers.swift */,
+				52B6C50E2811712D00F6E0F3 /* UITableViewCell+Disabled.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -1087,6 +1090,7 @@
 				5292F8A7250652BB00EA0F2A /* SceneServerGroupCell.swift in Sources */,
 				522AFFDC22BBA34900521EDC /* ActionCell.swift in Sources */,
 				52E54CE72345EDA700478F05 /* GenericState.swift in Sources */,
+				52B6C50F2811712D00F6E0F3 /* UITableViewCell+Disabled.swift in Sources */,
 				52DF5D8A228DA78A00C297C1 /* ConfigurationViewController.swift in Sources */,
 				521215292315290F0059FB3D /* GroupControlViewController.swift in Sources */,
 				52A8EA8824E6946D004C14C7 /* HeartbeatPublicationCell.swift in Sources */,

--- a/Example/nRFMeshProvision/UI/Base.lproj/Network.storyboard
+++ b/Example/nRFMeshProvision/UI/Base.lproj/Network.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eYe-6v-26u">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eYe-6v-26u">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,26 +18,26 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="peripheralCell" id="9GQ-tl-ciy" customClass="DeviceCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="56"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="56"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="9GQ-tl-ciy" id="5b8-E0-tR7">
-                                    <rect key="frame" x="0.0" y="0.0" width="383" height="56"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="56"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZMJ-H6-Pq4">
-                                            <rect key="frame" x="20" y="9" width="309" height="21"/>
+                                            <rect key="frame" x="20" y="9" width="311.5" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7P7-iB-CcF">
-                                            <rect key="frame" x="20" y="32" width="309" height="15"/>
+                                            <rect key="frame" x="20" y="32" width="311.5" height="15"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="rssi_4" translatesAutoresizingMaskIntoConstraints="NO" id="agq-KS-7m0">
-                                            <rect key="frame" x="337" y="11" width="38" height="34"/>
+                                            <rect key="frame" x="339.5" y="11" width="38" height="34"/>
                                             <color key="tintColor" systemColor="labelColor"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="38" id="brG-JP-Fhu"/>
@@ -110,7 +110,7 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="normal" textLabel="Jbt-7J-8NZ" detailTextLabel="ki6-Ug-3Hi" style="IBUITableViewCellStyleValue1" id="DFQ-f2-a6e">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="DFQ-f2-a6e" id="h6H-CM-7Og">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -134,7 +134,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="key" textLabel="pfO-uy-sDC" detailTextLabel="JAd-Fh-EOT" style="IBUITableViewCellStyleValue1" id="Muk-1J-LqO">
-                                <rect key="frame" x="0.0" y="99" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="75.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Muk-1J-LqO" id="9yF-pp-m1N">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -158,7 +158,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="subtitle" textLabel="k0t-Br-ZKs" detailTextLabel="pwS-G1-VKl" style="IBUITableViewCellStyleSubtitle" id="K7A-oW-n9C">
-                                <rect key="frame" x="0.0" y="142.5" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="119" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="K7A-oW-n9C" id="QM5-AY-8zZ">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -182,7 +182,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="action" id="lc6-Lu-n3M" customClass="ActionCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="198" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="174.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lc6-Lu-n3M" id="WjU-Yf-R69">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -217,7 +217,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="features" rowHeight="100" id="6AP-t4-Gpt" customClass="NodeFeaturesCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="241.5" width="414" height="100"/>
+                                <rect key="frame" x="0.0" y="218" width="414" height="100"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="6AP-t4-Gpt" id="KJN-Ia-0oy">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
@@ -319,18 +319,18 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailButton" indentationWidth="10" reuseIdentifier="switch" id="2HO-VY-kvg" customClass="SwitchCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="341.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="318" width="414" height="43"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2HO-VY-kvg" id="jOf-kh-Gdy">
-                                    <rect key="frame" x="0.0" y="0.0" width="370" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="373.5" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0bP-aX-r7S">
-                                            <rect key="frame" x="313" y="6.5" width="51" height="31"/>
+                                            <rect key="frame" x="316.5" y="6" width="51" height="31"/>
                                             <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </switch>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mg0-0v-t3c">
-                                            <rect key="frame" x="20" y="11" width="33" height="21.5"/>
+                                            <rect key="frame" x="20" y="11" width="33" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -380,7 +380,7 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="normal" textLabel="22d-4K-pnc" detailTextLabel="BR9-L1-jg9" style="IBUITableViewCellStyleValue1" id="4fI-CB-qLc">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="4fI-CB-qLc" id="OR6-9E-Aym">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -404,10 +404,10 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="subtitle" textLabel="PGf-uh-Rft" detailTextLabel="jIJ-kc-vTG" style="IBUITableViewCellStyleSubtitle" id="mbs-ys-par">
-                                <rect key="frame" x="0.0" y="99" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="75.5" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mbs-ys-par" id="Q6p-0e-jmY">
-                                    <rect key="frame" x="0.0" y="0.0" width="383" height="55.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="55.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="PGf-uh-Rft">
@@ -454,7 +454,7 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="normal" textLabel="3p5-Ls-7HB" detailTextLabel="WZp-yu-SUw" style="IBUITableViewCellStyleValue1" id="iMu-ff-fDV">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iMu-ff-fDV" id="Txb-p3-m6q">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -478,7 +478,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="key" textLabel="Ivw-Zk-1Ri" detailTextLabel="J04-h7-HNa" imageView="SVn-ht-AO0" style="IBUITableViewCellStyleSubtitle" id="otu-JZ-HV0">
-                                <rect key="frame" x="0.0" y="99" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="75.5" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="otu-JZ-HV0" id="NgI-An-9RZ">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -506,10 +506,10 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="destination" rowHeight="123" id="Spq-Ja-fLm" customClass="PublicationCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="154.5" width="414" height="123"/>
+                                <rect key="frame" x="0.0" y="131" width="414" height="123"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Spq-Ja-fLm" id="kqG-5g-2cX">
-                                    <rect key="frame" x="0.0" y="0.0" width="383" height="123"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="123"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_flag_24pt" translatesAutoresizingMaskIntoConstraints="NO" id="8EH-nP-ZvK">
@@ -517,13 +517,13 @@
                                             <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Element 1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Drg-5i-a3Q">
-                                            <rect key="frame" x="60" y="11" width="315" height="20.5"/>
+                                            <rect key="frame" x="60" y="11" width="317.5" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Node 1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dMG-tt-lVv">
-                                            <rect key="frame" x="60" y="31.5" width="315" height="14.5"/>
+                                            <rect key="frame" x="60" y="31.5" width="317.5" height="14.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
@@ -533,19 +533,19 @@
                                             <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="749" text="Application Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="81q-vD-0YQ">
-                                            <rect key="frame" x="60" y="73" width="315" height="24"/>
+                                            <rect key="frame" x="60" y="73" width="317.5" height="24"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Bound to Network Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FUD-56-vax">
-                                            <rect key="frame" x="60" y="97" width="323" height="15"/>
+                                            <rect key="frame" x="60" y="97" width="325.5" height="15"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Using" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qDA-7q-kry">
-                                            <rect key="frame" x="60" y="52" width="315" height="15"/>
+                                            <rect key="frame" x="60" y="52" width="317.5" height="15"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
@@ -586,10 +586,10 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="heartbeatPublication" rowHeight="123" id="099-xq-uYk" customClass="HeartbeatPublicationCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="277.5" width="414" height="123"/>
+                                <rect key="frame" x="0.0" y="254" width="414" height="123"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="099-xq-uYk" id="LS7-zd-726">
-                                    <rect key="frame" x="0.0" y="0.0" width="383" height="123"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="123"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_flag_24pt" translatesAutoresizingMaskIntoConstraints="NO" id="ARs-oW-tub">
@@ -597,13 +597,13 @@
                                             <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Unknown Group" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lod-En-hHF">
-                                            <rect key="frame" x="60" y="11" width="315" height="20.5"/>
+                                            <rect key="frame" x="60" y="11" width="317.5" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="0xC003" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vC4-n2-xDA">
-                                            <rect key="frame" x="60" y="31.5" width="315" height="14.5"/>
+                                            <rect key="frame" x="60" y="31.5" width="317.5" height="14.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
@@ -613,7 +613,7 @@
                                             <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="749" text="Network Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qfz-DV-SrY">
-                                            <rect key="frame" x="60" y="72" width="315" height="40"/>
+                                            <rect key="frame" x="60" y="72" width="317.5" height="40"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="40" id="hno-i2-n7I"/>
                                             </constraints>
@@ -622,7 +622,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Using" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4J9-Hb-Wcs">
-                                            <rect key="frame" x="60" y="52" width="315" height="14"/>
+                                            <rect key="frame" x="60" y="52" width="317.5" height="14"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
@@ -659,7 +659,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="group" textLabel="1oJ-fF-jyJ" detailTextLabel="Ezb-Bc-f95" imageView="hHF-iP-OqZ" style="IBUITableViewCellStyleSubtitle" id="ZHd-AD-r5e">
-                                <rect key="frame" x="0.0" y="400.5" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="377" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZHd-AD-r5e" id="erD-pz-EdV">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -687,7 +687,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="value" id="ewv-CT-3vO" customClass="SensorValueCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="456" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="432.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ewv-CT-3vO" id="kUc-HY-AEY">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -725,10 +725,10 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="heartbeatSubscription" rowHeight="117" id="7eN-W8-bl6" customClass="HeartbeatSubscriptionCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="499.5" width="414" height="117"/>
+                                <rect key="frame" x="0.0" y="476" width="414" height="117"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="7eN-W8-bl6" id="Sv5-p2-DUR">
-                                    <rect key="frame" x="0.0" y="0.0" width="383" height="117"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="117"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_flag_24pt" translatesAutoresizingMaskIntoConstraints="NO" id="NZg-b9-D6t">
@@ -736,7 +736,7 @@
                                             <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="749" text="Source" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hcK-RU-q0h">
-                                            <rect key="frame" x="60" y="11" width="315" height="40"/>
+                                            <rect key="frame" x="60" y="11" width="317.5" height="40"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="40" id="5Nr-0m-KyS"/>
                                             </constraints>
@@ -745,7 +745,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="To" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ScZ-JV-Cgi">
-                                            <rect key="frame" x="60" y="51" width="315" height="14"/>
+                                            <rect key="frame" x="60" y="51" width="317.5" height="14"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
@@ -755,13 +755,13 @@
                                             <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Unknown Group" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="My7-dn-jPO">
-                                            <rect key="frame" x="60" y="71" width="315" height="20.5"/>
+                                            <rect key="frame" x="60" y="71" width="317.5" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="0xC003" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aRE-0e-eEj">
-                                            <rect key="frame" x="60" y="91.5" width="315" height="14.5"/>
+                                            <rect key="frame" x="60" y="91.5" width="317.5" height="14.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
@@ -797,7 +797,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="action" textLabel="Wih-3i-ZYO" style="IBUITableViewCellStyleDefault" id="Coq-iZ-Cul">
-                                <rect key="frame" x="0.0" y="616.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="593" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Coq-iZ-Cul" id="A6y-Hp-Rsk">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -814,7 +814,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="rightAction" id="Q6u-8W-cen" customClass="RightActionCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="660" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="636.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Q6u-8W-cen" id="tVO-gC-OXg">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -870,7 +870,7 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="cell" textLabel="eER-lh-FO1" imageView="5cf-Bn-ahg" style="IBUITableViewCellStyleDefault" id="U6F-4M-EjA">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="U6F-4M-EjA" id="iY3-jw-MX0">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -921,7 +921,7 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" textLabel="Cc5-FL-aJy" imageView="orq-cS-Lg1" style="IBUITableViewCellStyleDefault" id="2dn-lH-BB6">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2dn-lH-BB6" id="fQ1-Yt-RnR">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -979,10 +979,10 @@
                             <tableViewSection id="RmD-4j-793">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="c7K-fm-78b" detailTextLabel="6zU-SL-IBl" style="IBUITableViewCellStyleValue1" id="Gww-KH-IFf">
-                                        <rect key="frame" x="0.0" y="18" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="18" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Gww-KH-IFf" id="my3-lv-2W1">
-                                            <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="c7K-fm-78b">
@@ -993,7 +993,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6zU-SL-IBl">
-                                                    <rect key="frame" x="331" y="12" width="44" height="20.5"/>
+                                                    <rect key="frame" x="333.5" y="12" width="44" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -1007,10 +1007,10 @@
                             <tableViewSection headerTitle="Provisioning data" id="PXD-VG-fTb">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="sJ7-Xf-3XG" detailTextLabel="iOG-Yh-pyA" style="IBUITableViewCellStyleValue1" id="skW-yF-7H1">
-                                        <rect key="frame" x="0.0" y="118" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="111.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="skW-yF-7H1" id="wb9-d5-HyN">
-                                            <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Unicast Address" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="sJ7-Xf-3XG">
@@ -1021,7 +1021,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="iOG-Yh-pyA">
-                                                    <rect key="frame" x="331" y="12" width="44" height="20.5"/>
+                                                    <rect key="frame" x="333.5" y="12" width="44" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -1031,10 +1031,10 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="tnA-cs-K5w" detailTextLabel="jB2-Ks-5Wg" style="IBUITableViewCellStyleValue1" id="Ndg-0Q-WKP">
-                                        <rect key="frame" x="0.0" y="162" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="155" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ndg-0Q-WKP" id="8aB-K7-Nni">
-                                            <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Network Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="tnA-cs-K5w">
@@ -1045,7 +1045,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jB2-Ks-5Wg">
-                                                    <rect key="frame" x="331" y="12" width="44" height="20.5"/>
+                                                    <rect key="frame" x="333.5" y="12" width="44" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -1061,8 +1061,8 @@
                             </tableViewSection>
                             <tableViewSection headerTitle="Device Capabilities" id="af4-PB-fZt">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="Oqg-7c-iJ0" detailTextLabel="E9e-8N-Sbw" style="IBUITableViewCellStyleSubtitle" id="X4R-XT-NZP">
-                                        <rect key="frame" x="0.0" y="262" width="414" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="Oqg-7c-iJ0" detailTextLabel="E9e-8N-Sbw" style="IBUITableViewCellStyleSubtitle" id="X4R-XT-NZP">
+                                        <rect key="frame" x="0.0" y="248.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="X4R-XT-NZP" id="idM-7j-BIS">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -1085,15 +1085,15 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="BAq-5b-9tR" detailTextLabel="pS5-Y5-QgE" style="IBUITableViewCellStyleSubtitle" id="yy7-AU-JwL">
-                                        <rect key="frame" x="0.0" y="306" width="414" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="BAq-5b-9tR" detailTextLabel="pS5-Y5-QgE" style="IBUITableViewCellStyleSubtitle" id="yy7-AU-JwL">
+                                        <rect key="frame" x="0.0" y="292.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yy7-AU-JwL" id="NYW-m7-WPo">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Supported Algorithms" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="BAq-5b-9tR">
-                                                    <rect key="frame" x="20" y="5" width="168" height="20.5"/>
+                                                    <rect key="frame" x="20" y="5" width="167.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1109,8 +1109,8 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="SdP-NS-3LU" detailTextLabel="zDh-JJ-bBg" style="IBUITableViewCellStyleSubtitle" id="eZz-wJ-sSf">
-                                        <rect key="frame" x="0.0" y="350" width="414" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="SdP-NS-3LU" detailTextLabel="zDh-JJ-bBg" style="IBUITableViewCellStyleSubtitle" id="eZz-wJ-sSf">
+                                        <rect key="frame" x="0.0" y="336.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eZz-wJ-sSf" id="JU7-kU-7e4">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -1133,8 +1133,8 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="MAo-QP-eik" detailTextLabel="Qdh-uv-1ef" style="IBUITableViewCellStyleSubtitle" id="zIh-z7-aCQ">
-                                        <rect key="frame" x="0.0" y="394" width="414" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="MAo-QP-eik" detailTextLabel="Qdh-uv-1ef" style="IBUITableViewCellStyleSubtitle" id="zIh-z7-aCQ">
+                                        <rect key="frame" x="0.0" y="380.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zIh-z7-aCQ" id="RvA-5b-yC4">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -1157,8 +1157,8 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="eb8-fF-0rX" detailTextLabel="xit-9M-VEk" style="IBUITableViewCellStyleSubtitle" id="yXs-ab-vbS">
-                                        <rect key="frame" x="0.0" y="438" width="414" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="eb8-fF-0rX" detailTextLabel="xit-9M-VEk" style="IBUITableViewCellStyleSubtitle" id="yXs-ab-vbS">
+                                        <rect key="frame" x="0.0" y="424.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yXs-ab-vbS" id="21N-Ac-V6X">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -1181,8 +1181,8 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="UHQ-mH-G4A" detailTextLabel="6SF-mc-Wie" style="IBUITableViewCellStyleSubtitle" id="r10-EK-VFc">
-                                        <rect key="frame" x="0.0" y="482" width="414" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="UHQ-mH-G4A" detailTextLabel="6SF-mc-Wie" style="IBUITableViewCellStyleSubtitle" id="r10-EK-VFc">
+                                        <rect key="frame" x="0.0" y="468.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="r10-EK-VFc" id="K8t-gu-4ze">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -1205,8 +1205,8 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="FYj-2z-A6L" detailTextLabel="Sef-42-c2U" style="IBUITableViewCellStyleSubtitle" id="cDY-r8-cnx">
-                                        <rect key="frame" x="0.0" y="526" width="414" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="FYj-2z-A6L" detailTextLabel="Sef-42-c2U" style="IBUITableViewCellStyleSubtitle" id="cDY-r8-cnx">
+                                        <rect key="frame" x="0.0" y="512.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cDY-r8-cnx" id="zuh-i6-uLf">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -1229,15 +1229,15 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="3cl-hR-g1F" detailTextLabel="98S-j6-Bn7" style="IBUITableViewCellStyleSubtitle" id="V9Y-Uy-SAb">
-                                        <rect key="frame" x="0.0" y="570" width="414" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="3cl-hR-g1F" detailTextLabel="98S-j6-Bn7" style="IBUITableViewCellStyleSubtitle" id="V9Y-Uy-SAb">
+                                        <rect key="frame" x="0.0" y="556.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="V9Y-Uy-SAb" id="dYF-2R-tkK">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Supported Input OOB Actions" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3cl-hR-g1F">
-                                                    <rect key="frame" x="20" y="5" width="226" height="20.5"/>
+                                                    <rect key="frame" x="20" y="5" width="225.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1300,7 +1300,7 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="subtitleCell" textLabel="UuD-A9-ecN" detailTextLabel="JJO-K5-FWi" imageView="SK2-Gc-j8W" style="IBUITableViewCellStyleSubtitle" id="kUW-jo-TIK">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kUW-jo-TIK" id="ZVc-L3-gUW">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -1377,10 +1377,10 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="node" rowHeight="120" id="0EL-zf-FEG" customClass="NodeViewCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="120"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="120"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0EL-zf-FEG" id="1ez-9g-bU1">
-                                    <rect key="frame" x="0.0" y="0.0" width="383" height="120"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="120"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="mesh-icon" translatesAutoresizingMaskIntoConstraints="NO" id="Txo-PC-sVO">
@@ -1391,7 +1391,7 @@
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Device name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="98E-5m-rAh">
-                                            <rect key="frame" x="84" y="11" width="291" height="21"/>
+                                            <rect key="frame" x="84" y="11" width="293.5" height="21"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -1421,13 +1421,13 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="18L-cV-20F">
-                                            <rect key="frame" x="153.5" y="40" width="221.5" height="16"/>
+                                            <rect key="frame" x="153.5" y="40" width="224" height="16"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fus-yD-CnI">
-                                            <rect key="frame" x="153.5" y="56" width="221.5" height="16"/>
+                                            <rect key="frame" x="153.5" y="56" width="224" height="16"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="16" id="PMh-X3-P1F"/>
                                             </constraints>
@@ -1436,7 +1436,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="htL-Ix-2vE">
-                                            <rect key="frame" x="153.5" y="72" width="221.5" height="16"/>
+                                            <rect key="frame" x="153.5" y="72" width="224" height="16"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="16" id="P7c-JG-sJd"/>
                                             </constraints>
@@ -1445,7 +1445,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ukb-VS-Bpo">
-                                            <rect key="frame" x="153.5" y="88" width="221.5" height="16"/>
+                                            <rect key="frame" x="153.5" y="88" width="224" height="16"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="16" id="uXf-Lr-Pjk"/>
                                             </constraints>
@@ -1553,7 +1553,7 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="cell" textLabel="3Fa-PP-psK" detailTextLabel="zTB-JB-wwc" imageView="J4L-Hn-dT8" style="IBUITableViewCellStyleSubtitle" id="Gow-zA-0ZK">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Gow-zA-0ZK" id="Pwt-a2-aFR">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -1611,7 +1611,7 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="sceneCell" textLabel="SWv-IP-7wd" imageView="dGK-qC-n0P" style="IBUITableViewCellStyleDefault" id="zr5-Ou-dXe">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zr5-Ou-dXe" id="jsA-VO-KNN">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -1662,7 +1662,7 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" textLabel="c6l-QB-tkL" detailTextLabel="xYK-ff-zZ5" imageView="v5K-qu-dhX" style="IBUITableViewCellStyleSubtitle" id="4Lv-n1-Nkc">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="4Lv-n1-Nkc" id="DkE-0E-6Pj">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -1725,7 +1725,7 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="sceneCell" textLabel="zCR-XQ-kge" imageView="fEr-9c-k7n" style="IBUITableViewCellStyleDefault" id="29G-HU-a10">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="29G-HU-a10" id="LwF-Ud-wiq">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -1831,7 +1831,7 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" textLabel="asV-mb-ygX" imageView="LzD-OQ-CSA" style="IBUITableViewCellStyleDefault" id="DxK-cQ-ZuD">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="DxK-cQ-ZuD" id="3lu-9U-GNm">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -1887,7 +1887,7 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="group" textLabel="qGJ-q6-tac" imageView="2uI-i4-AHX" style="IBUITableViewCellStyleDefault" id="9xQ-3Q-vvq">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="9xQ-3Q-vvq" id="33E-IW-2hh">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -1904,6 +1904,23 @@
                                             <rect key="frame" x="20" y="9.5" width="24" height="24"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </imageView>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="action" textLabel="IHh-sT-StB" style="IBUITableViewCellStyleDefault" id="Dcg-1z-usk">
+                                <rect key="frame" x="0.0" y="75.5" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Dcg-1z-usk" id="Fjf-KM-mdd">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Add Group" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="IHh-sT-StB">
+                                            <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
                                     </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
@@ -2044,7 +2061,7 @@
                             <tableViewSection id="yiL-Cp-kym">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="switch" rowHeight="70" id="6JR-Pa-8mI">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="70"/>
+                                        <rect key="frame" x="0.0" y="44.5" width="414" height="70"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="6JR-Pa-8mI" id="Dhc-vd-XmA">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="70"/>
@@ -2074,10 +2091,10 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="transitionTime" id="IDK-S0-dUM">
-                                        <rect key="frame" x="0.0" y="98" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="114.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="IDK-S0-dUM" id="Dhs-Bg-JpK">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="N/A" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DYN-n3-p2u">
@@ -2106,10 +2123,10 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="delay" id="1ik-da-nMU">
-                                        <rect key="frame" x="0.0" y="141.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="158.5" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1ik-da-nMU" id="eTZ-fb-EUc">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="N/A" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ybk-dc-hni">

--- a/Example/nRFMeshProvision/UI/Base.lproj/SetHeartbeatPublication.storyboard
+++ b/Example/nRFMeshProvision/UI/Base.lproj/SetHeartbeatPublication.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="H96-er-obO">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="H96-er-obO">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,7 +23,7 @@
                                         <rect key="frame" x="0.0" y="18" width="414" height="123"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="vL5-lo-0FR" id="C9M-81-jTy">
-                                            <rect key="frame" x="0.0" y="0.0" width="383" height="123"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="123"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_flag_24pt" translatesAutoresizingMaskIntoConstraints="NO" id="hS5-bj-HJT">
@@ -31,13 +31,13 @@
                                                     <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Unknown Group" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Ua-IU-7k1">
-                                                    <rect key="frame" x="60" y="11" width="315" height="20.5"/>
+                                                    <rect key="frame" x="60" y="11" width="317.5" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="0xC003" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vuv-K0-7kL">
-                                                    <rect key="frame" x="60" y="31.5" width="315" height="14.5"/>
+                                                    <rect key="frame" x="60" y="31.5" width="317.5" height="14.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
                                                     <nil key="highlightedColor"/>
@@ -47,7 +47,7 @@
                                                     <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="749" text="Network Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fJ5-93-fP0">
-                                                    <rect key="frame" x="60" y="72" width="315" height="40"/>
+                                                    <rect key="frame" x="60" y="72" width="317.5" height="40"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="40" id="vVa-sJ-mr2"/>
                                                     </constraints>
@@ -56,7 +56,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Using" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iil-6k-MPo">
-                                                    <rect key="frame" x="60" y="52" width="315" height="14"/>
+                                                    <rect key="frame" x="60" y="52" width="317.5" height="14"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
                                                     <nil key="highlightedColor"/>
@@ -124,10 +124,10 @@
                             <tableViewSection headerTitle="Periodic Heartbeats" footerTitle="Count and period between the publication of two consecutive periodical Heartbeat messages." id="lyU-uf-X8A">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="gND-M8-2qr">
-                                        <rect key="frame" x="0.0" y="284" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="278" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="gND-M8-2qr" id="FfL-3j-d5K">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="19" translatesAutoresizingMaskIntoConstraints="NO" id="w6a-6v-zSY">
@@ -156,10 +156,10 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="eI6-92-7dO">
-                                        <rect key="frame" x="0.0" y="328" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="321.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eI6-92-7dO" id="mfv-na-qQu">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="N/A" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O1a-MH-pTY">
@@ -192,7 +192,7 @@
                             <tableViewSection headerTitle="Features" footerTitle="The features that trigger sending Heartbeat messages when changed." id="hHw-b5-ihd">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="switch" rowHeight="44" id="IdF-6Z-ASj" customClass="SwitchCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="463.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="445" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="IdF-6Z-ASj" id="Kx8-kf-xi5">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -224,7 +224,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="switch" rowHeight="44" id="tf0-qB-0Ro" customClass="SwitchCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="507.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="489" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tf0-qB-0Ro" id="TfQ-f8-Xkg">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -256,7 +256,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="switch" rowHeight="44" id="5Et-NV-gwW" customClass="SwitchCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="551.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="533" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5Et-NV-gwW" id="IGs-Z4-mQG">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -288,7 +288,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="switch" rowHeight="44" id="OVs-MU-18U" customClass="SwitchCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="595.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="577" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OVs-MU-18U" id="Hkj-0j-0LC">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -394,7 +394,7 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="key" textLabel="Y7n-iB-t5r" imageView="mYY-j5-Clx" style="IBUITableViewCellStyleDefault" id="raC-Ti-qSV">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="raC-Ti-qSV" id="bna-zu-cdE">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -415,7 +415,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="normal" textLabel="eA5-uB-un9" imageView="EOI-oG-sAs" style="IBUITableViewCellStyleDefault" id="BqY-9f-gpq">
-                                <rect key="frame" x="0.0" y="99" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="75.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="BqY-9f-gpq" id="Cpg-6M-vbh">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -436,7 +436,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="empty" textLabel="CnW-Wi-MeE" imageView="Tq6-VH-MJv" style="IBUITableViewCellStyleDefault" id="phl-99-gaa">
-                                <rect key="frame" x="0.0" y="142.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="119" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="phl-99-gaa" id="u14-rH-yxj">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -453,6 +453,24 @@
                                             <rect key="frame" x="20" y="9.5" width="24" height="24"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </imageView>
+                                    </subviews>
+                                    <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="action" textLabel="rS8-5D-a9B" style="IBUITableViewCellStyleDefault" id="aXO-vh-mhP">
+                                <rect key="frame" x="0.0" y="162.5" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="aXO-vh-mhP" id="ms6-gu-mtd">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Add Group" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="rS8-5D-a9B">
+                                            <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
                                     </subviews>
                                     <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </tableViewCellContentView>

--- a/Example/nRFMeshProvision/UI/Base.lproj/SetPublication.storyboard
+++ b/Example/nRFMeshProvision/UI/Base.lproj/SetPublication.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oR7-ra-qwb">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oR7-ra-qwb">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,7 +23,7 @@
                                         <rect key="frame" x="0.0" y="18" width="375" height="123"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="6Sj-2I-aX6" id="AlB-Cn-u4m">
-                                            <rect key="frame" x="0.0" y="0.0" width="347.66666666666669" height="123"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350.33333333333331" height="123"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_flag_24pt" translatesAutoresizingMaskIntoConstraints="NO" id="dIa-rw-AEc">
@@ -31,13 +31,13 @@
                                                     <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Element 1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="93t-fb-GT5">
-                                                    <rect key="frame" x="56" y="11.000000000000002" width="283.66666666666669" height="20.666666666666671"/>
+                                                    <rect key="frame" x="56" y="11.000000000000002" width="286.33333333333331" height="20.666666666666671"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Node 1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yFj-zk-MZp">
-                                                    <rect key="frame" x="56" y="31.666666666666668" width="283.66666666666669" height="14.333333333333332"/>
+                                                    <rect key="frame" x="56" y="31.666666666666668" width="286.33333333333331" height="14.333333333333332"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
                                                     <nil key="highlightedColor"/>
@@ -47,19 +47,19 @@
                                                     <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="749" text="Application Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uCV-vG-SbP">
-                                                    <rect key="frame" x="56" y="73" width="283.66666666666669" height="24"/>
+                                                    <rect key="frame" x="56" y="73" width="286.33333333333331" height="24"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Bound to Network Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1hE-Ud-yeO">
-                                                    <rect key="frame" x="56" y="97" width="291.66666666666669" height="15"/>
+                                                    <rect key="frame" x="56" y="97" width="294.33333333333331" height="15"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Using" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d72-f1-gKq">
-                                                    <rect key="frame" x="56" y="52" width="283.66666666666669" height="15"/>
+                                                    <rect key="frame" x="56" y="52" width="286.33333333333331" height="15"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
                                                     <nil key="highlightedColor"/>
@@ -99,10 +99,10 @@
                             <tableViewSection id="ypk-Hq-KcM">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="6jV-0B-PXg" detailTextLabel="WJZ-yR-wNf" style="IBUITableViewCellStyleValue1" id="o5P-ew-a5g">
-                                        <rect key="frame" x="0.0" y="177" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="177" width="375" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="o5P-ew-a5g" id="0PU-fH-jus">
-                                            <rect key="frame" x="0.0" y="0.0" width="347.66666666666669" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350.33333333333331" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="TTL" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6jV-0B-PXg">
@@ -113,7 +113,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Default" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="WJZ-yR-wNf">
-                                                    <rect key="frame" x="284.66666666666669" y="11.999999999999998" width="55" height="20.333333333333332"/>
+                                                    <rect key="frame" x="287.33333333333331" y="11.999999999999998" width="55" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -123,7 +123,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="switch" rowHeight="44" id="8LD-Fe-cc6" customClass="SwitchCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="221" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="220.66666793823242" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8LD-Fe-cc6" id="yG0-3F-3FX">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
@@ -159,10 +159,10 @@
                             <tableViewSection headerTitle="Periodic publishing interval" id="vZk-us-KBy">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="ja8-Xh-9nV">
-                                        <rect key="frame" x="0.0" y="321" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="314.33333396911621" width="375" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ja8-Xh-9nV" id="COE-Fk-s7D">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="239" translatesAutoresizingMaskIntoConstraints="NO" id="Jiv-Le-ay1">
@@ -172,7 +172,7 @@
                                                     </connections>
                                                 </slider>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disabled" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LO7-zu-dod">
-                                                    <rect key="frame" x="249" y="11.666666666666664" width="110" height="21"/>
+                                                    <rect key="frame" x="249" y="11.333333333333336" width="110" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="110" id="hNw-ej-zAT"/>
                                                     </constraints>
@@ -195,14 +195,14 @@
                             <tableViewSection headerTitle="Retransmission Count &amp; Interval" id="ojl-d4-CPv">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="eoi-Cw-SDk">
-                                        <rect key="frame" x="0.0" y="421" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="407.66666793823242" width="375" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eoi-Cw-SDk" id="wke-Nw-5f1">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Disabled" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sca-nS-hF8">
-                                                    <rect key="frame" x="249" y="11.666666666666664" width="110" height="21"/>
+                                                    <rect key="frame" x="249" y="11.333333333333336" width="110" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="110" id="yiU-LS-bov"/>
                                                     </constraints>
@@ -227,14 +227,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="abE-8s-0Yz">
-                                        <rect key="frame" x="0.0" y="465" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="451.33333587646484" width="375" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="abE-8s-0Yz" id="aIT-pG-6NL">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="N/A" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ddb-4h-1kT">
-                                                    <rect key="frame" x="249" y="11.666666666666664" width="110" height="21"/>
+                                                    <rect key="frame" x="249" y="11.333333333333336" width="110" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="110" id="Kxp-dw-wPo"/>
                                                     </constraints>
@@ -311,7 +311,7 @@
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="key" textLabel="biv-XM-g70" detailTextLabel="ctm-gy-wjN" imageView="Cg4-Hh-ylL" style="IBUITableViewCellStyleSubtitle" id="6gd-60-7PQ">
-                                <rect key="frame" x="0.0" y="55.333332061767578" width="375" height="55.666667938232422"/>
+                                <rect key="frame" x="0.0" y="31.666666030883789" width="375" height="55.666667938232422"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="6gd-60-7PQ" id="vSH-Sy-xzS">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="55.666667938232422"/>
@@ -339,7 +339,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="subtitle" textLabel="1TO-aa-xER" detailTextLabel="j3y-ng-TxV" imageView="9PS-6l-iHV" style="IBUITableViewCellStyleSubtitle" id="rGW-CF-eMp">
-                                <rect key="frame" x="0.0" y="111" width="375" height="55.666667938232422"/>
+                                <rect key="frame" x="0.0" y="87.333333969116211" width="375" height="55.666667938232422"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="rGW-CF-eMp" id="448-dT-dY0">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="55.666667938232422"/>
@@ -367,7 +367,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="normal" textLabel="HaX-Zt-oAd" imageView="yaq-P3-Nkz" style="IBUITableViewCellStyleDefault" id="1GZ-lC-xqs">
-                                <rect key="frame" x="0.0" y="166.66666793823242" width="375" height="43.666667938232422"/>
+                                <rect key="frame" x="0.0" y="143.00000190734863" width="375" height="43.666667938232422"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1GZ-lC-xqs" id="z79-nE-KD3">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.666667938232422"/>
@@ -388,7 +388,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="empty" textLabel="ptw-nb-6kI" imageView="WoJ-Pw-tEh" style="IBUITableViewCellStyleDefault" id="vwG-EN-WFL">
-                                <rect key="frame" x="0.0" y="210.33333587646484" width="375" height="43.666667938232422"/>
+                                <rect key="frame" x="0.0" y="186.66666984558105" width="375" height="43.666667938232422"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="vwG-EN-WFL" id="eRU-2x-Swh">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.666667938232422"/>
@@ -407,6 +407,23 @@
                                         </imageView>
                                     </subviews>
                                     <color key="tintColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="action" textLabel="rmC-w8-HQp" style="IBUITableViewCellStyleDefault" id="aCR-PH-CbT">
+                                <rect key="frame" x="0.0" y="230.33333778381348" width="375" height="43.666667938232422"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="aCR-PH-CbT" id="Dr9-Dj-W9t">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.666667938232422"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Add Group" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="rmC-w8-HQp">
+                                            <rect key="frame" x="16" y="0.0" width="343" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
                         </prototypes>

--- a/Example/nRFMeshProvision/UI/Model/ConfigurationServer.xib
+++ b/Example/nRFMeshProvision/UI/Model/ConfigurationServer.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -67,6 +67,9 @@
                         <rect key="frame" x="330" y="109.5" width="64" height="30"/>
                         <state key="normal" title="Set Relay">
                             <color key="titleColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                        </state>
+                        <state key="disabled">
+                            <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </state>
                         <connections>
                             <action selector="setRelayTapped:" destination="RhT-zv-Hbx" eventType="touchUpInside" id="Z0R-rk-GBX"/>
@@ -160,6 +163,9 @@
                         <state key="normal" title="Set Network Transmit">
                             <color key="titleColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                         </state>
+                        <state key="disabled">
+                            <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </state>
                         <connections>
                             <action selector="setNetworkTransmitTapped:" destination="RhT-zv-Hbx" eventType="touchUpInside" id="vuf-VP-tgm"/>
                         </connections>
@@ -233,7 +239,7 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GATT PROXY" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pZg-Cd-Fwp">
-                                <rect key="frame" x="20" y="31" width="86" height="17"/>
+                                <rect key="frame" x="20" y="28" width="86" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" red="0.42745098040000001" green="0.42745098040000001" blue="0.44705882349999998" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -285,7 +291,7 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="FRIEND FEATURE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kil-Eu-rzv">
-                                <rect key="frame" x="20" y="31" width="113" height="17"/>
+                                <rect key="frame" x="20" y="28" width="113" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" red="0.42745098040000001" green="0.42745098040000001" blue="0.44705882349999998" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>

--- a/Example/nRFMeshProvision/UI/Model/GenericDefaultTransitionTime.xib
+++ b/Example/nRFMeshProvision/UI/Model/GenericDefaultTransitionTime.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -66,6 +66,9 @@
                         </constraints>
                         <state key="normal" title="Set">
                             <color key="titleColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                        </state>
+                        <state key="disabled">
+                            <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </state>
                         <connections>
                             <action selector="setTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="Ze5-7n-euf"/>
@@ -138,6 +141,9 @@
                         </constraints>
                         <state key="normal" title="Read">
                             <color key="titleColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                        </state>
+                        <state key="disabled">
+                            <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </state>
                         <connections>
                             <action selector="readTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="bad-lc-eve"/>

--- a/Example/nRFMeshProvision/UI/Model/GenericLevel.xib
+++ b/Example/nRFMeshProvision/UI/Model/GenericLevel.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -150,6 +150,9 @@
                         <state key="normal" title="Set">
                             <color key="titleColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                         </state>
+                        <state key="disabled">
+                            <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </state>
                         <connections>
                             <action selector="setTapped:" destination="OfH-s1-u7y" eventType="touchUpInside" id="P5A-MM-Eui"/>
                         </connections>
@@ -244,6 +247,9 @@
                         </constraints>
                         <state key="normal" title="Read">
                             <color key="titleColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                        </state>
+                        <state key="disabled">
+                            <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </state>
                         <connections>
                             <action selector="readTapped:" destination="OfH-s1-u7y" eventType="touchUpInside" id="fYG-Vq-Bvw"/>

--- a/Example/nRFMeshProvision/UI/Model/GenericOnOff.xib
+++ b/Example/nRFMeshProvision/UI/Model/GenericOnOff.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -111,6 +111,9 @@
                         <state key="normal" title="ON">
                             <color key="titleColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                         </state>
+                        <state key="disabled">
+                            <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </state>
                         <connections>
                             <action selector="onTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="vMq-NF-rdz"/>
                         </connections>
@@ -122,6 +125,9 @@
                         </constraints>
                         <state key="normal" title="OFF">
                             <color key="titleColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                        </state>
+                        <state key="disabled">
+                            <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </state>
                         <connections>
                             <action selector="offTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="DVD-ba-uIl"/>
@@ -217,6 +223,9 @@
                         </constraints>
                         <state key="normal" title="Read">
                             <color key="titleColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                        </state>
+                        <state key="disabled">
+                            <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </state>
                         <connections>
                             <action selector="readTapped:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="bad-lc-eve"/>

--- a/Example/nRFMeshProvision/UI/Model/GenericPowerOnOff.xib
+++ b/Example/nRFMeshProvision/UI/Model/GenericPowerOnOff.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -48,6 +48,9 @@
                         </constraints>
                         <state key="normal" title="Get">
                             <color key="titleColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                        </state>
+                        <state key="disabled">
+                            <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </state>
                         <connections>
                             <action selector="readTapped:" destination="B4P-wJ-v4L" eventType="touchUpInside" id="nB8-au-3sM"/>

--- a/Example/nRFMeshProvision/UI/Model/GenericPowerOnOffSetup.xib
+++ b/Example/nRFMeshProvision/UI/Model/GenericPowerOnOffSetup.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -91,6 +91,9 @@
                         </constraints>
                         <state key="normal" title="Set">
                             <color key="titleColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                        </state>
+                        <state key="disabled">
+                            <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </state>
                         <connections>
                             <action selector="sendTapped:" destination="evn-P7-ZvA" eventType="touchUpInside" id="87a-1g-3GF"/>

--- a/Example/nRFMeshProvision/UI/Model/VendorModel.xib
+++ b/Example/nRFMeshProvision/UI/Model/VendorModel.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Example/nRFMeshProvision/UITableViewCell+Disabled.swift
+++ b/Example/nRFMeshProvision/UITableViewCell+Disabled.swift
@@ -1,0 +1,62 @@
+//
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import UIKit
+
+extension UITableViewCell {
+    
+    func setEnabled(_ enabled: Bool) {
+        isUserInteractionEnabled = enabled
+        if enabled {
+            if #available(iOS 13.0, *) {
+                textLabel?.textColor = .label
+                detailTextLabel?.textColor = .label
+                imageView?.tintColor = .nordicLake
+            } else {
+                textLabel?.textColor = .darkText
+                detailTextLabel?.textColor = .darkText
+                imageView?.tintColor = .nordicLake
+            }
+        } else {
+            if #available(iOS 13.0, *) {
+                textLabel?.textColor = .secondaryLabel
+                detailTextLabel?.textColor = .secondaryLabel
+                imageView?.tintColor = .secondaryLabel
+            } else {
+                textLabel?.textColor = .lightGray
+                detailTextLabel?.textColor = .lightGray
+                imageView?.tintColor = .lightGray
+            }
+        }
+    }
+    
+}

--- a/Example/nRFMeshProvision/UITableViewCell+Disabled.swift
+++ b/Example/nRFMeshProvision/UITableViewCell+Disabled.swift
@@ -34,27 +34,32 @@ import UIKit
 
 extension UITableViewCell {
     
-    func setEnabled(_ enabled: Bool) {
-        isUserInteractionEnabled = enabled
-        if enabled {
-            if #available(iOS 13.0, *) {
-                textLabel?.textColor = .label
-                detailTextLabel?.textColor = .label
-                imageView?.tintColor = .nordicLake
+    var isEnabled: Bool {
+        get {
+            return isUserInteractionEnabled
+        }
+        set(enabled) {
+            isUserInteractionEnabled = enabled
+            if enabled {
+                if #available(iOS 13.0, *) {
+                    textLabel?.textColor = .label
+                    detailTextLabel?.textColor = .label
+                    imageView?.tintColor = .nordicLake
+                } else {
+                    textLabel?.textColor = .darkText
+                    detailTextLabel?.textColor = .darkText
+                    imageView?.tintColor = .nordicLake
+                }
             } else {
-                textLabel?.textColor = .darkText
-                detailTextLabel?.textColor = .darkText
-                imageView?.tintColor = .nordicLake
-            }
-        } else {
-            if #available(iOS 13.0, *) {
-                textLabel?.textColor = .secondaryLabel
-                detailTextLabel?.textColor = .secondaryLabel
-                imageView?.tintColor = .secondaryLabel
-            } else {
-                textLabel?.textColor = .lightGray
-                detailTextLabel?.textColor = .lightGray
-                imageView?.tintColor = .lightGray
+                if #available(iOS 13.0, *) {
+                    textLabel?.textColor = .secondaryLabel
+                    detailTextLabel?.textColor = .secondaryLabel
+                    imageView?.tintColor = .secondaryLabel
+                } else {
+                    textLabel?.textColor = .lightGray
+                    detailTextLabel?.textColor = .lightGray
+                    imageView?.tintColor = .lightGray
+                }
             }
         }
     }

--- a/Example/nRFMeshProvision/View Controllers/Common/RightActionCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Common/RightActionCell.swift
@@ -40,12 +40,6 @@ class RightActionCell: UITableViewCell {
     
     var delegate: (() -> ())?
     
-    var isEnabled: Bool = true {
-        didSet {
-            rightActionButton.isEnabled = isEnabled
-        }
-    }
-    
     override var textLabel: UILabel? {
         return rightActionButton.titleLabel
     }

--- a/Example/nRFMeshProvision/View Controllers/Control/ControlViewCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Control/ControlViewCell.swift
@@ -135,20 +135,20 @@ class ControlViewController: ProgressCollectionViewController {
         let name = model.isSimpleOnOffClient ? "Simple OnOff Client" : model.name ?? "Unknown Model"
         var message: String?
         if !model.subscriptions.isEmpty {
-            let groups = model.subscriptions.map({ $0.name }).joined(separator: ", ")
+            let groups = model.subscriptions.map { $0.name }.joined(separator: ", ")
             message = "This model is subscribed to the following groups: \(groups)."
             
             if let publish = model.publish {
                 let network = MeshNetworkManager.instance.meshNetwork!
                 let applicationKey = network.applicationKeys[publish.index]
-                let group = network.group(withAddress: publish.publicationAddress)
-                message! += " It is also set up to publish to \(group?.name ?? publish.publicationAddress.asString()) using \(applicationKey?.name ?? "unknown Application Key")."
+                let group = network.group(withAddress: publish.publicationAddress) ?? Group.specialGroup(withAddress: publish.publicationAddress)
+                message! += " It is also set up to publish to \(group?.name ?? publish.publicationAddress.asString()) using \(applicationKey?.name ?? "an unknown Application Key")."
             }
         } else if let publish = model.publish {
             let network = MeshNetworkManager.instance.meshNetwork!
             let applicationKey = network.applicationKeys[publish.index]
-            let group = network.group(withAddress: publish.publicationAddress)
-            message = "This model is set up to publish to \(group?.name ?? publish.publicationAddress.asString()) using \(applicationKey?.name ?? "unknown Application Key")."
+            let group = network.group(withAddress: publish.publicationAddress) ?? Group.specialGroup(withAddress: publish.publicationAddress)
+            message = "This model is set up to publish to \(group?.name ?? publish.publicationAddress.asString()) using \(applicationKey?.name ?? "an unknown Application Key")."
         } else {
             message = "This model does not have subscription or publication set. Go to Network tab, find the local provisioner and configure the \(name) on \(element.name ?? "Element \(element.index + 1)")."
         }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/Cells/HeartbeatPublicationCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/Cells/HeartbeatPublicationCell.swift
@@ -41,37 +41,21 @@ class HeartbeatPublicationCell: UITableViewCell {
     
     var heartbeatPublication: HeartbeatPublication! {
         didSet {
+            let meshNetwork = MeshNetworkManager.instance.meshNetwork!
             let address = heartbeatPublication.address
             if address.isUnicast {
-                let meshNetwork = MeshNetworkManager.instance.meshNetwork!
                 let node = meshNetwork.node(withAddress: address)
                 destinationLabel.text = node?.name ?? "Unknown Device"
                 destinationSubtitleLabel.text = nil
                 destinationIcon.tintColor = .nordicLake
                 destinationIcon.image = #imageLiteral(resourceName: "ic_flag_24pt")
             } else if address.isGroup {
-                switch address {
-                case .allProxies:
-                    destinationLabel.text = "All Proxies"
+                if let group = meshNetwork.group(withAddress: address) ?? Group.specialGroup(withAddress: address) {
+                    destinationLabel.text = group.name
                     destinationSubtitleLabel.text = nil
-                case .allFriends:
-                    destinationLabel.text = "All Friends"
-                    destinationSubtitleLabel.text = nil
-                case .allRelays:
-                    destinationLabel.text = "All Relays"
-                    destinationSubtitleLabel.text = nil
-                case .allNodes:
-                    destinationLabel.text = "All Nodes"
-                    destinationSubtitleLabel.text = nil
-                default:
-                    let meshNetwork = MeshNetworkManager.instance.meshNetwork!
-                    if let group = meshNetwork.group(withAddress: MeshAddress(address)) {
-                        destinationLabel.text = group.name
-                        destinationSubtitleLabel.text = nil
-                    } else {
-                        destinationLabel.text = "Unknown group"
-                        destinationSubtitleLabel.text = address.asString()
-                    }
+                } else {
+                    destinationLabel.text = "Unknown group"
+                    destinationSubtitleLabel.text = address.asString()
                 }
                 destinationIcon.image = #imageLiteral(resourceName: "tab_groups_outline_black_24pt")
                 destinationIcon.tintColor = .nordicLake
@@ -82,7 +66,6 @@ class HeartbeatPublicationCell: UITableViewCell {
                 destinationIcon.image = #imageLiteral(resourceName: "ic_flag_24pt")
             }
             
-            let meshNetwork = MeshNetworkManager.instance.meshNetwork!
             if let networkKey = meshNetwork.networkKeys[heartbeatPublication.networkKeyIndex] {
                 keyIcon.tintColor = .nordicLake
                 keyLabel.text = networkKey.name

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/Cells/HeartbeatSubscriptionCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/Cells/HeartbeatSubscriptionCell.swift
@@ -40,26 +40,18 @@ class HeartbeatSubscriptionCell: UITableViewCell {
     @IBOutlet weak var destinationIcon: UIImageView!
     @IBOutlet weak var destinationSubtitle: UILabel!
     
-    private let specialGroups: [Address: String] = [
-        Address.allProxies : "All Proxies",
-        Address.allFriends : "All Friends",
-        Address.allRelays : "All Relays",
-        Address.allNodes : "All Nodes"
-    ]
-    
     var subscription: HeartbeatSubscription! {
         didSet {
             let network = MeshNetworkManager.instance.meshNetwork!
-            sourceLabel.text = network.nodes
-                .first { $0.unicastAddress == subscription.source }?
+            sourceLabel.text = network.node(withAddress: subscription.source)?
                 .name ?? "Unknown Device"
             switch subscription.destination {
             case let unicastAddress where unicastAddress.isUnicast:
-                destinationLabel.text = network.nodes.first { $0.unicastAddress == unicastAddress }?.name ?? "Unknown Device"
+                destinationLabel.text = network.node(withAddress: unicastAddress)?.name ?? "Unknown Device"
                 destinationSubtitle.text = nil
                 destinationIcon.image = #imageLiteral(resourceName: "ic_flag_24pt")
-            case let groupAddress where !groupAddress.isSpecialGroup:
-                if let group = network.groups.first(where: { $0.address.address == groupAddress }) {
+            case let groupAddress where groupAddress.isGroup || groupAddress.isVirtual:
+                if let group = network.group(withAddress: groupAddress) ?? Group.specialGroup(withAddress: groupAddress) {
                     destinationLabel.text = group.name
                     destinationSubtitle.text = nil
                 } else {
@@ -68,14 +60,9 @@ class HeartbeatSubscriptionCell: UITableViewCell {
                 }
                 destinationIcon.image = #imageLiteral(resourceName: "ic_group_24pt")
             default:
-                if let specialGroup = specialGroups[subscription.destination] {
-                    destinationLabel.text = specialGroup
-                    destinationSubtitle.text = nil
-                } else {
-                    destinationLabel.text = "Unknown Group"
-                    destinationSubtitle.text = subscription.destination.asString()
-                }
-                destinationIcon.image = #imageLiteral(resourceName: "ic_group_24pt")
+                destinationLabel.text = "Unknown Address"
+                destinationSubtitle.text = subscription.destination.asString()
+                destinationIcon.image = #imageLiteral(resourceName: "ic_flag_24pt")
             }
         }
     }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/Cells/PublicationCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/Cells/PublicationCell.swift
@@ -42,6 +42,7 @@ class PublicationCell: UITableViewCell {
     
     var publish: Publish! {
         didSet {
+            let meshNetwork = MeshNetworkManager.instance.meshNetwork!
             let address = publish.publicationAddress
             if address.address.isUnicast {
                 let meshNetwork = MeshNetworkManager.instance.meshNetwork!
@@ -63,28 +64,12 @@ class PublicationCell: UITableViewCell {
                 destinationIcon.tintColor = .nordicLake
                 destinationIcon.image = #imageLiteral(resourceName: "ic_flag_24pt")
             } else if address.address.isGroup || address.address.isVirtual {
-                switch address.address {
-                case .allProxies:
-                    destinationLabel.text = "All Proxies"
+                if let group = meshNetwork.group(withAddress: address) ?? Group.specialGroup(withAddress: address) {
+                    destinationLabel.text = group.name
                     destinationSubtitleLabel.text = nil
-                case .allFriends:
-                    destinationLabel.text = "All Friends"
-                    destinationSubtitleLabel.text = nil
-                case .allRelays:
-                    destinationLabel.text = "All Relays"
-                    destinationSubtitleLabel.text = nil
-                case .allNodes:
-                    destinationLabel.text = "All Nodes"
-                    destinationSubtitleLabel.text = nil
-                default:
-                    let meshNetwork = MeshNetworkManager.instance.meshNetwork!
-                    if let group = meshNetwork.group(withAddress: address) {
-                        destinationLabel.text = group.name
-                        destinationSubtitleLabel.text = nil
-                    } else {
-                        destinationLabel.text = "Unknown group"
-                        destinationSubtitleLabel.text = address.asString()
-                    }
+                } else {
+                    destinationLabel.text = "Unknown group"
+                    destinationSubtitleLabel.text = address.asString()
                 }
                 destinationIcon.image = #imageLiteral(resourceName: "tab_groups_outline_black_24pt")
                 destinationIcon.tintColor = .nordicLake
@@ -95,7 +80,6 @@ class PublicationCell: UITableViewCell {
                 destinationIcon.image = #imageLiteral(resourceName: "ic_flag_24pt")
             }
             
-            let meshNetwork = MeshNetworkManager.instance.meshNetwork!
             if let applicationKey = meshNetwork.applicationKeys[publish.index] {
                 keyIcon.tintColor = .nordicLake
                 keyLabel.text = applicationKey.name

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
@@ -449,7 +449,8 @@ class ModelViewController: ProgressViewController {
                 let subscription = model.parentElement?.parentNode?.heartbeatSubscription
                 return indexPath.row == 0 && subscription != nil
             } else {
-                return indexPath.row < model.subscriptions.count
+                return indexPath.row < model.subscriptions.count &&
+                       model.subscriptions[indexPath.row].address.address != .allNodes
             }
         }
         return false

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
@@ -391,7 +391,11 @@ class ModelViewController: ProgressViewController {
             return indexPath.row == 0
         }
         if indexPath.isSubscribeSection {
-            return indexPath.row == model.subscriptions.count
+            if model.isConfigurationServer {
+                return indexPath.row == 0
+            } else {
+                return indexPath.row == model.subscriptions.count
+            }
         }
         if indexPath.isCustomSection && model.isSensorServer {
             return indexPath.row == sensorValues?.count ?? 0

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatPublicationDestinationsViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatPublicationDestinationsViewController.swift
@@ -61,7 +61,8 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
         nodes = network.nodes.filter { $0.uuid != target.uuid }
         // Virtual Groups may not be set as Heartbeat destination.
         // They will be shown as disabled.
-        groups = network.groups
+        // Sort the groups, so the Virtual Groups are at the end.
+        groups = network.groups.sorted { $1.address.address.isVirtual }
     }
 
     // MARK: - Table view data source

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatPublicationDestinationsViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatPublicationDestinationsViewController.swift
@@ -48,12 +48,6 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
     /// List of all Nodes, except the target one.
     private var nodes: [Node]!
     private var groups: [Group]!
-    private let specialGroups: [(title: String, address: Address)] = [
-        ("All Proxies", Address.allProxies),
-        ("All Friends", Address.allFriends),
-        ("All Relays", Address.allRelays),
-        ("All Nodes", Address.allNodes)
-    ]
     private var selectedKeyIndexPath: IndexPath?
     private var selectedIndexPath: IndexPath?
     
@@ -87,7 +81,7 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
         }
         if section == IndexPath.specialGroupsSection ||
           (section == IndexPath.groupsSection && groups.isEmpty) {
-            return specialGroups.count
+            return Group.specialGroups.count
         }
         return 0
     }
@@ -141,12 +135,12 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
         }
         if indexPath.isSpecialGroupsSection || (indexPath.isGroupsSection && groups.isEmpty) {
-            let pair = specialGroups[indexPath.row]
-            if let destination = selectedDestination, destination == pair.address {
+            let group = Group.specialGroups[indexPath.row]
+            if let destination = selectedDestination, destination == group.address.address {
                 selectedIndexPath = indexPath
                 selectedDestination = nil
             }
-            cell.textLabel?.text = pair.title
+            cell.textLabel?.text = group.name
             cell.imageView?.image = #imageLiteral(resourceName: "ic_group_24pt")
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
         }
@@ -205,8 +199,8 @@ private extension SetHeartbeatPublicationDestinationsViewController {
             let selectedGroup = groups[indexPath.row]
             delegate?.destinationSelected(selectedGroup.address.address)
         default:
-            let selectedGroup = specialGroups[indexPath.row]
-            delegate?.destinationSelected(selectedGroup.address)
+            let selectedGroup = Group.specialGroups[indexPath.row]
+            delegate?.destinationSelected(selectedGroup.address.address)
         }
     }
     

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatPublicationDestinationsViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatPublicationDestinationsViewController.swift
@@ -77,11 +77,10 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
         if section == IndexPath.nodesSection {
             return max(nodes.count, 1)
         }
-        if section == IndexPath.groupsSection && !groups.isEmpty {
-            return groups.count
+        if section == IndexPath.groupsSection {
+            return groups.count + 1 // Add Group
         }
-        if section == IndexPath.specialGroupsSection ||
-          (section == IndexPath.groupsSection && groups.isEmpty) {
+        if section == IndexPath.specialGroupsSection {
             return Group.specialGroups.count
         }
         return 0
@@ -109,6 +108,9 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
         guard !indexPath.isNodeSection || nodes.count > 0 else {
             return tableView.dequeueReusableCell(withIdentifier: "empty", for: indexPath)
         }
+        guard !indexPath.isGroupsSection || indexPath.row < groups.count else {
+            return tableView.dequeueReusableCell(withIdentifier: "action", for: indexPath)
+        }
         let cell = tableView.dequeueReusableCell(withIdentifier: indexPath.reuseIdentifier, for: indexPath)
         
         if indexPath.isKeySection {
@@ -132,7 +134,7 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
             cell.setEnabled(true)
         }
-        if indexPath.isGroupsSection && !groups.isEmpty {
+        if indexPath.isGroupsSection {
             let group = groups[indexPath.row]
             if let destination = selectedDestination, destination == group.address.address {
                 selectedIndexPath = indexPath
@@ -143,7 +145,7 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
             cell.setEnabled(!group.address.address.isVirtual)
         }
-        if indexPath.isSpecialGroupsSection || (indexPath.isGroupsSection && groups.isEmpty) {
+        if indexPath.isSpecialGroupsSection {
             let group = Group.specialGroups[indexPath.row]
             if let destination = selectedDestination, destination == group.address.address {
                 selectedIndexPath = indexPath
@@ -163,6 +165,15 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
         }
         
         tableView.deselectRow(at: indexPath, animated: true)
+        
+        // Add Group clicked.
+        if indexPath.isGroupsSection && indexPath.row == groups.count {
+            let tabBarController = presentingViewController as? RootTabBarController
+            dismiss(animated: true) {
+                tabBarController?.presentGroups()
+            }
+            return
+        }
         
         if indexPath.isKeySection {
             keySelected(indexPath)

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatPublicationDestinationsViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatPublicationDestinationsViewController.swift
@@ -121,7 +121,7 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
             }
             cell.textLabel?.text = networkKey.name
             cell.accessoryType = indexPath == selectedKeyIndexPath ? .checkmark : .none
-            cell.setEnabled(true)
+            cell.isEnabled = true
         }
         if indexPath.isNodeSection {
             let node = nodes[indexPath.row]
@@ -132,7 +132,7 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
             cell.textLabel?.text = node.name ?? "Unknown Device"
             cell.imageView?.image = #imageLiteral(resourceName: "ic_flag_24pt")
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
-            cell.setEnabled(true)
+            cell.isEnabled = true
         }
         if indexPath.isGroupsSection {
             let group = groups[indexPath.row]
@@ -143,7 +143,7 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
             cell.textLabel?.text = group.name
             cell.imageView?.image = #imageLiteral(resourceName: "ic_group_24pt")
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
-            cell.setEnabled(!group.address.address.isVirtual)
+            cell.isEnabled = !group.address.address.isVirtual
         }
         if indexPath.isSpecialGroupsSection {
             let group = Group.specialGroups[indexPath.row]
@@ -154,7 +154,7 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
             cell.textLabel?.text = group.name
             cell.imageView?.image = #imageLiteral(resourceName: "ic_group_24pt")
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
-            cell.setEnabled(true)
+            cell.isEnabled = true
         }
         return cell
     }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatPublicationDestinationsViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatPublicationDestinationsViewController.swift
@@ -59,8 +59,9 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
         let network = MeshNetworkManager.instance.meshNetwork!
         // Exclude the current Node.
         nodes = network.nodes.filter { $0.uuid != target.uuid }
-        // Exclude Virtual Groups, which may not be set as Heartbeat destination.
-        groups = network.groups.filter { $0.address.address.isGroup }
+        // Virtual Groups may not be set as Heartbeat destination.
+        // They will be shown as disabled.
+        groups = network.groups
     }
 
     // MARK: - Table view data source
@@ -91,12 +92,17 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
         case IndexPath.keysSection:
             return "Network Keys"
         case IndexPath.nodesSection:
-            return "Nodes"
-        case IndexPath.groupsSection:
-            return "Groups"
+            return "Destination"
         default:
             return nil
         }
+    }
+    
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        if section == IndexPath.groupsSection && groups.contains(where: { $0.address.address.isVirtual }) {
+            return "Note: Heartbeat messages cannot be sent to Virtual Groups."
+        }
+        return nil
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -113,6 +119,7 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
             }
             cell.textLabel?.text = networkKey.name
             cell.accessoryType = indexPath == selectedKeyIndexPath ? .checkmark : .none
+            cell.setEnabled(true)
         }
         if indexPath.isNodeSection {
             let node = nodes[indexPath.row]
@@ -123,6 +130,7 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
             cell.textLabel?.text = node.name ?? "Unknown Device"
             cell.imageView?.image = #imageLiteral(resourceName: "ic_flag_24pt")
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
+            cell.setEnabled(true)
         }
         if indexPath.isGroupsSection && !groups.isEmpty {
             let group = groups[indexPath.row]
@@ -133,6 +141,7 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
             cell.textLabel?.text = group.name
             cell.imageView?.image = #imageLiteral(resourceName: "ic_group_24pt")
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
+            cell.setEnabled(!group.address.address.isVirtual)
         }
         if indexPath.isSpecialGroupsSection || (indexPath.isGroupsSection && groups.isEmpty) {
             let group = Group.specialGroups[indexPath.row]
@@ -143,6 +152,7 @@ class SetHeartbeatPublicationDestinationsViewController: UITableViewController {
             cell.textLabel?.text = group.name
             cell.imageView?.image = #imageLiteral(resourceName: "ic_group_24pt")
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
+            cell.setEnabled(true)
         }
         return cell
     }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatPublicationViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatPublicationViewController.swift
@@ -200,8 +200,8 @@ private extension SetHeartbeatPublicationViewController {
         } else {
             destinationLabel.textColor = .darkText
         }
+        let meshNetwork = MeshNetworkManager.instance.meshNetwork!
         if address.isUnicast {
-            let meshNetwork = MeshNetworkManager.instance.meshNetwork!
             let node = meshNetwork.node(withAddress: address)
             destinationLabel.text = node?.name ?? "Unknown Device"
             destinationSubtitleLabel.text = nil
@@ -209,27 +209,14 @@ private extension SetHeartbeatPublicationViewController {
             destinationIcon.image = #imageLiteral(resourceName: "ic_flag_24pt")
             doneButton.isEnabled = true
         } else if address.isGroup {
-            switch address {
-            case .allProxies:
-                destinationLabel.text = "All Proxies"
+            if let group = meshNetwork.group(withAddress: address) ?? Group.specialGroup(withAddress: address) {
+                destinationLabel.text = group.name
                 destinationSubtitleLabel.text = nil
-            case .allFriends:
-                destinationLabel.text = "All Friends"
-                destinationSubtitleLabel.text = nil
-            case .allRelays:
-                destinationLabel.text = "All Relays"
-                destinationSubtitleLabel.text = nil
-            case .allNodes:
-                destinationLabel.text = "All Nodes"
-                destinationSubtitleLabel.text = nil
-            default:
-                let meshNetwork = MeshNetworkManager.instance.meshNetwork!
-                if let group = meshNetwork.group(withAddress: MeshAddress(address)) {
-                    destinationLabel.text = group.name
-                    destinationSubtitleLabel.text = nil
-                }
+            } else {
+                destinationLabel.text = "Unknown group"
+                destinationSubtitleLabel.text = address.asString()
             }
-            destinationIcon.image = #imageLiteral(resourceName: "ic_group_24pt")
+            destinationIcon.image = #imageLiteral(resourceName: "tab_groups_outline_black_24pt")
             destinationIcon.tintColor = .nordicLake
             doneButton.isEnabled = true
         } else {

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatSubscriptionViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatSubscriptionViewController.swift
@@ -74,8 +74,9 @@ class SetHeartbeatSubscriptionViewController: ProgressViewController {
         let network = MeshNetworkManager.instance.meshNetwork!
         // Exclude the current Node.
         nodes = network.nodes.filter { $0.uuid != node.uuid }
-        // Exclude Virtual Groups, which may not be set as Heartbeat destination.
-        groups = network.groups.filter { $0.address.address.isGroup }
+        // Virtual Groups may not be set as Heartbeat destination.
+        // They will be shown as disabled.
+        groups = network.groups
         
         if let subscription = node.heartbeatSubscription {
             selectedSource = subscription.source
@@ -117,6 +118,13 @@ class SetHeartbeatSubscriptionViewController: ProgressViewController {
         }
     }
     
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        if section == IndexPath.destinationGroupsSection && groups.contains(where: { $0.address.address.isVirtual }) {
+            return "Note: Heartbeat messages cannot be sent to Virtual Groups."
+        }
+        return nil
+    }
+    
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: indexPath.reuseIdentifier,
                                                  for: indexPath)
@@ -133,6 +141,7 @@ class SetHeartbeatSubscriptionViewController: ProgressViewController {
             }
             cell.textLabel?.text = otherNode.name ?? "Unknown Device"
             cell.accessoryType = indexPath == selectedSourceIndexPath ? .checkmark : .none
+            cell.setEnabled(true)
         }
         if indexPath.isDestinationSection {
             if let destination = selectedDestination, destination == node.unicastAddress {
@@ -141,6 +150,7 @@ class SetHeartbeatSubscriptionViewController: ProgressViewController {
             }
             cell.textLabel?.text = node.name ?? "Unknown Device"
             cell.accessoryType = indexPath == selectedDestinationIndexPath ? .checkmark : .none
+            cell.setEnabled(true)
         }
         if indexPath.isGroupsSection {
             let group = groups[indexPath.row]
@@ -150,6 +160,7 @@ class SetHeartbeatSubscriptionViewController: ProgressViewController {
             }
             cell.textLabel?.text = group.name
             cell.accessoryType = indexPath == selectedDestinationIndexPath ? .checkmark : .none
+            cell.setEnabled(!group.address.address.isVirtual)
         }
         if indexPath.isSpecialGroupsSection {
             let group = Group.specialGroups[indexPath.row]
@@ -159,6 +170,7 @@ class SetHeartbeatSubscriptionViewController: ProgressViewController {
             }
             cell.textLabel?.text = group.name
             cell.accessoryType = indexPath == selectedDestinationIndexPath ? .checkmark : .none
+            cell.setEnabled(true)
         }
         return cell
     }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatSubscriptionViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatSubscriptionViewController.swift
@@ -61,12 +61,6 @@ class SetHeartbeatSubscriptionViewController: ProgressViewController {
     /// List of all Nodes, except the target one.
     private var nodes: [Node]!
     private var groups: [Group]!
-    private let specialGroups: [(title: String, address: Address)] = [
-        ("All Proxies", Address.allProxies),
-        ("All Friends", Address.allFriends),
-        ("All Relays", Address.allRelays),
-        ("All Nodes", Address.allNodes)
-    ]
     private var selectedSourceIndexPath: IndexPath?
     private var selectedDestinationIndexPath: IndexPath?
     
@@ -106,7 +100,7 @@ class SetHeartbeatSubscriptionViewController: ProgressViewController {
         case IndexPath.destinationGroupsSection where !groups.isEmpty:
             return groups.count
         default:
-            return specialGroups.count
+            return Group.specialGroups.count
         }
     }
     
@@ -158,12 +152,12 @@ class SetHeartbeatSubscriptionViewController: ProgressViewController {
             cell.accessoryType = indexPath == selectedDestinationIndexPath ? .checkmark : .none
         }
         if indexPath.isSpecialGroupsSection {
-            let group = specialGroups[indexPath.row]
-            if let destination = selectedDestination, destination == group.address {
+            let group = Group.specialGroups[indexPath.row]
+            if let destination = selectedDestination, destination == group.address.address {
                 selectedDestinationIndexPath = indexPath
                 selectedDestination = nil
             }
-            cell.textLabel?.text = group.title
+            cell.textLabel?.text = group.name
             cell.accessoryType = indexPath == selectedDestinationIndexPath ? .checkmark : .none
         }
         return cell
@@ -231,7 +225,7 @@ private extension SetHeartbeatSubscriptionViewController {
                 node.unicastAddress :
                 destinationIndexPath.isGroupsSection && !groups.isEmpty ?
                     groups[destinationIndexPath.row].address.address :
-                    specialGroups[destinationIndexPath.row].address
+                    Group.specialGroups[destinationIndexPath.row].address.address
         let periodLog = self.periodLog
         
         start("Setting Heartbeat Subscription...") {

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatSubscriptionViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatSubscriptionViewController.swift
@@ -76,7 +76,8 @@ class SetHeartbeatSubscriptionViewController: ProgressViewController {
         nodes = network.nodes.filter { $0.uuid != node.uuid }
         // Virtual Groups may not be set as Heartbeat destination.
         // They will be shown as disabled.
-        groups = network.groups
+        // Sort the groups, so the Virtual Groups are at the end.
+        groups = network.groups.sorted { $1.address.address.isVirtual }
         
         if let subscription = node.heartbeatSubscription {
             selectedSource = subscription.source

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatSubscriptionViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetHeartbeatSubscriptionViewController.swift
@@ -141,7 +141,7 @@ class SetHeartbeatSubscriptionViewController: ProgressViewController {
             }
             cell.textLabel?.text = otherNode.name ?? "Unknown Device"
             cell.accessoryType = indexPath == selectedSourceIndexPath ? .checkmark : .none
-            cell.setEnabled(true)
+            cell.isEnabled = true
         }
         if indexPath.isDestinationSection {
             if let destination = selectedDestination, destination == node.unicastAddress {
@@ -150,7 +150,7 @@ class SetHeartbeatSubscriptionViewController: ProgressViewController {
             }
             cell.textLabel?.text = node.name ?? "Unknown Device"
             cell.accessoryType = indexPath == selectedDestinationIndexPath ? .checkmark : .none
-            cell.setEnabled(true)
+            cell.isEnabled = true
         }
         if indexPath.isGroupsSection {
             let group = groups[indexPath.row]
@@ -160,7 +160,7 @@ class SetHeartbeatSubscriptionViewController: ProgressViewController {
             }
             cell.textLabel?.text = group.name
             cell.accessoryType = indexPath == selectedDestinationIndexPath ? .checkmark : .none
-            cell.setEnabled(!group.address.address.isVirtual)
+            cell.isEnabled = !group.address.address.isVirtual
         }
         if indexPath.isSpecialGroupsSection {
             let group = Group.specialGroups[indexPath.row]
@@ -170,7 +170,7 @@ class SetHeartbeatSubscriptionViewController: ProgressViewController {
             }
             cell.textLabel?.text = group.name
             cell.accessoryType = indexPath == selectedDestinationIndexPath ? .checkmark : .none
-            cell.setEnabled(true)
+            cell.isEnabled = true
         }
         return cell
     }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationDestinationsViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationDestinationsViewController.swift
@@ -49,12 +49,6 @@ class SetPublicationDestinationsViewController: UITableViewController {
     /// List of Elements containing Model bound to selected Application Key.
     private var compatibleElements: [Element]!
     private var groups: [Group]!
-    private let specialGroups: [(title: String, address: Address)] = [
-        ("All Proxies", Address.allProxies),
-        ("All Friends", Address.allFriends),
-        ("All Relays", Address.allRelays),
-        ("All Nodes", Address.allNodes)
-    ]
     private var selectedKeyIndexPath: IndexPath?
     private var selectedIndexPath: IndexPath?
     
@@ -93,7 +87,7 @@ class SetPublicationDestinationsViewController: UITableViewController {
         }
         if section == IndexPath.specialGroupsSection ||
           (section == IndexPath.groupsSection && groups.isEmpty) {
-            return specialGroups.count
+            return Group.specialGroups.count
         }
         return 0
     }
@@ -161,12 +155,12 @@ class SetPublicationDestinationsViewController: UITableViewController {
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
         }
         if indexPath.isSpecialGroupsSection || (indexPath.isGroupsSection && groups.isEmpty) {
-            let pair = specialGroups[indexPath.row]
-            if let destination = selectedDestination, destination.address == pair.address {
+            let group = Group.specialGroups[indexPath.row]
+            if let destination = selectedDestination, destination == group.address {
                 selectedIndexPath = indexPath
                 selectedDestination = nil
             }
-            cell.textLabel?.text = pair.title
+            cell.textLabel?.text = group.name
             cell.imageView?.image = #imageLiteral(resourceName: "ic_group_24pt")
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
         }
@@ -254,8 +248,8 @@ private extension SetPublicationDestinationsViewController {
             let selectedGroup = groups[indexPath.row]
             delegate?.destinationSelected(selectedGroup.address)
         default:
-            let selectedGroup = specialGroups[indexPath.row]
-            delegate?.destinationSelected(MeshAddress(selectedGroup.address))
+            let selectedGroup = Group.specialGroups[indexPath.row]
+            delegate?.destinationSelected(selectedGroup.address)
         }
     }
 }

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationDestinationsViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationDestinationsViewController.swift
@@ -82,11 +82,10 @@ class SetPublicationDestinationsViewController: UITableViewController {
         if section == IndexPath.elementsSection {
             return max(compatibleElements.count, 1)
         }
-        if section == IndexPath.groupsSection && !groups.isEmpty {
-            return groups.count
+        if section == IndexPath.groupsSection {
+            return groups.count + 1 // Add Group
         }
-        if section == IndexPath.specialGroupsSection ||
-          (section == IndexPath.groupsSection && groups.isEmpty) {
+        if section == IndexPath.specialGroupsSection {
             return Group.specialGroups.count
         }
         return 0
@@ -125,6 +124,9 @@ class SetPublicationDestinationsViewController: UITableViewController {
         guard !indexPath.isElementsSection || compatibleElements.count > 0 else {
             return tableView.dequeueReusableCell(withIdentifier: "empty", for: indexPath)
         }
+        guard !indexPath.isGroupsSection || indexPath.row < groups.count else {
+            return tableView.dequeueReusableCell(withIdentifier: "action", for: indexPath)
+        }
         let cell = tableView.dequeueReusableCell(withIdentifier: indexPath.reuseIdentifier, for: indexPath)
         
         if indexPath.isKeySection {
@@ -144,7 +146,7 @@ class SetPublicationDestinationsViewController: UITableViewController {
             cell.imageView?.image = #imageLiteral(resourceName: "ic_flag_24pt")
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
         }
-        if indexPath.isGroupsSection && !groups.isEmpty {
+        if indexPath.isGroupsSection {
             let group = groups[indexPath.row]
             if let destination = selectedDestination, destination == group.address {
                 selectedIndexPath = indexPath
@@ -154,7 +156,7 @@ class SetPublicationDestinationsViewController: UITableViewController {
             cell.imageView?.image = #imageLiteral(resourceName: "ic_group_24pt")
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
         }
-        if indexPath.isSpecialGroupsSection || (indexPath.isGroupsSection && groups.isEmpty) {
+        if indexPath.isSpecialGroupsSection {
             let group = Group.specialGroups[indexPath.row]
             if let destination = selectedDestination, destination == group.address {
                 selectedIndexPath = indexPath
@@ -173,6 +175,15 @@ class SetPublicationDestinationsViewController: UITableViewController {
         }
         
         tableView.deselectRow(at: indexPath, animated: true)
+        
+        // Add Group clicked.
+        if indexPath.isGroupsSection && indexPath.row == groups.count {
+            let tabBarController = presentingViewController as? RootTabBarController
+            dismiss(animated: true) {
+                tabBarController?.presentGroups()
+            }
+            return
+        }
         
         if indexPath.isKeySection {
             keySelected(indexPath, initial: false)

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationViewController.swift
@@ -313,16 +313,15 @@ private extension SetPublicationViewController {
             destinationIcon.tintColor = .nordicLake
             destinationIcon.image = #imageLiteral(resourceName: "ic_flag_24pt")
             doneButton.isEnabled = true
-        } else if let group = Group.specialGroup(withAddress: address) {
-            destinationLabel.text = group.name
-            destinationSubtitleLabel.text = nil
-            destinationIcon.image = #imageLiteral(resourceName: "ic_group_24pt")
-            destinationIcon.tintColor = .nordicLake
-            doneButton.isEnabled = true
-        } else if let group = meshNetwork.group(withAddress: address) {
-            destinationLabel.text = group.name
-            destinationSubtitleLabel.text = nil
-            destinationIcon.image = #imageLiteral(resourceName: "ic_group_24pt")
+        } else if address.address.isGroup || address.address.isVirtual {
+            if let group = meshNetwork.group(withAddress: address) ?? Group.specialGroup(withAddress: address) {
+                destinationLabel.text = group.name
+                destinationSubtitleLabel.text = nil
+            } else {
+                destinationLabel.text = "Unknown group"
+                destinationSubtitleLabel.text = address.asString()
+            }
+            destinationIcon.image = #imageLiteral(resourceName: "tab_groups_outline_black_24pt")
             destinationIcon.tintColor = .nordicLake
             doneButton.isEnabled = true
         } else {

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SetPublicationViewController.swift
@@ -292,6 +292,7 @@ private extension SetPublicationViewController {
         } else {
             destinationLabel.textColor = .darkText
         }
+        let meshNetwork = MeshNetworkManager.instance.meshNetwork!
         if address.address.isUnicast {
             let meshNetwork = MeshNetworkManager.instance.meshNetwork!
             let node = meshNetwork.node(withAddress: address.address)
@@ -312,27 +313,15 @@ private extension SetPublicationViewController {
             destinationIcon.tintColor = .nordicLake
             destinationIcon.image = #imageLiteral(resourceName: "ic_flag_24pt")
             doneButton.isEnabled = true
-        } else if address.address.isGroup || address.address.isVirtual {
-            switch address.address {
-            case .allProxies:
-                destinationLabel.text = "All Proxies"
-                destinationSubtitleLabel.text = nil
-            case .allFriends:
-                destinationLabel.text = "All Friends"
-                destinationSubtitleLabel.text = nil
-            case .allRelays:
-                destinationLabel.text = "All Relays"
-                destinationSubtitleLabel.text = nil
-            case .allNodes:
-                destinationLabel.text = "All Nodes"
-                destinationSubtitleLabel.text = nil
-            default:
-                let meshNetwork = MeshNetworkManager.instance.meshNetwork!
-                if let group = meshNetwork.group(withAddress: address) {
-                    destinationLabel.text = group.name
-                    destinationSubtitleLabel.text = nil
-                }
-            }
+        } else if let group = Group.specialGroup(withAddress: address) {
+            destinationLabel.text = group.name
+            destinationSubtitleLabel.text = nil
+            destinationIcon.image = #imageLiteral(resourceName: "ic_group_24pt")
+            destinationIcon.tintColor = .nordicLake
+            doneButton.isEnabled = true
+        } else if let group = meshNetwork.group(withAddress: address) {
+            destinationLabel.text = group.name
+            destinationSubtitleLabel.text = nil
             destinationIcon.image = #imageLiteral(resourceName: "ic_group_24pt")
             destinationIcon.tintColor = .nordicLake
             doneButton.isEnabled = true

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SubscribeViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SubscribeViewController.swift
@@ -141,7 +141,7 @@ class SubscribeViewController: ProgressViewController {
         tableView.deselectRow(at: indexPath, animated: true)
         
         // Add Group clicked.
-        guard indexPath.section != 0 || indexPath.row < groups.count else {
+        if indexPath.section == 0 && indexPath.row == groups.count {
             let tabBarController = presentingViewController as? RootTabBarController
             dismiss(animated: true) {
                 tabBarController?.presentGroups()

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SubscribeViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SubscribeViewController.swift
@@ -49,7 +49,8 @@ class SubscribeViewController: ProgressViewController {
         guard let selectedIndexPath = selectedIndexPath else {
             return
         }
-        let group = groups[selectedIndexPath.row]
+        let groupSet: [Group] = selectedIndexPath.section == 0 ? groups : specialGroups
+        let group = groupSet[selectedIndexPath.row]
         addSubscription(to: group)
     }
     
@@ -59,32 +60,21 @@ class SubscribeViewController: ProgressViewController {
     var delegate: SubscriptionDelegate?
     
     private var groups: [Group]!
+    private var specialGroups: [Group]!
     private var selectedIndexPath: IndexPath?
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        let presentGroups = UIButtonAction(title: "Groups") { [weak self] in
-            guard let self = self else { return }
-            let tabBarController = self.presentingViewController as? RootTabBarController
-            self.dismiss(animated: true) {
-                tabBarController?.presentGroups()
-            }
-        }
-        tableView.setEmptyView(title: "No groups",
-                               message: "Go to Groups to create a group.",
-                               messageImage: #imageLiteral(resourceName: "baseline-groups"),
-                               action: presentGroups)
         
         MeshNetworkManager.instance.delegate = self
         
         let network = MeshNetworkManager.instance.meshNetwork!
         let alreadySubscribedGroups = model.subscriptions
-        groups = network.groups.filter {
-            !alreadySubscribedGroups.contains($0)
-        }
-        if groups.isEmpty {
-            tableView.showEmptyView()
-        }
+        groups = network.groups
+            .filter { !alreadySubscribedGroups.contains($0) }
+        specialGroups = Group.specialGroups
+            .filter { $0 != .allNodes }
+            .filter { !alreadySubscribedGroups.contains($0) }
         // Initially, no group is checked.
         doneButton.isEnabled = false
     }
@@ -92,16 +82,56 @@ class SubscribeViewController: ProgressViewController {
     // MARK: - Table view data source
 
     override func numberOfSections(in tableView: UITableView) -> Int {
+        if !specialGroups.isEmpty {
+            return 2
+        }
         return 1
+    }
+    
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        if section == 0 {
+            return "Groups"
+        }
+        return nil
+    }
+    
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        if section == 1 && !specialGroups.isEmpty {
+            if model.parentElement?.isPrimary ?? false {
+                return """
+                       All models on the primary Element are automatically subscribed to the All\u{00a0}Nodes \
+                       address and those of the groups listed above which have the corresponding feature \
+                       enabled on the node.
+                                       
+                       Subscribing to any of the groups will bypass the feature check so that the model \
+                       will always receive messages sent to that group.
+                       """
+            } else {
+                return """
+                       Models on a non-primary Element may be subscribed to any of the above-listed groups, \
+                       but the corresponding feature will not be checked.
+                       
+                       It is not possible to subscribe any model to the All\u{00a0}Nodes address.
+                       """
+            }
+        }
+        return nil
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return groups.count
+        if section == 1 {
+            return specialGroups.count
+        }
+        return groups.count + 1 // 1 for Add Group button
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard indexPath.section != 0 || indexPath.row < groups.count else {
+            return tableView.dequeueReusableCell(withIdentifier: "action", for: indexPath)
+        }
         let cell = tableView.dequeueReusableCell(withIdentifier: "group", for: indexPath)
-        cell.textLabel?.text = groups[indexPath.row].name
+        let groupSet = indexPath.section == 0 ? groups! : specialGroups!
+        cell.textLabel?.text = groupSet[indexPath.row].name
         cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
         return cell
     }
@@ -109,6 +139,16 @@ class SubscribeViewController: ProgressViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         
+        // Add Group clicked.
+        guard indexPath.section != 0 || indexPath.row < groups.count else {
+            let tabBarController = presentingViewController as? RootTabBarController
+            dismiss(animated: true) {
+                tabBarController?.presentGroups()
+            }
+            return
+        }
+
+        // A group clicked.
         var rows: [IndexPath] = []
         if let previousSelection = selectedIndexPath {
             rows.append(previousSelection)

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/SubscribeViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/SubscribeViewController.swift
@@ -131,7 +131,8 @@ class SubscribeViewController: ProgressViewController {
         }
         let cell = tableView.dequeueReusableCell(withIdentifier: "group", for: indexPath)
         let groupSet = indexPath.section == 0 ? groups! : specialGroups!
-        cell.textLabel?.text = groupSet[indexPath.row].name
+        let group = groupSet[indexPath.row]
+        cell.textLabel?.text = group.name
         cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
         return cell
     }

--- a/Example/nRFMeshProvision/View Controllers/Proxy/Cells/AddressCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Proxy/Cells/AddressCell.swift
@@ -44,31 +44,23 @@ class AddressCell: UITableViewCell {
             switch address! {
                 
             case let address where address.isUnicast:
-                let elements = meshNetwork.nodes.flatMap { $0.elements }
-                let targetElement = elements.first { $0.unicastAddress == address }
+                let node = meshNetwork.node(withAddress: address)
+                let targetElement = node?.element(withAddress: address)
                 
                 title.text = targetElement != nil ?
                     targetElement!.name ?? "Element \(targetElement!.index + 1)" : "Unknown Element"
-                subtitle.text = targetElement?.parentNode?.name ?? "Unknown device"
+                subtitle.text = node?.name ?? "Unknown device"
                 icon.image = #imageLiteral(resourceName: "ic_flag_24pt")
                 tintColor = .nordicLake
                 
-            case let address where address.isSpecialGroup:
-                icon.image = #imageLiteral(resourceName: "ic_group_24pt")
-                subtitle.text = nil
-                switch address {
-                case Address.allProxies: title.text = "All Proxies"
-                case Address.allRelays:  title.text = "All Relays"
-                case Address.allFriends: title.text = "All Friends"
-                default:                 title.text = "All Nodes"
-                }
-                tintColor = .nordicLake
-                
             case let address where address.isGroup || address.isVirtual:
-                let group = meshNetwork.groups.first { $0.address.address == address }
-                
-                title.text = group?.name ?? "Unknown group"
-                subtitle.text = group?.address.virtualLabel?.uuidString
+                if let group = meshNetwork.group(withAddress: address) ?? Group.specialGroup(withAddress: address) {
+                    title.text = group.name
+                    subtitle.text = group.address.virtualLabel?.uuidString
+                } else {
+                    title.text = "Unknown Group"
+                    subtitle.text = address.asString()
+                }                
                 icon.image = #imageLiteral(resourceName: "ic_group_24pt")
                 tintColor = .nordicLake
                 

--- a/nRFMeshProvision/Classes/ExportConfiguration.swift
+++ b/nRFMeshProvision/Classes/ExportConfiguration.swift
@@ -79,7 +79,7 @@ public enum ExportConfiguration {
         /// exported. Nodes belonging to excluded Provisioners will not be
         /// exported.
         case allWithDeviceKey
-        /// The same as `.all`, but device keys will not be exported.
+        /// The same as `.allWithDeviceKey`, but device keys will not be exported.
         case allWithoutDeviceKey
         /// The given Nodes will be exported. This allows to export Nodes with
         /// Device Key (full) or without Device Key (partial). The device on which

--- a/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationClientHandler.swift
+++ b/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationClientHandler.swift
@@ -227,7 +227,9 @@ internal class ConfigurationClientHandler: ModelDelegate {
                     break
                 }
                 // Here it should be safe to search for the group.
-                guard let group = meshNetwork.group(withAddress: address) else {
+                guard let group = Group.specialGroup(withAddress: address) ??
+                                  meshNetwork.group(withAddress: address),
+                          group != .allNodes else {
                     break
                 }
                 switch request {
@@ -250,8 +252,11 @@ internal class ConfigurationClientHandler: ModelDelegate {
                let model = element.model(withModelId: list.modelId) {
                 model.unsubscribeFromAll()
                 for address in list.addresses {
-                    if let group = meshNetwork.groups.first(where: { $0.address.address == address }) {
-                        model.subscribe(to: group)
+                    if let group = Group.specialGroup(withAddress: address) ??
+                                   meshNetwork.group(withAddress: address) {
+                        if group != .allNodes {
+                            model.subscribe(to: group)
+                        }
                     } else {
                         if address.isGroup && !address.isSpecialGroup {
                             do {
@@ -264,8 +269,8 @@ internal class ConfigurationClientHandler: ModelDelegate {
                                 continue
                             }
                         } else {
-                            // Unknown Virtual Group. The Virtual Label is unknown,
-                            // so we can't create it here.
+                            // Unknown Virtual Group, or a special group.
+                            // The Virtual Label is unknown, so we can't create it here.
                             continue
                         }
                     }

--- a/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationServerHandler.swift
+++ b/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationServerHandler.swift
@@ -324,7 +324,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
             if !request.publish.isCancel {
                 // A new Group?
                 let address = request.publish.publicationAddress.address
-                if address.isGroup && address < 0xFF00 &&
+                if address.isGroup && !address.isSpecialGroup &&
                    meshNetwork.group(withAddress: request.publish.publicationAddress) == nil {
                     let group = try! Group(name: NSLocalizedString("New Group", comment: ""),
                                            address: address)
@@ -386,20 +386,20 @@ internal class ConfigurationServerHandler: ModelDelegate {
             guard model.delegate?.isSubscriptionSupported != false else {
                 return ConfigModelSubscriptionStatus(responseTo: request, with: .notASubscribeModel)
             }
-            var group = meshNetwork.group(withAddress: MeshAddress(request.address))
-            if let group = group {
-                model.subscribe(to: group)
-            } else {
-                do {
-                    group = try Group(name: NSLocalizedString("New Group", comment: ""),
-                                      address: request.address)
-                    try meshNetwork.add(group: group!)
-                    model.subscribe(to: group!)
-                } catch {
-                    return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidAddress)
+            do {
+                let address = MeshAddress(request.address)
+                // A Model can be subscribed to any Group except from All nodes.
+                let group = try Group.specialGroup(withAddress: address) ??
+                                meshNetwork.group(withAddress: address) ??
+                                createGroup(withAddress: address)
+                guard group != .allNodes else {
+                    throw MeshNetworkError.invalidAddress
                 }
+                model.subscribe(to: group)
+                return ConfigModelSubscriptionStatus(confirmAdding: group, to: model)!
+            } catch {
+                return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidAddress)
             }
-            return ConfigModelSubscriptionStatus(confirmAdding: group!, to: model)!
             
         case let request as ConfigModelSubscriptionOverwrite:
             guard let element = localNode.element(withAddress: request.elementAddress) else {
@@ -414,22 +414,21 @@ internal class ConfigurationServerHandler: ModelDelegate {
             guard model.delegate?.isSubscriptionSupported != false else {
                 return ConfigModelSubscriptionStatus(responseTo: request, with: .notASubscribeModel)
             }
-            var group = meshNetwork.group(withAddress: MeshAddress(request.address))
-            if let group = group {
+            do {
+                let address = MeshAddress(request.address)
+                // A Model can be subscribed to any Group except from All nodes.
+                let group = try Group.specialGroup(withAddress: address) ??
+                                meshNetwork.group(withAddress: address) ??
+                                createGroup(withAddress: address)
+                guard group != .allNodes else {
+                    throw MeshNetworkError.invalidAddress
+                }
                 model.unsubscribeFromAll()
                 model.subscribe(to: group)
-            } else {
-                do {
-                    group = try Group(name: NSLocalizedString("New Group", comment: ""),
-                                      address: request.address)
-                    try meshNetwork.add(group: group!)
-                    model.unsubscribeFromAll()
-                    model.subscribe(to: group!)
-                } catch {
-                    return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidAddress)
-                }
+                return ConfigModelSubscriptionStatus(confirmAdding: group, to: model)!
+            } catch {
+                return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidAddress)
             }
-            return ConfigModelSubscriptionStatus(confirmAdding: group!, to: model)!
             
         case let request as ConfigModelSubscriptionDelete:
             guard let element = localNode.element(withAddress: request.elementAddress) else {
@@ -454,20 +453,15 @@ internal class ConfigurationServerHandler: ModelDelegate {
             guard model.delegate?.isSubscriptionSupported != false else {
                 return ConfigModelSubscriptionStatus(responseTo: request, with: .notASubscribeModel)
             }
-            var group = meshNetwork.group(withAddress: MeshAddress(request.virtualLabel))
-            if group != nil {
-                model.subscribe(to: group!)
-            } else {
-                do {
-                    group = try Group(name: NSLocalizedString("New Group", comment: ""),
-                                      address: MeshAddress(request.virtualLabel))
-                    try meshNetwork.add(group: group!)
-                    model.subscribe(to: group!)
-                } catch {
-                    return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidAddress)
-                }
+            do {
+                let address = MeshAddress(request.virtualLabel)
+                let group = try meshNetwork.group(withAddress: address) ??
+                                createGroup(withAddress: address)
+                model.subscribe(to: group)
+                return ConfigModelSubscriptionStatus(confirmAdding: group, to: model)!
+            } catch {
+                return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidAddress)
             }
-            return ConfigModelSubscriptionStatus(confirmAdding: group!, to: model)!
             
         case let request as ConfigModelSubscriptionVirtualAddressOverwrite:
             guard let element = localNode.element(withAddress: request.elementAddress) else {
@@ -479,22 +473,16 @@ internal class ConfigurationServerHandler: ModelDelegate {
             guard model.delegate?.isSubscriptionSupported != false else {
                 return ConfigModelSubscriptionStatus(responseTo: request, with: .notASubscribeModel)
             }
-            var group = meshNetwork.group(withAddress: MeshAddress(request.virtualLabel))
-            if group != nil {
+            do {
+                let address = MeshAddress(request.virtualLabel)
+                let group = try meshNetwork.group(withAddress: address) ??
+                                createGroup(withAddress: address)
                 model.unsubscribeFromAll()
-                model.subscribe(to: group!)
-            } else {
-                do {
-                    group = try Group(name: NSLocalizedString("New Group", comment: ""),
-                                      address: MeshAddress(request.virtualLabel))
-                    try meshNetwork.add(group: group!)
-                    model.unsubscribeFromAll()
-                    model.subscribe(to: group!)
-                } catch {
-                    return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidAddress)
-                }
+                model.subscribe(to: group)
+                return ConfigModelSubscriptionStatus(confirmAdding: group, to: model)!
+            } catch {
+                return ConfigModelSubscriptionStatus(responseTo: request, with: .invalidAddress)
             }
-            return ConfigModelSubscriptionStatus(confirmAdding: group!, to: model)!
             
         case let request as ConfigModelSubscriptionVirtualAddressDelete:
             guard let element = localNode.element(withAddress: request.elementAddress) else {
@@ -706,6 +694,17 @@ internal class ConfigurationServerHandler: ModelDelegate {
         }
     }
         
+}
+
+private extension ConfigurationServerHandler {
+    
+    private func createGroup(withAddress address: MeshAddress) throws -> Group {
+        let group = try Group(name: NSLocalizedString("New Group", comment: ""),
+                              address: address)
+        try meshNetwork.add(group: group)
+        return group
+    }
+    
 }
 
 

--- a/nRFMeshProvision/Classes/Mesh API/Group+MeshNetwork.swift
+++ b/nRFMeshProvision/Classes/Mesh API/Group+MeshNetwork.swift
@@ -43,6 +43,10 @@ public extension Group {
         guard let meshNetwork = meshNetwork else {
             return false
         }
+        guard !address.address.isSpecialGroup else {
+            // Special groups are considered as used by design.
+            return true
+        }
         for group in meshNetwork.groups {
             // If the Group is a parent of some other Group, return `true`.
             if isDirectParentOf(group) {
@@ -117,9 +121,15 @@ public extension Group {
     
     /// Sets the parent-child relationship between this and the given Group.
     ///
+    /// Neigher the Group, or the parent Group can be a Special Group.
+    ///
     /// - parameter parent: The parent Group.
     func setAsChildOf(_ parent: Group) {
         guard parent != self else {
+            return
+        }
+        guard !address.address.isSpecialGroup &&
+              !parent.address.address.isSpecialGroup else {
             return
         }
         parentAddress = parent.groupAddress
@@ -128,9 +138,15 @@ public extension Group {
     
     /// Sets the parent-child relationship between this and the given Group.
     ///
+    /// Neigher the Group, or the child Group can be a Special Group.
+    ///
     /// - parameter child: The child Group.
     func setAsParentOf(_ child: Group) {
         guard child != self else {
+            return
+        }
+        guard !address.address.isSpecialGroup &&
+              !child.address.address.isSpecialGroup else {
             return
         }
         child.parentAddress = groupAddress

--- a/nRFMeshProvision/Classes/Mesh API/MeshNetwork+Groups.swift
+++ b/nRFMeshProvision/Classes/Mesh API/MeshNetwork+Groups.swift
@@ -37,7 +37,15 @@ public extension MeshNetwork {
     /// - parameter address: The Group Address.
     /// - returns: The Group with given Address, or `nil` if no such found.
     func group(withAddress address: MeshAddress) -> Group? {
-        return groups.first { $0.address == address }
+        return group(withAddress: address.address)
+    }
+    
+    /// Returns the Group with given Address, or 'nil` if no such was found.
+    ///
+    /// - parameter address: The Group Address.
+    /// - returns: The Group with given Address, or `nil` if no such found.
+    func group(withAddress address: Address) -> Group? {
+        return groups.first { $0.address.address == address }
     }
     
     /// Adds a new Group to the network.
@@ -45,10 +53,16 @@ public extension MeshNetwork {
     /// If the mesh network already contains a Group with the same address,
     /// this method throws an error.
     ///
+    /// Groups with predefined addresses (i.e. All Nodes) cannot be added as
+    /// custom groups.
+    ///
     /// - parameter group: The Group to be added.
     /// - throws: This method throws an error if a Group with the same address
-    ///           already exists in the mesh network.
+    ///           already exists in the mesh network, or it is a Special Group.
     func add(group: Group) throws {
+        guard !group.address.address.isSpecialGroup else {
+            throw MeshNetworkError.invalidAddress
+        }
         guard !groups.contains(group) else {
             throw MeshNetworkError.groupAlreadyExists
         }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigHeartbeatSubscriptionSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigHeartbeatSubscriptionSet.swift
@@ -93,14 +93,14 @@ public struct ConfigHeartbeatSubscriptionSet: AcknowledgedConfigMessage {
     /// Creates Config Heartbeat Subscription Set message with given parameters.
     ///
     /// - Parameters:
-    ///   - source: Source address for Heartbeat messages. The address shall
-    ///             be a Unicast Address.
-    ///   - destination: Destination address for Heartbeat messages. The address shall
-    ///                  be a Unicast Address, or a Group Address.
     ///   - periodLog: Duration for processing Heartbeat messages. This field is the interval used
     ///                for sending messages. The value will be calculated as 2^(periodLog-1).
     ///                Allowed values are in range 0x01...0x11. To disable Heartbeat subscriptions
     ///                use `init()`.
+    ///   - source: Source address for Heartbeat messages. The address shall
+    ///             be a Unicast Address.
+    ///   - destination: Destination address for Heartbeat messages. The address shall
+    ///                  be a Unicast Address, or a Group Address.
     public init?(startProcessingHeartbeatMessagesFor periodLog: UInt8,
                  secondsSentFrom source: Address, to destination: Address) {
         guard source.isUnicast else {

--- a/nRFMeshProvision/Classes/Mesh Model/Address.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Address.swift
@@ -35,6 +35,8 @@ public typealias Address = UInt16
 
 public extension Address {
     
+    /// An Unassigned Address is an address in which the Element of a Node
+    /// has not been configured yet or no address has been allocated.
     static let unassignedAddress: Address = 0x0000
     static let minUnicastAddress: Address = 0x0001
     static let maxUnicastAddress: Address = 0x7FFF
@@ -43,9 +45,40 @@ public extension Address {
     static let minGroupAddress:   Address = 0xC000
     static let maxGroupAddress:   Address = 0xFEFF
     
+    /// A message sent to the all-proxies address will be processed by the
+    /// Primary Element of all nodes that have the friend functionality enabled.
+    ///
+    /// That means, that Models on the Primary Element of all the Nodes are
+    /// automatically subscribed to all-proxies address if the Node has
+    /// Proxy functionality enabled. Models on the Primary and other Elements
+    /// of a Node may subscribe to this address to receive messages no matter
+    /// what the feature state is.
     static let allProxies:        Address = 0xFFFC
+    /// A message sent to the all-friends address will be processed by the
+    /// Primary Element of all nodes that have the friend functionality enabled.
+    ///
+    /// That means, that Models on the Primary Element of all the Nodes are
+    /// automatically subscribed to all-friends address if the Node has
+    /// Friend functionality enabled. Models on the Primary and other Elements
+    /// of a Node may subscribe to this address to receive messages no matter
+    /// what the feature state is.
     static let allFriends:        Address = 0xFFFD
+    /// A message sent to the all-relays address will be processed by the
+    /// Primary Element of all nodes that have the relay functionality enabled.
+    ///
+    /// That means, that Models on the Primary Element of all the Nodes are
+    /// automatically subscribed to all-relays address if the Node has
+    /// Relay functionality enabled. Models on the Primary and other Elements
+    /// of a Node may subscribe to this address to receive messages no matter
+    /// what the feature state is.
     static let allRelays:         Address = 0xFFFE
+    /// A message sent to the all-nodes address will be processed by the
+    /// Primary Element of all nodes.
+    ///
+    /// That means, that all Models on the Primary Element of all the Nodes
+    /// are automatically subscibed to all-nodes address. It is not possible
+    /// for Models on other Elements to receive messages sent to All Nodes address,
+    /// as they cannot subscribe to this address.
     static let allNodes:          Address = 0xFFFF
     
 }

--- a/nRFMeshProvision/Classes/Mesh Model/Group.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Group.swift
@@ -91,6 +91,13 @@ public class Group: Codable {
         try self.init(name: name, address: MeshAddress(address))
     }
     
+    private init(name: String, specialGroup: Address) {
+        self.name = name
+        self.groupAddress = specialGroup.hex
+        self.address = MeshAddress(specialGroup)
+        self.parentAddress = "0000"
+    }
+    
     // MARK: - Codable
     
     private enum CodingKeys: String, CodingKey {
@@ -138,6 +145,35 @@ extension Group: Equatable, Hashable {
     
     public func hash(into hasher: inout Hasher) {
         hasher.combine(groupAddress)
+    }
+    
+}
+
+public extension Group {
+    /// A message sent to the All Nodes address shall be processed by the primary Element
+    /// of all nodes.
+    static let allNodes   = Group(name: NSLocalizedString("All Nodes", comment: ""),   specialGroup: .allNodes)
+    /// A message sent to the All Relays address shall be processed by the primary Element
+    /// of all nodes that have the relay functionality enabled, or by any Model subscribed
+    /// to it.
+    static let allRelays  = Group(name: NSLocalizedString("All Relays", comment: ""),  specialGroup: .allRelays)
+    /// A message sent to the All Friends address shall be processed by the primary Element
+    /// of all nodes that have the friend functionality enabled, or by any Model subscribed
+    /// to it.
+    static let allFriends = Group(name: NSLocalizedString("All Friends", comment: ""), specialGroup: .allFriends)
+    /// A message sent to the All Proxies address shall be processed by the primary Element
+    /// of all nodes that have the proxy functionality enabled, or by any Model subscribed
+    /// to it.
+    static let allProxies = Group(name: NSLocalizedString("All Proxies", comment: ""), specialGroup: .allProxies)
+    /// Returns all special Groups supported by this version of the mesh library.
+    static let specialGroups: [Group] = [.allRelays, .allFriends, .allProxies, .allNodes]
+    /// Returns a special Group with the given address, or nil.
+    static func specialGroup(withAddress address: Address) -> Group? {
+        return specialGroups.first { $0.address.address == address }
+    }
+    /// Returns a special Group with the given address, or nil.
+    static func specialGroup(withAddress address: MeshAddress) -> Group? {
+        return specialGroup(withAddress: address.address)
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Model/Model.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Model.swift
@@ -60,8 +60,13 @@ public class Model: Codable {
     /// not known to the local database, and those are not returned.
     /// Use `isSubscribed(to:)` to check other Groups.
     public var subscriptions: [Group] {
-        return parentElement?.parentNode?.meshNetwork?.groups
-            .filter { subscribe.contains($0.groupAddress ) } ?? []
+        // A model may be additionally subscribed to any special address
+        // except from All Nodes.
+        let subscribableSpecialgroups = Group.specialGroups
+            .filter { $0 != .allNodes }
+        return (subscribableSpecialgroups +
+               (parentElement?.parentNode?.meshNetwork?.groups ?? []))
+            .filter { subscribe.contains($0.groupAddress) }
     }
     /// The configuration of this Model's publication.
     public private(set) var publish: Publish?

--- a/nRFMeshProvision/Classes/Mesh Model/Model.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Model.swift
@@ -56,17 +56,23 @@ public class Model: Codable {
     /// or Virtual Label UUIDs (32-character hexadecimal string).
     internal private(set) var subscribe: [String]
     /// Returns the list of known Groups that this Model is subscribed to.
+    /// Models on the Primary Element are also subscribed to the All Nodes address.
+    ///
     /// It may be that the Model is subscribed to some other Groups, which are
     /// not known to the local database, and those are not returned.
+    ///
     /// Use `isSubscribed(to:)` to check other Groups.
     public var subscriptions: [Group] {
         // A model may be additionally subscribed to any special address
         // except from All Nodes.
-        let subscribableSpecialgroups = Group.specialGroups
+        let subscribableSpecialGroups = Group.specialGroups
             .filter { $0 != .allNodes }
-        return (subscribableSpecialgroups +
-               (parentElement?.parentNode?.meshNetwork?.groups ?? []))
+        let groups = parentElement?.parentNode?.meshNetwork?.groups ?? []
+        let result = (groups + subscribableSpecialGroups)
             .filter { subscribe.contains($0.groupAddress) }
+        // Models on the primary Element are always subscribed to the All Nodes
+        // address.
+        return (parentElement?.isPrimary ?? false) ? result + [.allNodes] : result
     }
     /// The configuration of this Model's publication.
     public private(set) var publish: Publish?

--- a/nRFMeshProvision/Classes/MeshNetworkError.swift
+++ b/nRFMeshProvision/Classes/MeshNetworkError.swift
@@ -70,7 +70,7 @@ public enum MeshNetworkError: Error {
     /// Throw when trying to remove a Group that is either a parent of another
     /// Group, or set as publication or subscription address for any Model.
     case groupInUse
-    /// Throw when trying to remove a Scene that is
+    /// Throw when trying to remove a Scene stored by at least one Scene Register.
     case sceneInUse
     /// Thrown when the given Key Index is not valid.
     case keyIndexOutOfRange

--- a/nRFMeshProvision/Classes/ProxyFilter.swift
+++ b/nRFMeshProvision/Classes/ProxyFilter.swift
@@ -267,7 +267,7 @@ public extension ProxyFilter {
         let subscriptions = models.flatMap { $0.subscriptions }
         addresses.formUnion(subscriptions.map({ $0.address.address }))
         // Add All Nodes group address.
-        addresses.insert(Address.allNodes)
+        addresses.insert(.allNodes)
         // Submit.
         add(addresses: addresses)
     }


### PR DESCRIPTION
This PR fixes #409.

This PR adds an option to subscribe to any of the special groups excluding All Nodes.
Also, few helper methods have been added:
- `Group.allNodes`, `Group.allProxies`, `Group.allRelays`, `Group.allFriends`
- `Group.specialGroups`
- `Group.specialGroup(withAddress:)`

TODO:
- [x] Handling subscription as server and client
- [x] UI to subscribe a model to special addresses
- [x] A special Group cannot be set as a parent or a child group.
- [x] A special name cannot have its name changed
- [x] Special groups should be used in Set Publication Destination address
- [x] Option to Add Group from Set Publication Destination