### PR TITLE
Node features fixed

### DIFF
--- a/Example/nRFMeshProvision/UI/Base.lproj/Network.storyboard
+++ b/Example/nRFMeshProvision/UI/Base.lproj/Network.storyboard
@@ -1062,21 +1062,21 @@
                             <tableViewSection headerTitle="Device Capabilities" id="af4-PB-fZt">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="Oqg-7c-iJ0" detailTextLabel="E9e-8N-Sbw" style="IBUITableViewCellStyleSubtitle" id="X4R-XT-NZP">
-                                        <rect key="frame" x="0.0" y="248.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="248.5" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="X4R-XT-NZP" id="idM-7j-BIS">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Elements Count" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Oqg-7c-iJ0">
-                                                    <rect key="frame" x="20" y="5" width="120.5" height="20.5"/>
+                                                    <rect key="frame" x="20" y="10" width="120.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Loading..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="E9e-8N-Sbw">
-                                                    <rect key="frame" x="20" y="25.5" width="56" height="14.5"/>
+                                                    <rect key="frame" x="20" y="31.5" width="56" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -1086,21 +1086,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="BAq-5b-9tR" detailTextLabel="pS5-Y5-QgE" style="IBUITableViewCellStyleSubtitle" id="yy7-AU-JwL">
-                                        <rect key="frame" x="0.0" y="292.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="304" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yy7-AU-JwL" id="NYW-m7-WPo">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Supported Algorithms" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="BAq-5b-9tR">
-                                                    <rect key="frame" x="20" y="5" width="167.5" height="20.5"/>
+                                                    <rect key="frame" x="20" y="10" width="167.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Loading..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="pS5-Y5-QgE">
-                                                    <rect key="frame" x="20" y="25.5" width="56" height="14.5"/>
+                                                    <rect key="frame" x="20" y="31.5" width="56" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -1110,21 +1110,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="SdP-NS-3LU" detailTextLabel="zDh-JJ-bBg" style="IBUITableViewCellStyleSubtitle" id="eZz-wJ-sSf">
-                                        <rect key="frame" x="0.0" y="336.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="359.5" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eZz-wJ-sSf" id="JU7-kU-7e4">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Public Key Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="SdP-NS-3LU">
-                                                    <rect key="frame" x="20" y="5" width="121" height="20.5"/>
+                                                    <rect key="frame" x="20" y="10" width="121" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Loading..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="zDh-JJ-bBg">
-                                                    <rect key="frame" x="20" y="25.5" width="56" height="14.5"/>
+                                                    <rect key="frame" x="20" y="31.5" width="56" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -1134,21 +1134,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="MAo-QP-eik" detailTextLabel="Qdh-uv-1ef" style="IBUITableViewCellStyleSubtitle" id="zIh-z7-aCQ">
-                                        <rect key="frame" x="0.0" y="380.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="415" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zIh-z7-aCQ" id="RvA-5b-yC4">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Static OOB Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MAo-QP-eik">
-                                                    <rect key="frame" x="20" y="5" width="126" height="20.5"/>
+                                                    <rect key="frame" x="20" y="10" width="126" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Loading..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Qdh-uv-1ef">
-                                                    <rect key="frame" x="20" y="25.5" width="56" height="14.5"/>
+                                                    <rect key="frame" x="20" y="31.5" width="56" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -1158,21 +1158,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="eb8-fF-0rX" detailTextLabel="xit-9M-VEk" style="IBUITableViewCellStyleSubtitle" id="yXs-ab-vbS">
-                                        <rect key="frame" x="0.0" y="424.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="470.5" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yXs-ab-vbS" id="21N-Ac-V6X">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Output OOB Size" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="eb8-fF-0rX">
-                                                    <rect key="frame" x="20" y="5" width="130" height="20.5"/>
+                                                    <rect key="frame" x="20" y="10" width="130" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Loading..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="xit-9M-VEk">
-                                                    <rect key="frame" x="20" y="25.5" width="56" height="14.5"/>
+                                                    <rect key="frame" x="20" y="31.5" width="56" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -1182,21 +1182,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="UHQ-mH-G4A" detailTextLabel="6SF-mc-Wie" style="IBUITableViewCellStyleSubtitle" id="r10-EK-VFc">
-                                        <rect key="frame" x="0.0" y="468.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="526" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="r10-EK-VFc" id="K8t-gu-4ze">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Supported Output OOB Actions" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UHQ-mH-G4A">
-                                                    <rect key="frame" x="20" y="5" width="240" height="20.5"/>
+                                                    <rect key="frame" x="20" y="10" width="240" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Loading..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6SF-mc-Wie">
-                                                    <rect key="frame" x="20" y="25.5" width="56" height="14.5"/>
+                                                    <rect key="frame" x="20" y="31.5" width="56" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -1206,21 +1206,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="FYj-2z-A6L" detailTextLabel="Sef-42-c2U" style="IBUITableViewCellStyleSubtitle" id="cDY-r8-cnx">
-                                        <rect key="frame" x="0.0" y="512.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="581.5" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cDY-r8-cnx" id="zuh-i6-uLf">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Input OOB Size" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="FYj-2z-A6L">
-                                                    <rect key="frame" x="20" y="5" width="116" height="20.5"/>
+                                                    <rect key="frame" x="20" y="10" width="116" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Loading..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Sef-42-c2U">
-                                                    <rect key="frame" x="20" y="25.5" width="56" height="14.5"/>
+                                                    <rect key="frame" x="20" y="31.5" width="56" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -1230,21 +1230,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="3cl-hR-g1F" detailTextLabel="98S-j6-Bn7" style="IBUITableViewCellStyleSubtitle" id="V9Y-Uy-SAb">
-                                        <rect key="frame" x="0.0" y="556.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="637" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="V9Y-Uy-SAb" id="dYF-2R-tkK">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Supported Input OOB Actions" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3cl-hR-g1F">
-                                                    <rect key="frame" x="20" y="5" width="225.5" height="20.5"/>
+                                                    <rect key="frame" x="20" y="10" width="225.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Loading..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="98S-j6-Bn7">
-                                                    <rect key="frame" x="20" y="25.5" width="56" height="14.5"/>
+                                                    <rect key="frame" x="20" y="31.5" width="56" height="14.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>

--- a/Example/nRFMeshProvision/UI/Base.lproj/Network.storyboard
+++ b/Example/nRFMeshProvision/UI/Base.lproj/Network.storyboard
@@ -223,7 +223,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Node Features" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F8r-BD-geo">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Features" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F8r-BD-geo">
                                             <rect key="frame" x="20" y="8" width="374" height="22"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/Cells/NodeFeaturesCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/Cells/NodeFeaturesCell.swift
@@ -39,10 +39,25 @@ class NodeFeaturesCell: UITableViewCell {
     
     var node: Node! {
         didSet {
-            relayLabel.text = node.features?.relay?.debugDescription ?? "Unknown"
-            proxyLabel.text = node.features?.proxy?.debugDescription ?? "Unknown"
-            friendLabel.text = node.features?.friend?.debugDescription ?? "Unknown"
-            lowPowerLabel.text = node.features?.lowPower?.debugDescription ?? "Unknown"
+            // The Page 0 of the Composition Data contains only "supported" / "not supported" info for Node features.
+            // The accurate "enabled" / "not enabled" information is obtained by sending a Config ... Get messages
+            // for given feature, which may also return "not supported".
+            // nRF Mesh app sends those messages from the Configuration Server Model screen, together with
+            // Config Network Transmit Get. That means, that if Network Transmit object is not nil, that means that
+            // the features status was requested.
+            if let _ = node.networkTransmit {
+                relayLabel.text = node.features?.relay?.debugDescription ?? "Unknown"
+                proxyLabel.text = node.features?.proxy?.debugDescription ?? "Unknown"
+                friendLabel.text = node.features?.friend?.debugDescription ?? "Unknown"
+                lowPowerLabel.text = node.features?.lowPower?.debugDescription ?? "Unknown"
+            } else {
+                // Otherwise, the "not enabled" does not mean that the feature is actually disabled, but that
+                // its "enabled" / "not enabled" state is unknown. The only certain state is "not supported".
+                relayLabel.text = node.features?.relay == .notSupported ? node.features?.relay?.debugDescription : "Unknown"
+                proxyLabel.text = node.features?.proxy == .notSupported ? node.features?.proxy?.debugDescription : "Unknown"
+                friendLabel.text = node.features?.friend == .notSupported ? node.features?.friend?.debugDescription : "Unknown"
+                lowPowerLabel.text = node.features?.lowPower == .notSupported ? node.features?.lowPower?.debugDescription : "Unknown"
+            }
         }
     }
     

--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ConfigurationViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ConfigurationViewController.swift
@@ -144,7 +144,7 @@ class ConfigurationViewController: ProgressViewController {
         case IndexPath.elementsSection:
             return "Elements"
         case IndexPath.compositionDataSection:
-            return "Composition Data"
+            return "Node information"
         default:
             return nil
         }

--- a/nRFMeshProvision/Classes/Legacy/MeshNodeEntry.swift
+++ b/nRFMeshProvision/Classes/Legacy/MeshNodeEntry.swift
@@ -87,7 +87,7 @@ internal struct MeshNodeEntry: Codable {
         guard let featureFlags = featureFlags else {
             return nil
         }
-        return NodeFeaturesState(rawValue: featureFlags.asUInt16)
+        return NodeFeaturesState(mask: featureFlags.asUInt16)
     }
     
     var nodeElements: [Element] {

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigCompositionDataStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigCompositionDataStatus.swift
@@ -128,7 +128,7 @@ public struct Page0: CompositionDataPage {
         productIdentifier = parameters.read(fromOffset: 3)
         versionIdentifier = parameters.read(fromOffset: 5)
         minimumNumberOfReplayProtectionList = parameters.read(fromOffset: 7)
-        features = NodeFeaturesState(rawValue: parameters.read(fromOffset: 9))
+        features = NodeFeaturesState(mask: parameters.read(fromOffset: 9))
         
         var readElements: [Element] = []
         var offset = 11

--- a/nRFMeshProvision/Classes/Mesh Model/Node.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Node.swift
@@ -834,7 +834,10 @@ internal extension Node {
         productIdentifier = page0.productIdentifier
         versionIdentifier = page0.versionIdentifier
         minimumNumberOfReplayProtectionList = page0.minimumNumberOfReplayProtectionList
-        features = page0.features
+        // Don't override features if they already were known.
+        // Accurate features states could have been acquired by reading each feature state,
+        // while the Page 0 of the Composition Data contains only Supported / Not Supported.
+        features = features ?? page0.features
         // And set the Elements received.
         set(elements: page0.elements)
         meshNetwork?.timestamp = Date()

--- a/nRFMeshProvision/Classes/Mesh Model/NodeFeatures.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/NodeFeatures.swift
@@ -123,6 +123,16 @@ public class NodeFeaturesState: Codable {
         self.lowPower = nil
     }
     
+    /// This method creates the Node Features State object based on the
+    /// feature bit-field from the Page 0 of the Composition Data.
+    ///
+    /// - important: Mind, that it has to convert "supported" state into
+    ///              either "not enabled" or "enabled". The "not enabled" is
+    ///              chosen in this implementation. This does not mean, that
+    ///              the feature is actually not enabled. To get the actual
+    ///              value, use Config ... Get messages.
+    /// - parameter rawValue: Features field from the Page 0 of the Compositon Page.
+    /// - seeAlso:   https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/pull/414
     internal init(rawValue: UInt16) {
         self.relay    = rawValue & 0x01 == 0 ? .notSupported : .notEnabled
         self.proxy    = rawValue & 0x02 == 0 ? .notSupported : .notEnabled

--- a/nRFMeshProvision/Classes/Mesh Model/NodeFeatures.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/NodeFeatures.swift
@@ -131,13 +131,13 @@ public class NodeFeaturesState: Codable {
     ///              chosen in this implementation. This does not mean, that
     ///              the feature is actually not enabled. To get the actual
     ///              value, use Config ... Get messages.
-    /// - parameter rawValue: Features field from the Page 0 of the Compositon Page.
+    /// - parameter mask: Features field from the Page 0 of the Compositon Page.
     /// - seeAlso:   https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/pull/414
-    internal init(rawValue: UInt16) {
-        self.relay    = rawValue & 0x01 == 0 ? .notSupported : .notEnabled
-        self.proxy    = rawValue & 0x02 == 0 ? .notSupported : .notEnabled
-        self.friend   = rawValue & 0x04 == 0 ? .notSupported : .notEnabled
-        self.lowPower = rawValue & 0x08 == 0 ? .notSupported : .notEnabled
+    internal init(mask: UInt16) {
+        self.relay    = mask & 0x01 == 0 ? .notSupported : .notEnabled
+        self.proxy    = mask & 0x02 == 0 ? .notSupported : .notEnabled
+        self.friend   = mask & 0x04 == 0 ? .notSupported : .notEnabled
+        self.lowPower = mask & 0x08 == 0 ? .notSupported : .notEnabled
     }
 }
 


### PR DESCRIPTION
This PR fixes #264.

### Background

The [Configuration Database specification 1.0.0](https://www.bluetooth.com/specifications/specs/mesh-configuration-database-profile-1-0/), following Mesh Profile 1.0.1 spec, allows 3 values for a feature state:  
* 0 - Not enabled
* 1 - Enabled
* 2 - Not supported

However, the Page 0 of the Composition Page returns the feature states as a bitfield: supported (1) or not supported (0). Therefore, just after obtaining Composition Data the library has to match "supported" into 2 states: "enabled" or "disabled". It does it by assuming the feature is "not enabled":
https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/blob/d09b03b81790e08faeb1e7fb117124aa568d4117/nRFMeshProvision/Classes/Mesh%20Model/NodeFeatures.swift#L126-L131

The actual state of a feature has to be requested using *Config ... Get* messages, which in the nRF Mesh app is possible from the Primary Element -> Configuration Server Model screen by using Pull to Refresh.

### Possible options

As the actual state cannot be known just by reading Composition Data, there were 2 options:
1. Read feature states just after Composition Data and Default TTL after first connection.
2. Display the states of those features as "Unknown" until they are requested.

### Solution

We decided to go with option 2, as easier to implement and more readable.
The nRF Mesh app requests feature states from Configuration Server screen. It does it together with Network Transmit state, which is never nullified. Therefore, we know, that if Network Transmit state is not null, that feature data are accurate; otherwise "not enabled" does not mean not enabled, but rather "unknown".

Note, that this workaround has only been implemented in the sample app, not in the library. It is up to the implementation to decided which solution to choose.
