### PR TITLE
Fix: Disabling Node Identity switch in case of an error

### DIFF
--- a/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
+++ b/Example/nRFMeshProvision/View Controllers/Network/Configuration/ModelViewController.swift
@@ -806,6 +806,8 @@ extension ModelViewController: MeshNetworkDelegate {
                 }
             } else {
                 done {
+                    self.nodeIdentityStates[self.identityIndex].state = .notSupported
+                    self.tableView.reloadSections(.bindings, with: .automatic)
                     self.presentAlert(title: "Error", message: status.message)
                     self.refreshControl?.endRefreshing()
                 }


### PR DESCRIPTION
Sometimes the Node Identity can't be set and the device returns an error. In that case the switch will get disabled. To enable, users need to pull the list again to read the current state.