### PR TITLE
Support for TimeGet/Set/Status and TimeZoneGet/Set/Status.

### DIFF
--- a/Example/Tests/TimeMessages.swift
+++ b/Example/Tests/TimeMessages.swift
@@ -1,0 +1,87 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import XCTest
+@testable import nRFMeshProvision
+
+class TimeMessages: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testIncomingTaiTime() {
+        let time = TaiTime.unmarshal(Data([120, 86, 52, 18, 0, 50, 120, 255, 225, 74]))
+        
+        XCTAssertEqual(time.seconds, 305419896)
+        XCTAssertEqual(time.subSecond, 50)
+        XCTAssertEqual(time.uncertainty, 120)
+        XCTAssertEqual(time.authority, true)
+        XCTAssertEqual(time.taiDelta, 28672)
+        XCTAssertEqual(time.tzOffset, 2.5)
+    }
+
+    func testOutgoingTaiTime() {
+        let time = TaiTime.marshal(TaiTime(seconds: 305419896, subSecond: 50, uncertainty: 120, authority: true, taiDelta: 28672, tzOffset: 2.5))
+        
+        XCTAssertEqual(time, Data([120, 86, 52, 18, 0, 50, 120, 255, 225, 74]))
+    }
+
+    func testIncomingTimeZoneStatus() {
+        let msg = TimeZoneStatus(parameters: Data([68, 60, 213, 106, 129, 45, 0]))
+        
+        XCTAssertEqual(msg?.currentTzOffset, 1)
+        XCTAssertEqual(msg?.nextTzOffset, -1)
+        XCTAssertEqual(msg?.taiSeconds, 763456213)
+    }
+
+    func testOutgoingTimeZoneStatus() {
+        let msg = TimeZoneStatus(currentTzOffset: 1.5, nextTzOffset: -1.25, taiSeconds: 763456213)
+        
+        XCTAssertEqual(msg.parameters, Data([70, 59, 213, 106, 129, 45, 0]))
+    }
+
+    func testIncomingTimeZoneSet() {
+        let msg = TimeZoneSet(parameters: Data([90, 213, 106, 129, 45, 0]))
+        
+        XCTAssertEqual(msg?.tzOffset, 6.5)
+        XCTAssertEqual(msg?.taiSeconds, 763456213)
+    }
+
+    func testOutgoingTimeZoneSet() {
+        let msg = TimeZoneSet(tzOffset: -6.5, taiSeconds: 763456213)
+        
+        XCTAssertEqual(msg.parameters, Data([38, 213, 106, 129, 45, 0]))
+    }
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Time and Scenes/TimeGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Time and Scenes/TimeGet.swift
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2022, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct TimeGet: AcknowledgedGenericMessage {
+    public static let opCode: UInt32 = 0x8237
+    public static let responseType: StaticMeshMessage.Type = TimeStatus.self
+    
+    public var parameters: Data? {
+        return nil
+    }
+    
+    public init() {
+        // Empty
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.isEmpty else {
+            return nil
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Time and Scenes/TimeSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Time and Scenes/TimeSet.swift
@@ -1,0 +1,61 @@
+/*
+* Copyright (c) 2022, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct TimeSet: TimeMessage {
+    public static let opCode: UInt32 = 0x5C
+    public static let responseType: StaticMeshMessage.Type = TimeStatus.self
+    
+    public var parameters: Data? {
+        return TaiTime.marshal(time)
+    }
+
+    public let time: TaiTime
+
+    /// Creates an empty Time Set message.
+    ///
+    public init() {
+        self.time = TaiTime()
+    }
+
+    /// Creates the Time Set message.
+    public init(time: TaiTime) {
+        self.time = time
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 10 else {
+            return nil
+        }
+        time = TaiTime.unmarshal(parameters)
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Time and Scenes/TimeStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Time and Scenes/TimeStatus.swift
@@ -1,0 +1,54 @@
+/*
+* Copyright (c) 2022, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct TimeStatus: GenericMessage {
+    public static let opCode: UInt32 = 0x5D
+    
+    public var parameters: Data? {
+        return TaiTime.marshal(time)
+    }
+    
+    public let time: TaiTime
+
+    /// Creates the Time Status message.
+    public init(time: TaiTime) {
+        self.time = time
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 10 else {
+            return nil
+        }
+        time = TaiTime.unmarshal(parameters)
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Time and Scenes/TimeZoneGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Time and Scenes/TimeZoneGet.swift
@@ -1,0 +1,51 @@
+/*
+* Copyright (c) 2022, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct TimeZoneGet: AcknowledgedGenericMessage {
+    public static let opCode: UInt32 = 0x823B
+    public static let responseType: StaticMeshMessage.Type = TimeZoneStatus.self
+    
+    public var parameters: Data? {
+        return nil
+    }
+    
+    public init() {
+        // Empty
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.isEmpty else {
+            return nil
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Time and Scenes/TimeZoneSet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Time and Scenes/TimeZoneSet.swift
@@ -1,0 +1,67 @@
+/*
+* Copyright (c) 2022, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct TimeZoneSet: AcknowledgedGenericMessage {
+    public static let opCode: UInt32 = 0x823C
+    public static let responseType: StaticMeshMessage.Type = TimeZoneStatus.self
+    
+    public var parameters: Data? {
+        let data = Data() + tzOffset.encodeToTzOffset()
+        return data + Data([taiSeconds.getByte(at: 0), taiSeconds.getByte(at: 1), taiSeconds.getByte(at: 2), taiSeconds.getByte(at: 3), taiSeconds.getByte(at: 4)])
+    }
+    
+    /// The upcoming local time zone offset.
+    public let tzOffset: Double
+    /// The TAI seconds time when the new offset should be applied.
+    public let taiSeconds: UInt64
+    
+    /// Creates the Time Zone Set message.
+    ///
+    /// - parameters:
+    ///   - tzOffset: the new offset.
+    ///   - taiSeconds: the time in TAI seconds when the new offset should be applied.
+    public init(tzOffset: Double, taiSeconds: UInt64) {
+        self.tzOffset = tzOffset
+        self.taiSeconds = taiSeconds
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 6 else {
+            return nil
+        }
+
+        let meshOffset: UInt8 = parameters.read()
+        tzOffset = meshOffset.decodeFromTzOffset()
+        taiSeconds = parameters.read(numBytes: 5, fromOffset: 1)
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/Time and Scenes/TimeZoneStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Time and Scenes/TimeZoneStatus.swift
@@ -1,0 +1,73 @@
+/*
+* Copyright (c) 2022, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public struct TimeZoneStatus: GenericMessage {
+    public static let opCode: UInt32 = 0x823D
+    
+    public var parameters: Data? {
+        let data =  Data() + currentTzOffset.encodeToTzOffset() + nextTzOffset.encodeToTzOffset()
+        
+        return data + Data([taiSeconds.getByte(at: 0), taiSeconds.getByte(at: 1), taiSeconds.getByte(at: 2), taiSeconds.getByte(at: 3), taiSeconds.getByte(at: 4)])
+    }
+    
+    /// The corrent local time zone offset.
+    public let currentTzOffset: Double
+    /// The upcoming local time zone offset.
+    public let nextTzOffset: Double
+    /// The TAI seconds time when the new offset should be applied.
+    public let taiSeconds: UInt64
+
+    /// Creates the Time Zone Status message.
+    ///
+    /// - parameters:
+    ///   - currentTzOffset: the current offset.
+    ///   - nextTzOffset: the new offset.
+    ///   - taiSeconds: the time in TAI seconds when the new offset should be applied.
+    public init(currentTzOffset: Double, nextTzOffset: Double, taiSeconds: UInt64) {
+        self.currentTzOffset = currentTzOffset
+        self.nextTzOffset = nextTzOffset
+        self.taiSeconds = taiSeconds
+    }
+
+    public init?(parameters: Data) {
+        guard parameters.count == 7 else {
+            return nil
+        }
+
+        let currentMeshOffset: UInt8 = parameters.read()
+        currentTzOffset = currentMeshOffset.decodeFromTzOffset()
+        let newMeshOffset: UInt8 = parameters.read(fromOffset: 1)
+        nextTzOffset = newMeshOffset.decodeFromTzOffset()
+        taiSeconds = parameters.read(numBytes: 5, fromOffset: 2)
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Messages/TimeMessage.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/TimeMessage.swift
@@ -1,0 +1,129 @@
+/*
+* Copyright (c) 2022, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+
+public protocol TimeMessage: StaticMeshMessage {
+    var time: TaiTime { get }
+}
+
+public struct TaiTime {
+    /// The current TAI time in seconds.
+    public let seconds: UInt64
+    /// The sub-second time in units of 1/256th second.
+    public let subSecond: UInt8
+    /// The estimated uncertainty in 10-millisecond steps.
+    public let uncertainty: UInt8
+    /// Whether this time is authorative (from a "known good" source, such as GPS or NTP).
+    public let authority: Bool
+    /// Current difference between TAI and UTC in seconds (range -255 to 32512).
+    public let taiDelta: Int16
+    /// The Local time zone offset.
+    public let tzOffset: Double
+    
+    public init() {
+        self.seconds = 0
+        self.subSecond = 0
+        self.uncertainty = 0
+        self.authority = false
+        self.taiDelta = 0
+        self.tzOffset = 0
+    }
+    
+    public init(seconds: UInt64, subSecond: UInt8, uncertainty: UInt8, authority: Bool, taiDelta: Int16, tzOffset: Double) {
+        self.seconds = seconds
+        self.subSecond = subSecond
+        self.uncertainty = uncertainty
+        self.authority = authority
+        self.taiDelta = taiDelta
+        self.tzOffset = tzOffset
+    }
+}
+
+// MARK: - Extensions for encoding and decoding parameters in time messages.
+extension UInt64 {
+    public func getByte(at offset: Int) -> UInt8 {
+        return UInt8(self >> (8 * offset) & 0xFF)
+    }
+}
+
+extension Double {
+    public func encodeToTzOffset() -> UInt8 {
+        return UInt8(max(-127, min(128, Int(self * 4) + Int(TZ_START_RANGE))))
+    }
+}
+
+extension UInt8 {
+    public func decodeFromTzOffset() -> Double {
+        return Double(Int(self) - Int(TZ_START_RANGE)) / 4;
+    }
+}
+
+// MARK: - Constants for encoding and decoding parameters in time messages.
+let TZ_START_RANGE: UInt8 = 0x40
+let TAI_DELTA_START_RANGE: Int16 = 0xFF
+
+// MARK: - Extensions for encoding and decoding TAI time objects.
+extension TaiTime {
+    public static func unmarshal(_ parameters: Data) -> TaiTime {
+        let seconds = parameters.read(numBytes: 5)
+        let subSecond: UInt8 = parameters.read(fromOffset: 5)
+        let uncertainty: UInt8 = parameters.read(fromOffset: 6)
+        let authorityAndTaiDelta: UInt16 = parameters.read(fromOffset: 7)
+        let tzOffset: UInt8 = parameters.read(fromOffset: 9)
+
+        let authority = (authorityAndTaiDelta & 0x0001) == 0x0001 ? true : false
+        let taiDelta = Int16(authorityAndTaiDelta >> 1)
+
+        return TaiTime(seconds: seconds, subSecond: subSecond, uncertainty: uncertainty, authority: authority, taiDelta: taiDelta - TAI_DELTA_START_RANGE, tzOffset: tzOffset.decodeFromTzOffset())
+    }
+    
+    public static func marshal(_ time: TaiTime) -> Data {
+        var data = Data()
+
+        //  Protocol only supports 40 bits of time, strip the rest of the 64-bit value.
+        data.append(contentsOf: [time.seconds.getByte(at: 0), time.seconds.getByte(at: 1), time.seconds.getByte(at: 2), time.seconds.getByte(at: 3), time.seconds.getByte(at: 4)])
+
+        data.append(time.subSecond)
+        data.append(time.uncertainty)
+
+        // Time authority offset the bytes by one bit, so do some
+        // twiddling until we're back in sync.
+        let meshDelta = time.taiDelta + TAI_DELTA_START_RANGE
+        let octet1: UInt8 = (time.authority ? 0x80 : 0x00) | UInt8(meshDelta & 0x7F)
+        let octet2: UInt8 = UInt8((meshDelta >> 7) & 0xFF)
+
+        data.append(contentsOf: [octet1, octet2])
+        data.append(time.tzOffset.encodeToTzOffset())
+        
+        return data
+    }
+}

--- a/nRFMeshProvision/Classes/Type Extensions/Data.swift
+++ b/nRFMeshProvision/Classes/Type Extensions/Data.swift
@@ -53,6 +53,16 @@ extension Data {
         return UInt32(self[offset]) | UInt32(self[offset + 1]) << 8 | UInt32(self[offset + 2]) << 16
     }
     
+    func read(numBytes bytes: Int, fromOffset offset: Int = 0) -> UInt64 {
+        var res: UInt64 = 0
+
+        for i in 0...bytes-1 {
+            res += UInt64(self[offset + i]) << (i * 8)
+        }
+        
+        return res
+    }
+    
     func readBigEndian<R: FixedWidthInteger>(fromOffset offset: Int = 0) -> R {
         let r: R = read(fromOffset: offset)
         return r.bigEndian


### PR DESCRIPTION
Basic support for the mesh time commands. Skipped the TAI/UTC Delta and Time Role commands for now.

I was considering making the API use for iOS types for simplicity, but that would require new dependencies or a lot more code that I don't know if it fits in the SDK. Things like converting between UTC and TAI. Maybe something for a future commit, if it is deemed to fit in the SDK.

The commands are not tested live, but the expected test results in the unit tests are taken from the Android SDK, where those commands have been tested.