### PR TITLE
Added support for Generic Location Global messages.

### DIFF
--- a/Example/Tests/GlobalLocationStatus.swift
+++ b/Example/Tests/GlobalLocationStatus.swift
@@ -1,0 +1,56 @@
+/*
+* Copyright (c) 2022, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import XCTest
+@testable import nRFMeshProvision
+
+class GlobalLocationStatus: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testIncoming() {
+        let status = GenericLocationGlobalStatus(parameters: Data([0x34, 0xCB, 0xC7, 0x5A, 0x66, 0x66, 0x66, 0x0E, 0xC8, 0x00]))
+
+        XCTAssertEqual(status?.latitude.position() ?? 0.0, 63.83, accuracy: 0.01)
+        XCTAssertEqual(status?.longitude.position() ?? 0.0, 20.25, accuracy: 0.01)
+        XCTAssertEqual(status?.altitude.altitude(), 200)
+    }
+    
+    func testOutgoing() {
+        let status = GenericLocationGlobalStatus(latitude: Latitude(position: 63.83)!, longitude: Longitude(position: 20.25)!, altitude: Altitude.altitude(200))
+        XCTAssertEqual(status.parameters!, Data([0x34, 0xCB, 0xC7, 0x5A, 0x66, 0x66, 0x66, 0x0E, 0xC8, 0x00]))
+    }
+}

--- a/Example/Tests/GlobalLocations.swift
+++ b/Example/Tests/GlobalLocations.swift
@@ -1,0 +1,141 @@
+/*
+* Copyright (c) 2022, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import XCTest
+@testable import nRFMeshProvision
+
+class GlobalLocations: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testIncomingLatitude() {
+        let noConfig = Latitude(raw: -1)
+        XCTAssertNil(noConfig.position())
+
+        let minValue = Latitude(raw: Int32.min)
+        XCTAssertEqual(minValue.position() ?? 0.0, -90.0, accuracy: 0.01)
+
+        let maxValue = Latitude(raw: Int32.max)
+        XCTAssertEqual(maxValue.position() ?? 0.0, 90, accuracy: 0.01)
+
+        let positiveSweden = Latitude(raw: 1523043124)
+        XCTAssertEqual(positiveSweden.position() ?? 0.0, 63.83, accuracy: 0.01)
+
+        let negativeSydney = Latitude(raw: -807453851)
+        XCTAssertEqual(negativeSydney.position() ?? 0.0, -33.84, accuracy: 0.01)
+    }
+    
+    func testOutgoingLatitude() {
+        let noConfig = Latitude.notConfigured
+        XCTAssertEqual(noConfig.encode(), -1)
+
+        let minValue = Latitude(position: -90.0)
+        XCTAssertEqual(minValue?.encode() ?? 0, Int32.min + 1)
+
+        let maxValue = Latitude(position: 90.0)
+        XCTAssertEqual(maxValue?.encode() ?? 0, Int32.max - 1)
+
+        let positiveSweden = Latitude(position: 63.83)
+        XCTAssertEqual(positiveSweden?.encode() ?? 0, 1523043124)
+
+        // Not identical to the incoming test above due to float precision.
+        let negativeSydney = Latitude(position: -33.84)
+        XCTAssertEqual(negativeSydney?.encode() ?? 0, -807453852)
+    }
+
+    func testIncomingLongitude() {
+        let noConfig = Longitude(raw: -1)
+        XCTAssertNil(noConfig.position())
+
+        let minValue = Longitude(raw: Int32.min)
+        XCTAssertEqual(minValue.position() ?? 0.0, -180.0, accuracy: 0.01)
+
+        let maxValue = Longitude(raw: Int32.max)
+        XCTAssertEqual(maxValue.position() ?? 0.0, 180, accuracy: 0.01)
+
+        let positiveSweden = Longitude(raw: 241591910)
+        XCTAssertEqual(positiveSweden.position() ?? 0.0, 20.25, accuracy: 0.01)
+
+        let negativeLosAngeles = Longitude(raw: -1411373974)
+        XCTAssertEqual(negativeLosAngeles.position() ?? 0.0, -118.30, accuracy: 0.01)
+    }
+    
+    func testOutgoingLongitude() {
+        let noConfig = Longitude.notConfigured
+        XCTAssertEqual(noConfig.encode(), -1)
+
+        let minValue = Longitude(position: -180.0)
+        XCTAssertEqual(minValue?.encode() ?? 0, Int32.min + 1)
+
+        let maxValue = Longitude(position: 180.0)
+        XCTAssertEqual(maxValue?.encode() ?? 0, Int32.max - 1)
+
+        let positiveSweden = Longitude(position: 20.25)
+        XCTAssertEqual(positiveSweden?.encode() ?? 0, 241591910)
+
+        // Not identical to the incoming test above due to float precision.
+        let negativeLosAngeles = Longitude(position: -118.30)
+        XCTAssertEqual(negativeLosAngeles?.encode() ?? 0, -1411373975)
+    }
+
+    func testIncomingAltitude() {
+        let noConfig = Altitude(raw: 0x7FFF)
+        XCTAssertEqual(noConfig, Altitude.notConfigured)
+
+        let tooLarge = Altitude(raw: 0x7FFE)
+        XCTAssertEqual(tooLarge, Altitude.tooLarge)
+
+        let minValue = Altitude(raw: -32768)
+        XCTAssertEqual(minValue.altitude(), -32768)
+
+        let maxValue = Altitude(raw: 0x7FFD)
+        XCTAssertEqual(maxValue.altitude(), 0x7FFD)
+    }
+    
+    func testOutgoingAltitude() {
+        let noConfig = Altitude.notConfigured
+        XCTAssertEqual(noConfig.encode(), 0x7FFF)
+
+        let tooLarge = Altitude.tooLarge
+        XCTAssertEqual(tooLarge.encode(), 0x7FFE)
+
+        let minValue = Altitude.altitude(-32768)
+        XCTAssertEqual(minValue.encode(), -32768)
+
+        let maxValue = Altitude.altitude(0x7FFD)
+        XCTAssertEqual(maxValue.encode(), 0x7FFD)
+    }
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Generic/GenericLocationGlobalGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Generic/GenericLocationGlobalGet.swift
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2022, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct GenericLocationGlobalGet: AcknowledgedGenericMessage {
+    public static let opCode: UInt32 = 0x8225
+    public static let responseType: StaticMeshMessage.Type = GenericLocationGlobalStatus.self
+    
+    public var parameters: Data? {
+        return nil
+    }
+    
+    public init() {
+        // Empty
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.isEmpty else {
+            return nil
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Generic/GenericLocationGlobalSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Generic/GenericLocationGlobalSet.swift
@@ -1,0 +1,61 @@
+/*
+* Copyright (c) 2022, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct GenericLocationGlobalSet: AcknowledgedGenericMessage {
+    public static let opCode: UInt32 = 0x41
+    public static let responseType: StaticMeshMessage.Type = GenericLocationGlobalStatus.self
+    
+    public var parameters: Data? {
+        return Data() + latitude.encode() + longitude.encode() + altitude.encode()
+    }
+
+    public var latitude: Latitude
+    public var longitude: Longitude
+    public var altitude: Altitude
+
+    /// Creates the Generic Location Global Set message.
+    public init(latitude: Latitude, longitude: Longitude, altitude: Altitude) {
+        self.latitude = latitude
+        self.longitude = longitude
+        self.altitude = altitude
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 10 else {
+            return nil
+        }
+
+        latitude = Latitude(raw: parameters.read())
+        longitude = Longitude(raw: parameters.read(fromOffset: 4))
+        altitude = Altitude(raw: parameters.read(fromOffset: 8))
+    }
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Generic/GenericLocationGlobalSetUnacknowledged.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Generic/GenericLocationGlobalSetUnacknowledged.swift
@@ -1,0 +1,60 @@
+/*
+* Copyright (c) 2022, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct GenericLocationGlobalSetUnacknowledged: GenericMessage {
+    public static let opCode: UInt32 = 0x42
+    
+    public var parameters: Data? {
+        return Data() + latitude.encode() + longitude.encode() + altitude.encode()
+    }
+
+    public var latitude: Latitude
+    public var longitude: Longitude
+    public var altitude: Altitude
+
+    /// Creates the Generic Location Global Set message.
+    public init(latitude: Latitude, longitude: Longitude, altitude: Altitude) {
+        self.latitude = latitude
+        self.longitude = longitude
+        self.altitude = altitude
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 10 else {
+            return nil
+        }
+
+        latitude = Latitude(raw: parameters.read())
+        longitude = Longitude(raw: parameters.read(fromOffset: 4))
+        altitude = Altitude(raw: parameters.read(fromOffset: 8))
+    }
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Generic/GenericLocationGlobalStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Generic/GenericLocationGlobalStatus.swift
@@ -1,0 +1,60 @@
+/*
+* Copyright (c) 2022, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import AppKit
+
+public struct GenericLocationGlobalStatus: GenericMessage, LocationStatusMessage {
+    public static var opCode: UInt32 = 0x40
+    
+    public var parameters: Data? {
+        return Data() + latitude.encode() + longitude.encode() + altitude.encode()
+    }
+
+    public var latitude: Latitude
+    public var longitude: Longitude
+    public var altitude: Altitude
+    
+    public init(latitude: Latitude, longitude: Longitude, altitude: Altitude) {
+        self.latitude = latitude
+        self.longitude = longitude
+        self.altitude = altitude
+    }
+
+    public init?(parameters: Data) {
+        guard parameters.count == 10 else {
+            return nil
+        }
+
+        latitude = Latitude(raw: parameters.read())
+        longitude = Longitude(raw: parameters.read(fromOffset: 4))
+        altitude = Altitude(raw: parameters.read(fromOffset: 8))
+    }
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/LocationMessage.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/LocationMessage.swift
@@ -1,0 +1,172 @@
+/*
+* Copyright (c) 2022, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public protocol LocationStatusMessage: GenericMessage {
+    /// Latitude
+    var latitude: Latitude { get }
+    /// Longitude
+    var longitude: Longitude { get }
+    /// Altitude
+    var altitude: Altitude { get }
+}
+
+public protocol LocationMessage: StaticMeshMessage {
+    // No additional fields.
+}
+
+public protocol AcknowledgedLocationMessage: LocationMessage, StaticAcknowledgedMeshMessage {
+    // No additional fields.
+}
+
+public enum Latitude {
+    init(raw parameter: Int32) {
+        if (parameter == -1) {
+            self = .notConfigured
+        } else {
+            self = .coordinate(parameter)
+        }
+    }
+
+    /// Creates an instance of a Latitude object.
+    ///
+    /// - parameters:
+    ///   - position: The WGS84 coordinate longitude. Valid values are between -180 and 180.
+    init?(position: Double) {
+        if (position < -90 || position > 90) {
+            return nil
+        }
+        
+        self = .coordinate(max(Int32.min + 1, min(Int32.max - 1, Int32(floor((position / 90) * (pow(2, 31) - 1))))))
+    }
+    
+    func encode() -> Int32 {
+        switch self {
+        case .coordinate(let parameter):
+            return parameter
+        case .notConfigured:
+            return -1
+        }
+    }
+
+    func position() -> Double? {
+        switch self {
+        case .coordinate(let parameter):
+            return Double(parameter) / (pow(2, 31) - 1) * 90
+        case .notConfigured:
+            return nil
+        }
+    }
+    
+    case coordinate(Int32)
+    case notConfigured
+}
+
+public enum Longitude {
+    init(raw parameter: Int32) {
+        if (parameter == -1) {
+            self = .notConfigured
+        } else {
+            self = .coordinate(parameter)
+        }
+    }
+
+    /// Creates an instance of a Longitude object.
+    ///
+    /// - parameters:
+    ///   - position: The WGS84 coordinate longitude. Valid values are between -180 and 180.
+    init?(position: Double) {
+        if (position < -180 || position > 180) {
+            return nil
+        }
+
+        self = .coordinate(max(Int32.min + 1, min(Int32.max - 1, Int32(floor((position / 180) * (pow(2, 31) - 1))))))
+    }
+
+    func encode() -> Int32 {
+        switch self {
+        case .coordinate(let parameter):
+            return parameter
+        case .notConfigured:
+            return -1
+        }
+    }
+
+    func position() -> Double? {
+        switch self {
+        case .coordinate(let parameter):
+            return Double(parameter) / (pow(2, 31) - 1) * 180
+        case .notConfigured:
+            return nil
+        }
+    }
+
+    case coordinate(Int32)
+    case notConfigured
+}
+
+public enum Altitude : Equatable {
+    init(raw parameter: Int16) {
+        if (parameter == 0x7FFF) {
+            self = .notConfigured
+        } else if (parameter == 0x7FFE) {
+            self = .tooLarge
+        } else {
+            self = .altitude(parameter)
+        }
+    }
+
+    func encode() -> Int16 {
+        switch self {
+        case .altitude(let position):
+            return position
+        case .tooLarge:
+            return 0x7FFE
+        case .notConfigured:
+            return 0x7FFF
+        }
+    }
+
+    func altitude() -> Int16? {
+        switch self {
+        case .altitude(let parameter):
+            return parameter
+        case .tooLarge:
+            return nil
+        case .notConfigured:
+            return nil
+        }
+    }
+    
+    case altitude(Int16)
+    case tooLarge
+    case notConfigured
+}


### PR DESCRIPTION
First stab at adding messages to support the Global Location state. Tried to match other messages as best I could, but please let me know if I should re-arrange things.

Not tested on a live device, hoping the unit tests are good enough. The only thing I'm concerned about is the byte order, but since the generation of the message parameters is identical to old messages, I'm thinking it should be ok.