### PR TITLE
Support for controlling Node identities on connected nodes

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -156,6 +156,10 @@
 		519902827741276D09AE2E5AA61572F9 /* ConfigurationClientHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429EEC1B049B5C3467397CE7F9416CB2 /* ConfigurationClientHandler.swift */; };
 		5243E7560D923A61278B1537756BAF47 /* ConfigRelayStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = E530C2123B025C449CF1BA9A0BE8ECA8 /* ConfigRelayStatus.swift */; };
 		5273983D1BF2106CA0C53C4C2131748D /* LightLightnessSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7851EC3A32167A9ADEF33D842EF50B0B /* LightLightnessSet.swift */; };
+		5286EA402812CF5800D6BB4A /* NodeIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5286EA3F2812CF5800D6BB4A /* NodeIdentity.swift */; };
+		5286EA422812D09100D6BB4A /* ConfigNodeIdentityStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5286EA412812D09100D6BB4A /* ConfigNodeIdentityStatus.swift */; };
+		52B6C5112812CD5400F6E0F3 /* ConfigNodeIdentityGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6C5102812CD5400F6E0F3 /* ConfigNodeIdentityGet.swift */; };
+		52B6C5132812CDE100F6E0F3 /* ConfigNodeIdentitySet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6C5122812CDE100F6E0F3 /* ConfigNodeIdentitySet.swift */; };
 		52ED0F31490F62AABF6EBDC4D279A3E3 /* LightCTLTemperatureStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64AEE7FA925423BE67FFB38787CF62E2 /* LightCTLTemperatureStatus.swift */; };
 		53C0C874141D5596FC3C395857378662 /* nRFMeshProvision-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BB823594546C634C25D825F551CCA09 /* nRFMeshProvision-dummy.m */; };
 		5419D23A75236616FD9003BFEAB0A196 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C21C8E900A0E68E2325ECFEC2E7B92 /* Digest.swift */; };
@@ -623,8 +627,12 @@
 		4F3D54FBED2683C4C2494CE04416796E /* SceneRegisterGet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneRegisterGet.swift; sourceTree = "<group>"; };
 		508C62CB8BA890D68D7B2F4E8E83E86A /* LightCTLDefaultGet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightCTLDefaultGet.swift; sourceTree = "<group>"; };
 		5262FECD90084F3137342916AD6E9C0B /* RangeObject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RangeObject.swift; sourceTree = "<group>"; };
+		5286EA3F2812CF5800D6BB4A /* NodeIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeIdentity.swift; sourceTree = "<group>"; };
+		5286EA412812D09100D6BB4A /* ConfigNodeIdentityStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigNodeIdentityStatus.swift; sourceTree = "<group>"; };
 		528AC8FAA9E5C2769942C32A216F648D /* GenericOnPowerUpStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericOnPowerUpStatus.swift; sourceTree = "<group>"; };
 		5292B138FB4A5FEDD970E2B413D73D3D /* Node+Elements.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Node+Elements.swift"; sourceTree = "<group>"; };
+		52B6C5102812CD5400F6E0F3 /* ConfigNodeIdentityGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigNodeIdentityGet.swift; sourceTree = "<group>"; };
+		52B6C5122812CDE100F6E0F3 /* ConfigNodeIdentitySet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigNodeIdentitySet.swift; sourceTree = "<group>"; };
 		52B98E435AA20B809CCBB7242F32FFC4 /* MeshLoggerDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MeshLoggerDelegate.swift; sourceTree = "<group>"; };
 		5379B0AD59C1F2452490E18D2865BCC3 /* SegmentedControlMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SegmentedControlMessage.swift; sourceTree = "<group>"; };
 		54F99DACD3B025BCD51F8712477EE7E8 /* PKCS5.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PKCS5.swift; path = Sources/CryptoSwift/PKCS/PKCS5.swift; sourceTree = "<group>"; };
@@ -1014,6 +1022,7 @@
 				0CBC0B6FAD4B8E1DF73631988515F121 /* Model.swift */,
 				355ED2D4B8F04F77C1B39F78F3FA0C2F /* NetworkKey.swift */,
 				72ED3DDBFD00AED0CAA487EF9E76837E /* Node.swift */,
+				5286EA3F2812CF5800D6BB4A /* NodeIdentity.swift */,
 				BACD0FE9A61DC965025072E374C64116 /* NodeFeatures.swift */,
 				79DE1BB78C67A11FB5AD7C4AB764EDF5 /* OnPowerUp.swift */,
 				B86A553495CC2B321C4339F628CBBA55 /* Provisioner.swift */,
@@ -1237,6 +1246,9 @@
 				BA8A4F393B009B3B45D8DADB770023CA /* ConfigNetworkTransmitGet.swift */,
 				3C839C63B60103C76F5C618A8DAE55AA /* ConfigNetworkTransmitSet.swift */,
 				5F313269726925A176E91D78B37F98AF /* ConfigNetworkTransmitStatus.swift */,
+				52B6C5102812CD5400F6E0F3 /* ConfigNodeIdentityGet.swift */,
+				52B6C5122812CDE100F6E0F3 /* ConfigNodeIdentitySet.swift */,
+				5286EA412812D09100D6BB4A /* ConfigNodeIdentityStatus.swift */,
 				F54180E8BB7670AD489F0D45D84F3D9D /* ConfigNodeReset.swift */,
 				9BD9AEA5931F6114937E2C4D0A575C6B /* ConfigNodeResetStatus.swift */,
 				D2C7C5F81DEE69295FA46E9983BAC40A /* ConfigRelayGet.swift */,
@@ -2171,6 +2183,7 @@
 				73EC00915329F88D2201D2282953E8CD /* GenericPowerDefaultSetUnacknowledged.swift in Sources */,
 				D0ABB3345CF4E93F2D7AA7A3812FD66A /* GenericPowerDefaultStatus.swift in Sources */,
 				16A217CB4E2175617B700562F041239D /* GenericPowerDefautGet.swift in Sources */,
+				52B6C5132812CDE100F6E0F3 /* ConfigNodeIdentitySet.swift in Sources */,
 				2BF5C547259135FA558124EA4CCDBF44 /* GenericPowerLastGet.swift in Sources */,
 				6D4605D740E988ACF8D4CA466B5FE92F /* GenericPowerLastStatus.swift in Sources */,
 				E642805372FFD4D547922A0B2E133187 /* GenericPowerLevelGet.swift in Sources */,
@@ -2217,6 +2230,7 @@
 				02F502AC1963CB4F54658DCD56C8F2A3 /* LightHSLGet.swift in Sources */,
 				AC75039AF0DD14EDEB4610A69F5E9A4D /* LightHSLHueGet.swift in Sources */,
 				F60A9F05C21CAE02D39CA0388C4AAB49 /* LightHSLHueSet.swift in Sources */,
+				5286EA402812CF5800D6BB4A /* NodeIdentity.swift in Sources */,
 				A326638C56DD366216DD029DA7584F02 /* LightHSLHueSetUnacknowledged.swift in Sources */,
 				F119CBEF5B8AD8F6FA12504D96341FA8 /* LightHSLHueStatus.swift in Sources */,
 				B21F27F13A5704B1A52DD48484BEF3EE /* LightHSLRangeGet.swift in Sources */,
@@ -2296,6 +2310,7 @@
 				33316952A577752DD6468F39A95AAF0C /* Model+Keys.swift in Sources */,
 				CE6CF8EDE9E3D3C9A85EC32D806929D6 /* Model+Name.swift in Sources */,
 				59BFA72BC0B77C81540FD741CCBBD88B /* Model.swift in Sources */,
+				5286EA422812D09100D6BB4A /* ConfigNodeIdentityStatus.swift in Sources */,
 				48AFB63F63251C00DE87AD877C7B4D7A /* ModelDelegate.swift in Sources */,
 				EE7AA00F3B0F6DD7F187F13585852D4E /* Models.swift in Sources */,
 				AC394E14E326C3128DECE4B42C339D75 /* NetworkKey+MeshNetwork.swift in Sources */,
@@ -2341,6 +2356,7 @@
 				7DD2FBA4DE6546D8CC3438798143C02D /* SceneNumber.swift in Sources */,
 				636951E6E39EFB76B402D09066ABC4AE /* SceneRange.swift in Sources */,
 				92AFE23E4B2FBC785218FEC0964FE11B /* SceneRecall.swift in Sources */,
+				52B6C5112812CD5400F6E0F3 /* ConfigNodeIdentityGet.swift in Sources */,
 				E169C43E1DC3FD3D7980FADC32562370 /* SceneRecallUnacknowledged.swift in Sources */,
 				96D399CB49191AAE36D1ECEF5EFAC09F /* SceneRegisterGet.swift in Sources */,
 				4BD2D0C31C1ED6D92F8B9E8F96A82DB8 /* SceneRegisterStatus.swift in Sources */,

--- a/Example/nRFMeshProvision/UI/Base.lproj/Network.storyboard
+++ b/Example/nRFMeshProvision/UI/Base.lproj/Network.storyboard
@@ -841,6 +841,41 @@
                                     <outlet property="rightActionButton" destination="SAT-fQ-1mT" id="gEn-fg-MTI"/>
                                 </connections>
                             </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="switch" id="ukA-iV-k75" customClass="SwitchCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="680" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ukA-iV-k75" id="q0I-rL-LSs">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P1w-ws-FGk">
+                                            <rect key="frame" x="345" y="6.5" width="51" height="31"/>
+                                            <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                                            <connections>
+                                                <action selector="switchDidChange:" destination="ukA-iV-k75" eventType="valueChanged" id="PJe-b6-sbf"/>
+                                            </connections>
+                                        </switch>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pqx-lg-qPZ">
+                                            <rect key="frame" x="20" y="11" width="33" height="21.5"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="P1w-ws-FGk" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="pqx-lg-qPZ" secondAttribute="trailing" constant="8" id="6z1-Ex-fNK"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="P1w-ws-FGk" secondAttribute="trailing" id="Hjl-Cf-j5l"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="pqx-lg-qPZ" secondAttribute="bottom" id="MJF-K0-Vwr"/>
+                                        <constraint firstItem="P1w-ws-FGk" firstAttribute="centerY" secondItem="pqx-lg-qPZ" secondAttribute="centerY" id="Q9V-Es-lVs"/>
+                                        <constraint firstItem="pqx-lg-qPZ" firstAttribute="leading" secondItem="q0I-rL-LSs" secondAttribute="leadingMargin" id="VEy-CM-Czk"/>
+                                        <constraint firstItem="pqx-lg-qPZ" firstAttribute="top" secondItem="q0I-rL-LSs" secondAttribute="topMargin" id="qGc-K8-Tbd"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="switch" destination="P1w-ws-FGk" id="PGw-eW-Ytf"/>
+                                    <outlet property="title" destination="pqx-lg-qPZ" id="d6j-lZ-Zao"/>
+                                </connections>
+                            </tableViewCell>
                         </prototypes>
                         <connections>
                             <outlet property="dataSource" destination="veF-nS-gn0" id="cDP-zl-VqJ"/>

--- a/Example/nRFMeshProvision/UI/Model/ConfigurationServer.xib
+++ b/Example/nRFMeshProvision/UI/Model/ConfigurationServer.xib
@@ -10,11 +10,11 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="908" id="RhT-zv-Hbx" customClass="ConfigurationServerViewCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="906"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="1072" id="RhT-zv-Hbx" customClass="ConfigurationServerViewCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="1070"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="RhT-zv-Hbx" id="065-UL-Q8f">
-                <rect key="frame" x="0.0" y="0.0" width="414" height="906"/>
+                <rect key="frame" x="0.0" y="0.0" width="414" height="1070"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <slider opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="7" translatesAutoresizingMaskIntoConstraints="NO" id="tZ4-Df-a3a">
@@ -208,13 +208,13 @@
                         </constraints>
                     </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="The Secure Network Beacon state determines if a node is periodically broadcasting Secure Network beacons." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gxD-is-qIK">
-                        <rect key="frame" x="20" y="411.5" width="374" height="54"/>
+                        <rect key="frame" x="20" y="411.5" width="374" height="23"/>
                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <color key="textColor" systemColor="secondaryLabelColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PSn-E0-bIg">
-                        <rect key="frame" x="20" y="473.5" width="394" height="0.5"/>
+                        <rect key="frame" x="20" y="442.5" width="394" height="0.5"/>
                         <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                         <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
                         <constraints>
@@ -222,17 +222,17 @@
                         </constraints>
                     </view>
                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="cFg-Ds-bZw">
-                        <rect key="frame" x="345" y="482" width="51" height="31"/>
+                        <rect key="frame" x="345" y="451" width="51" height="31"/>
                         <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <action selector="secureNetworkBeaconDidChange:" destination="RhT-zv-Hbx" eventType="valueChanged" id="agy-wL-Uls"/>
                         </connections>
                     </switch>
                     <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Cub-nh-IZx" userLabel="Section">
-                        <rect key="frame" x="0.0" y="521" width="414" height="56"/>
+                        <rect key="frame" x="0.0" y="490" width="414" height="56"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="arZ-dV-nb4" userLabel="Finishing Line">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="0.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="0.0"/>
                                 <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="0.33000000000000002" id="ASR-vf-IDB"/>
@@ -266,14 +266,14 @@
                         </constraints>
                     </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mpe-Bp-8SZ">
-                        <rect key="frame" x="20" y="585" width="374" height="74.5"/>
+                        <rect key="frame" x="20" y="554" width="374" height="72"/>
                         <string key="text">If the Proxy feature is disabled, a GATT client device can connect over GATT to that node for configuration and control. Messages from the GATT bearer are not relayed to the advertising bearer.</string>
                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <color key="textColor" systemColor="secondaryLabelColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Sbl-RQ-VgE">
-                        <rect key="frame" x="20" y="667.5" width="394" height="0.0"/>
+                        <rect key="frame" x="20" y="634" width="394" height="0.0"/>
                         <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                         <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
                         <constraints>
@@ -281,7 +281,7 @@
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HoH-je-kKm" userLabel="Section">
-                        <rect key="frame" x="0.0" y="714.5" width="414" height="56"/>
+                        <rect key="frame" x="0.0" y="681" width="414" height="56"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bAf-Dq-Zdv" userLabel="Finishing Line">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="0.5"/>
@@ -318,14 +318,14 @@
                         </constraints>
                     </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gVr-aU-fD1">
-                        <rect key="frame" x="20" y="778.5" width="374" height="72"/>
+                        <rect key="frame" x="20" y="745" width="374" height="72"/>
                         <string key="text">The Friend Feature state indicates support for the Friend feature. Disabling this feature will terminate all Friend relationships and clear the associated Friend Queue.</string>
                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <color key="textColor" systemColor="secondaryLabelColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D12-ZA-L55">
-                        <rect key="frame" x="20" y="858.5" width="394" height="0.5"/>
+                        <rect key="frame" x="20" y="825" width="394" height="0.5"/>
                         <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
                         <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
                         <constraints>
@@ -333,19 +333,63 @@
                         </constraints>
                     </view>
                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="ztF-Vw-61s">
-                        <rect key="frame" x="345" y="675.5" width="51" height="31"/>
+                        <rect key="frame" x="345" y="642" width="51" height="31"/>
                         <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <action selector="gattProxyDidChange:" destination="RhT-zv-Hbx" eventType="valueChanged" id="Qb8-Jp-AcR"/>
                         </connections>
                     </switch>
                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="plw-fg-Zic">
-                        <rect key="frame" x="345" y="867" width="51" height="31"/>
+                        <rect key="frame" x="345" y="833.5" width="51" height="31"/>
                         <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                         <connections>
                             <action selector="friendFeatureDidChange:" destination="RhT-zv-Hbx" eventType="valueChanged" id="7MY-X0-ITr"/>
                         </connections>
                     </switch>
+                    <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jue-ta-vK0" userLabel="Section">
+                        <rect key="frame" x="0.0" y="872.5" width="414" height="56"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S1g-H2-0sy" userLabel="Finishing Line">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="0.5"/>
+                                <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="0.33000000000000002" id="XAK-pq-szR"/>
+                                </constraints>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NODE IDENTITY" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3ls-hQ-f8f">
+                                <rect key="frame" x="20" y="28" width="105" height="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" red="0.42745098040000001" green="0.42745098040000001" blue="0.44705882349999998" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Pn-W3-NBm" userLabel="Beginning Line">
+                                <rect key="frame" x="0.0" y="55.5" width="414" height="0.5"/>
+                                <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="0.33000000000000002" id="adI-n6-cVf"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="8Pn-W3-NBm" secondAttribute="trailing" id="BQc-UG-J9h"/>
+                            <constraint firstItem="3ls-hQ-f8f" firstAttribute="leading" secondItem="Jue-ta-vK0" secondAttribute="leadingMargin" id="BmX-kl-9Iu"/>
+                            <constraint firstItem="3ls-hQ-f8f" firstAttribute="bottom" secondItem="Jue-ta-vK0" secondAttribute="bottomMargin" id="GRK-Rb-WMP"/>
+                            <constraint firstAttribute="trailing" secondItem="S1g-H2-0sy" secondAttribute="trailing" id="IBH-Pb-LKS"/>
+                            <constraint firstItem="S1g-H2-0sy" firstAttribute="leading" secondItem="Jue-ta-vK0" secondAttribute="leading" id="b8h-7I-xVD"/>
+                            <constraint firstItem="S1g-H2-0sy" firstAttribute="top" secondItem="Jue-ta-vK0" secondAttribute="top" id="bRX-vL-8Cj"/>
+                            <constraint firstAttribute="height" constant="56" id="bTm-KT-w76"/>
+                            <constraint firstItem="8Pn-W3-NBm" firstAttribute="leading" secondItem="Jue-ta-vK0" secondAttribute="leading" id="kMw-Gq-Hpa"/>
+                            <constraint firstAttribute="bottom" secondItem="8Pn-W3-NBm" secondAttribute="bottom" id="uNp-KO-al9"/>
+                        </constraints>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TT2-fb-RHp">
+                        <rect key="frame" x="20" y="936.5" width="374" height="125.5"/>
+                        <mutableString key="text">The Node Identity state determines if a node is advertising with Node Identity messages on a subnet. If the Mesh Proxy Service is exposed, the node can be configured to advertise with Node Identity on a subnet.  Pull the list down to read and change states.</mutableString>
+                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
                 </subviews>
                 <constraints>
                     <constraint firstItem="mpe-Bp-8SZ" firstAttribute="trailing" secondItem="065-UL-Q8f" secondAttribute="trailingMargin" id="0R4-GC-r9X"/>
@@ -355,8 +399,10 @@
                     <constraint firstItem="gVr-aU-fD1" firstAttribute="trailing" secondItem="065-UL-Q8f" secondAttribute="trailingMargin" id="2G4-rK-uQj"/>
                     <constraint firstItem="hn1-Xh-LXI" firstAttribute="trailing" secondItem="BK3-fh-qbs" secondAttribute="trailing" id="3I0-In-Yyb"/>
                     <constraint firstItem="mpe-Bp-8SZ" firstAttribute="top" secondItem="Cub-nh-IZx" secondAttribute="bottom" constant="8" id="3a8-m9-Hrr"/>
+                    <constraint firstItem="TT2-fb-RHp" firstAttribute="top" secondItem="Jue-ta-vK0" secondAttribute="bottom" constant="8" id="3vS-Ri-5Jb"/>
                     <constraint firstItem="Eac-j2-yZp" firstAttribute="trailing" secondItem="4OU-Wl-Pn6" secondAttribute="trailing" id="5rf-Go-m0q"/>
                     <constraint firstItem="Z1C-6S-hxd" firstAttribute="trailing" secondItem="SWp-oU-68u" secondAttribute="trailing" id="5st-aA-QGQ"/>
+                    <constraint firstItem="TT2-fb-RHp" firstAttribute="leading" secondItem="065-UL-Q8f" secondAttribute="leadingMargin" id="8XO-8f-lpa"/>
                     <constraint firstItem="NG0-c0-Iid" firstAttribute="leading" secondItem="4xc-mA-Pwm" secondAttribute="trailing" constant="16" id="A0c-TY-YHL"/>
                     <constraint firstItem="PSn-E0-bIg" firstAttribute="leading" secondItem="065-UL-Q8f" secondAttribute="leadingMargin" id="A1w-t8-u0U"/>
                     <constraint firstItem="gxD-is-qIK" firstAttribute="leading" secondItem="065-UL-Q8f" secondAttribute="leadingMargin" id="A5V-Fd-SPE"/>
@@ -365,23 +411,26 @@
                     <constraint firstItem="ztF-Vw-61s" firstAttribute="trailing" secondItem="065-UL-Q8f" secondAttribute="trailingMargin" id="CSo-e6-HVP"/>
                     <constraint firstItem="Cub-nh-IZx" firstAttribute="top" secondItem="cFg-Ds-bZw" secondAttribute="bottom" constant="8" id="ChI-5U-bQM"/>
                     <constraint firstAttribute="trailing" secondItem="D12-ZA-L55" secondAttribute="trailing" id="DVz-IK-sBp"/>
+                    <constraint firstItem="Jue-ta-vK0" firstAttribute="top" secondItem="plw-fg-Zic" secondAttribute="bottom" constant="8" id="Dd8-N5-A3J"/>
                     <constraint firstAttribute="trailing" secondItem="PSn-E0-bIg" secondAttribute="trailing" id="Dp9-V5-jjV"/>
                     <constraint firstItem="w3q-47-EFW" firstAttribute="leading" secondItem="ZqL-7X-uqV" secondAttribute="leading" id="E4d-NN-jMU"/>
                     <constraint firstItem="Eac-j2-yZp" firstAttribute="centerY" secondItem="ZqL-7X-uqV" secondAttribute="centerY" id="Fyb-3v-yvy"/>
                     <constraint firstItem="D12-ZA-L55" firstAttribute="leading" secondItem="065-UL-Q8f" secondAttribute="leadingMargin" id="GGP-Sp-JK7"/>
                     <constraint firstAttribute="trailingMargin" secondItem="gxD-is-qIK" secondAttribute="trailing" id="GrO-I5-RUu"/>
+                    <constraint firstAttribute="trailing" secondItem="Jue-ta-vK0" secondAttribute="trailing" id="HFH-du-uuv"/>
                     <constraint firstItem="gxD-is-qIK" firstAttribute="top" secondItem="qlO-yr-4Ka" secondAttribute="bottom" constant="8" id="HSE-HM-VwO"/>
                     <constraint firstItem="NG0-c0-Iid" firstAttribute="trailing" secondItem="BK3-fh-qbs" secondAttribute="trailing" id="Hem-dn-5bI"/>
                     <constraint firstItem="w3q-47-EFW" firstAttribute="trailing" secondItem="Gyw-xP-peX" secondAttribute="trailing" id="Hug-aW-HF4"/>
                     <constraint firstItem="Gyw-xP-peX" firstAttribute="bottom" secondItem="jYX-uN-s3g" secondAttribute="bottom" constant="8" id="ImV-62-Ng3"/>
                     <constraint firstItem="cFg-Ds-bZw" firstAttribute="top" secondItem="PSn-E0-bIg" secondAttribute="bottom" constant="8" id="J9l-FC-Qdl"/>
+                    <constraint firstItem="Jue-ta-vK0" firstAttribute="leading" secondItem="065-UL-Q8f" secondAttribute="leading" id="Jdr-1j-xXC"/>
                     <constraint firstItem="BK3-fh-qbs" firstAttribute="leading" secondItem="tZ4-Df-a3a" secondAttribute="trailing" constant="16" id="Lqc-BR-KP7"/>
                     <constraint firstItem="4OU-Wl-Pn6" firstAttribute="leading" secondItem="jYX-uN-s3g" secondAttribute="trailing" constant="16" id="N4L-mc-Fgk"/>
                     <constraint firstItem="SWp-oU-68u" firstAttribute="bottom" secondItem="tZ4-Df-a3a" secondAttribute="bottom" constant="8" id="N9Y-WV-GxZ"/>
                     <constraint firstItem="HoH-je-kKm" firstAttribute="leading" secondItem="065-UL-Q8f" secondAttribute="leading" id="NNV-Z1-NUH"/>
+                    <constraint firstItem="TT2-fb-RHp" firstAttribute="trailing" secondItem="065-UL-Q8f" secondAttribute="trailingMargin" id="OgK-qR-KAE"/>
                     <constraint firstAttribute="trailing" secondItem="SWp-oU-68u" secondAttribute="trailing" id="Qdl-wf-iHd"/>
                     <constraint firstItem="SWp-oU-68u" firstAttribute="leading" secondItem="tZ4-Df-a3a" secondAttribute="leading" id="RAo-et-f0y"/>
-                    <constraint firstAttribute="bottom" secondItem="plw-fg-Zic" secondAttribute="bottom" constant="8" id="RIb-V6-kpL"/>
                     <constraint firstItem="HoH-je-kKm" firstAttribute="top" secondItem="ztF-Vw-61s" secondAttribute="bottom" constant="8" id="Snw-R7-837"/>
                     <constraint firstItem="Z1C-6S-hxd" firstAttribute="top" secondItem="4xc-mA-Pwm" secondAttribute="bottom" constant="8" id="U8x-SY-pbr"/>
                     <constraint firstAttribute="trailing" secondItem="HoH-je-kKm" secondAttribute="trailing" id="UE5-FR-LfN"/>
@@ -406,6 +455,7 @@
                     <constraint firstAttribute="trailing" secondItem="Cub-nh-IZx" secondAttribute="trailing" id="mcR-d2-OLh"/>
                     <constraint firstItem="KOs-C7-Mi1" firstAttribute="top" secondItem="w3q-47-EFW" secondAttribute="bottom" constant="8" id="mu5-8s-52B"/>
                     <constraint firstItem="qlO-yr-4Ka" firstAttribute="top" secondItem="KOs-C7-Mi1" secondAttribute="bottom" constant="8" id="oDo-S4-lFy"/>
+                    <constraint firstAttribute="bottom" secondItem="TT2-fb-RHp" secondAttribute="bottom" constant="8" id="oWn-gB-jdc"/>
                     <constraint firstItem="w0c-zx-Bht" firstAttribute="top" secondItem="hn1-Xh-LXI" secondAttribute="bottom" constant="8" id="occ-wO-gej"/>
                     <constraint firstItem="BK3-fh-qbs" firstAttribute="trailing" secondItem="065-UL-Q8f" secondAttribute="trailingMargin" id="rgI-uI-oFl"/>
                     <constraint firstItem="Sbl-RQ-VgE" firstAttribute="top" secondItem="mpe-Bp-8SZ" secondAttribute="bottom" constant="8" id="sTG-14-C8o"/>
@@ -439,7 +489,7 @@
                 <outlet property="secureNetworkBeaconSwitch" destination="cFg-Ds-bZw" id="6AA-Qk-0F4"/>
                 <outlet property="setRelayButton" destination="hn1-Xh-LXI" id="0HA-W0-Cc6"/>
             </connections>
-            <point key="canvasLocation" x="-10.144927536231885" y="79.017857142857139"/>
+            <point key="canvasLocation" x="-10.144927536231885" y="133.92857142857142"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/Example/nRFMeshProvision/View Controllers/Common/SwitchCell.swift
+++ b/Example/nRFMeshProvision/View Controllers/Common/SwitchCell.swift
@@ -35,4 +35,9 @@ class SwitchCell: UITableViewCell {
     @IBOutlet weak var title: UILabel!
     @IBOutlet weak var `switch`: UISwitch!
     
+    @IBAction func switchDidChange(_ sender: UISwitch) {
+        delegate?(sender.isOn)
+    }
+    
+    var delegate: ((Bool) -> ())?
 }

--- a/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationClientHandler.swift
+++ b/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationClientHandler.swift
@@ -57,6 +57,7 @@ internal class ConfigurationClientHandler: ModelDelegate {
             ConfigFriendStatus.self,
             ConfigBeaconStatus.self,
             ConfigNetworkTransmitStatus.self,
+            ConfigNodeIdentityStatus.self,
             ConfigNodeResetStatus.self,
             ConfigHeartbeatPublicationStatus.self,
             ConfigHeartbeatSubscriptionStatus.self,
@@ -339,6 +340,11 @@ internal class ConfigurationClientHandler: ModelDelegate {
                 // This may be set to nil.
                 node.heartbeatSubscription = HeartbeatSubscription(status)
             }
+            
+        // Node Identity
+        case is ConfigNodeIdentityStatus:
+            // Do nothing. The model does not need to be updated.
+            break
             
         case is ConfigKeyRefreshPhaseStatus:
             // Do nothing. The model does not need to be updated.

--- a/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationServerHandler.swift
+++ b/nRFMeshProvision/Classes/Layers/Foundation Layer/ConfigurationServerHandler.swift
@@ -76,6 +76,8 @@ internal class ConfigurationServerHandler: ModelDelegate {
             ConfigBeaconSet.self,
             ConfigNetworkTransmitSet.self,
             ConfigNetworkTransmitGet.self,
+            ConfigNodeIdentityGet.self,
+            ConfigNodeIdentitySet.self,
             ConfigNodeReset.self,
             ConfigHeartbeatPublicationGet.self,
             ConfigHeartbeatPublicationSet.self,
@@ -563,6 +565,13 @@ internal class ConfigurationServerHandler: ModelDelegate {
             
         case is ConfigNetworkTransmitGet:
             return ConfigNetworkTransmitStatus(for: localNode)
+            
+        // Node Identity
+        case let request as ConfigNodeIdentityGet:
+            return ConfigNodeIdentityStatus(responseTo: request)
+            
+        case let request as ConfigNodeIdentitySet:
+            return ConfigNodeIdentityStatus(responseTo: request)
                 
         // Resetting Node
         case is ConfigNodeReset:

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigNodeIdentityGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigNodeIdentityGet.swift
@@ -1,0 +1,53 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct ConfigNodeIdentityGet: AcknowledgedConfigMessage, ConfigNetKeyMessage {
+    public static let opCode: UInt32 = 0x8046
+    public static let responseType: StaticMeshMessage.Type = ConfigNodeIdentityStatus.self
+    
+    public var parameters: Data? {
+        return encodeNetKeyIndex()
+    }
+    
+    public let networkKeyIndex: KeyIndex
+    
+    public init(networkKey: NetworkKey) {
+        self.networkKeyIndex = networkKey.index
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 2 else {
+            return nil
+        }
+        networkKeyIndex = Self.decodeNetKeyIndex(from: parameters, at: 0)
+    }
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigNodeIdentitySet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigNodeIdentitySet.swift
@@ -1,0 +1,64 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct ConfigNodeIdentitySet: AcknowledgedConfigMessage, ConfigNetKeyMessage {
+    public static let opCode: UInt32 = 0x8047
+    public static let responseType: StaticMeshMessage.Type = ConfigNodeIdentityStatus.self
+    
+    public var parameters: Data? {
+        return encodeNetKeyIndex() + identity.rawValue
+    }
+    
+    public let networkKeyIndex: KeyIndex
+    /// The Node Identity state determines if a node is advertising with Node Identity
+    /// messages on a subnet.
+    public let identity: NodeIdentity
+    
+    /// Creates the Config Node Identity Set message.
+    ///
+    /// - parameters:
+    ///   - networkKey: The Network Key index for requested subnet.
+    ///   - identity:   The Node Identity state determines if a node is advertising with
+    ///                 Node Identity messages on a subnet.
+    public init(networkKey: NetworkKey, identity: NodeIdentity) {
+        self.networkKeyIndex = networkKey.index
+        self.identity = identity
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 3 else {
+            return nil
+        }
+        networkKeyIndex = Self.decodeNetKeyIndex(from: parameters, at: 0)
+        identity = NodeIdentity(rawValue: parameters[2]) ?? .notSupported
+    }
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigNodeIdentityStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigNodeIdentityStatus.swift
@@ -1,0 +1,81 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct ConfigNodeIdentityStatus: ConfigNetKeyMessage, ConfigStatusMessage {
+    public static let opCode: UInt32 = 0x8048
+    
+    public var parameters: Data? {
+        return Data([status.rawValue]) + encodeNetKeyIndex() + identity.rawValue
+    }
+    
+    public let networkKeyIndex: KeyIndex
+    public let identity: NodeIdentity
+    public let status: ConfigMessageStatus
+    
+    /// Creates a Config Node Identity Status object.
+    ///
+    /// - parameters:
+    ///   - identity: The Node Identity state.
+    ///   - networkKey: The Network Key.
+    ///   - status: The status.
+    public init(report identity: NodeIdentity,
+                for networkKey: NetworkKey,
+                with status: ConfigMessageStatus) {
+        self.networkKeyIndex = networkKey.index
+        self.identity = identity
+        self.status = status
+    }
+    
+    /// Creates a response to the given request.
+    ///
+    /// - parameter request: The request has to be of type
+    ///                      `ConfigNodeIdentityGet` or `ConfigNodeIdentitySet`.
+    public init(responseTo request: ConfigNetKeyMessage) {
+        self.networkKeyIndex = request.networkKeyIndex
+        // iOS does not support advertising with Node Identity.
+        self.identity = .notSupported
+        self.status = .success
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 4 else {
+            return nil
+        }
+        guard let status = ConfigMessageStatus(rawValue: parameters[0]) else {
+            return nil
+        }
+        self.status = status
+        networkKeyIndex = Self.decodeNetKeyIndex(from: parameters, at: 1)
+        identity = NodeIdentity(rawValue: parameters[3]) ?? .notSupported
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Model/NodeIdentity.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/NodeIdentity.swift
@@ -41,3 +41,15 @@ public enum NodeIdentity: UInt8 {
     /// Advertising with Node Identity is not supported
     case notSupported = 0x02
 }
+
+extension NodeIdentity: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        switch self {
+        case .stopped:      return NSLocalizedString("Stopped", comment: "")
+        case .running:      return NSLocalizedString("Running", comment: "")
+        case .notSupported: return NSLocalizedString("Not Supported", comment: "")
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Model/NodeIdentity.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/NodeIdentity.swift
@@ -1,0 +1,43 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// The Node Identity state determines if a node is advertising with Node Identity
+/// messages on a subnet. If the Mesh Proxy Service is exposed, the node can be
+/// configured to advertise with Node Identity on a subnet.
+public enum NodeIdentity: UInt8 {
+    /// Advertising with Node Identity for a subnet is stopped.
+    case stopped      = 0x00
+    /// Advertising with Node Identity for a subnet is running.
+    case running      = 0x01
+    /// Advertising with Node Identity is not supported
+    case notSupported = 0x02
+}


### PR DESCRIPTION
This PR fixes #400.

New features added in this PR:
- Config Node Identity Get / Set / Status messages
- `NodeIdentity` enumeration with string convertible
- Option to start and stop advertising with Node Identity for given subnet (Node -> Primary Element -> Configuration Server Model -> Node Identity

Note: The state of Node Identity is not saved in CDB, therefore before starting or stopping this feature the user has to pull the list on Configuration Server to refresh the current statuses. Only then the Switches became enabled (if this is supported on the selected Node).