### PR TITLE
Bug fix: Acknowledged messages sent to group addr should not await Statuses

### DIFF
--- a/nRFMeshProvision/Classes/Layers/Access Layer/AccessLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Access Layer/AccessLayer.swift
@@ -608,8 +608,7 @@ private extension AccessLayer {
         /// request. When the response isn't received after the first retry,
         /// it will try again every time doubling the last delay until the
         /// time goes out.
-        let initialDelay: TimeInterval =
-            networkManager.acknowledgmentMessageInterval(ttl, pdu.segmentsCount)
+        let initialDelay = networkManager.acknowledgmentMessageInterval(ttl, pdu.segmentsCount)
         /// The timeout before which the response should be received.
         let timeout = networkManager.acknowledgmentMessageTimeout
         
@@ -621,7 +620,8 @@ private extension AccessLayer {
                     self.logger?.d(.access, "Resending \(pdu)")
                     self.networkManager.upperTransportLayer.send(pdu, withTtl: initialTtl, using: keySet)
                 }
-            }, timeout: timeout, timeoutBlock: { [weak self] in
+            },
+            timeout: timeout, timeoutBlock: { [weak self] in
                 guard let self = self else { return }
                 self.logger?.w(.access, "Response to \(pdu) not received (timeout)")
                 let category: LogCategory = request is AcknowledgedConfigMessage ? .foundationModel : .model
@@ -630,12 +630,13 @@ private extension AccessLayer {
                                           sentFrom: pdu.source, to: pdu.destination.address,
                                           using: self.networkManager.manager))
                 self.mutex.sync {
-                    self.reliableMessageContexts.removeAll(where: { $0.timeoutTimer == nil })
+                    self.reliableMessageContexts.removeAll { $0.timeoutTimer == nil }
                 }
                 self.networkManager.notifyAbout(AccessError.timeout,
                                                 duringSendingMessage: request,
                                                 from: element, to: pdu.destination.address)
-            })
+            }
+        )
         mutex.sync {
             reliableMessageContexts.append(ack)
         }

--- a/nRFMeshProvision/Classes/Layers/Lower Transport Layer/LowerTransportLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Lower Transport Layer/LowerTransportLayer.swift
@@ -293,7 +293,7 @@ internal class LowerTransportLayer {
     ///            `false` if no packets were received or the message
     ///            was complete before calling this method.
     func isReceivingMessage(from address: Address) -> Bool {
-        return incompleteSegments.contains { entry -> Bool in
+        return incompleteSegments.contains { entry in
             (entry.key >> 16) & 0xFFFF == UInt32(address)
         }
     }


### PR DESCRIPTION
This PR fixes #423.

In the previous implementation a reliable context was sent for all Acknowledge messages. A timer in that context was awaiting a Status message sent from the address used as the destination of the acknowledged message. However, such Status was not possible, as every message is sent with source address set to a Unicast Address of the sending Element, therefore such messages were always timing out.

After the change, the reliable context is only set when the destination address is of Unicast type.