### PR TITLE
Making properties public in Light LC messages

### DIFF
--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeSet.swift
@@ -36,7 +36,7 @@ public struct LightLCModeSet: AcknowledgedGenericMessage {
     
     /// Whether the controller is turned on and the binding with the Light Lightness
     /// state is enabled.
-    let controllerStatus: Bool
+    public let controllerStatus: Bool
     
     public var parameters: Data? {
         return Data() + controllerStatus

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeSetUnacknowledged.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeSetUnacknowledged.swift
@@ -35,7 +35,7 @@ public struct LightLCModeSetUnacknowledged: GenericMessage {
     
     /// Whether the controller is turned on and the binding with the Light Lightness
     /// state is enabled.
-    let controllerStatus: Bool
+    public let controllerStatus: Bool
     
     public var parameters: Data? {
         return Data() + controllerStatus

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCModeStatus.swift
@@ -35,7 +35,7 @@ public struct LightLCModeStatus: GenericMessage {
     
     /// Whether the controller is turned on and the binding with the Light Lightness
     /// state is enabled.
-    let controllerStatus: Bool
+    public let controllerStatus: Bool
     
     public var parameters: Data? {
         return Data() + controllerStatus

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeSet.swift
@@ -36,7 +36,7 @@ public struct LightLCOccupancyModeSet: AcknowledgedGenericMessage {
     
     /// Whether the controller may transition from a standby state when occupancy
     /// is reported.
-    let occupancyMode: Bool
+    public let occupancyMode: Bool
     
     public var parameters: Data? {
         return Data() + occupancyMode

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeSetUnacknowledged.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeSetUnacknowledged.swift
@@ -35,7 +35,7 @@ public struct LightLCOccupancyModeSetUnacknowledged: GenericMessage {
     
     /// Whether the controller may transition from a standby state when occupancy
     /// is reported.
-    let occupancyMode: Bool
+    public let occupancyMode: Bool
     
     public var parameters: Data? {
         return Data() + occupancyMode

--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLCOccupancyModeStatus.swift
@@ -35,7 +35,7 @@ public struct LightLCOccupancyModeStatus: GenericMessage {
     
     /// Whether the controller may transition from a standby state when occupancy
     /// is reported.
-    let occupancyMode: Bool
+    public let occupancyMode: Bool
     
     public var parameters: Data? {
         return Data() + occupancyMode


### PR DESCRIPTION
This PR fixes #421.

It changes the access modifier of `controlStatus` and `occupancyMode` to `public`.