### PR TITLE
fix: prevent ivindex timestamp update on initial beacon

### DIFF
--- a/nRFMeshProvision/Classes/Layers/Network Layer/NetworkLayer.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/NetworkLayer.swift
@@ -315,7 +315,7 @@ private extension NetworkLayer {
             
             // Store the last IV Index.
             defaults.set(meshNetwork.ivIndex.asMap, forKey: IvIndex.indexKey)
-            if lastIVIndex != meshNetwork.ivIndex || lastTransitionDate == nil {
+            if lastIVIndex != meshNetwork.ivIndex {
                 defaults.set(Date(), forKey: IvIndex.timestampKey)
                 
                 let ivRecovery = meshNetwork.ivIndex.index > lastIVIndex.index + 1 &&


### PR DESCRIPTION
Resolves #438 

The timestamp stored for ivindex update should be a timestamp for transition of the ivindex. It should not be updated unless there is an actual transition happens, even if the last transition date is nil.

This can cause issue when first beacon is received with index 0 but next one is received with index >=1 since the node can undergo iv index update immediately after being provisioned due to presence of older nodes. This issue leads to configuration failures