### PR TITLE
Change LightLightnessDefaultGet opCode from 0x8254 to 0x8255

### DIFF
--- a/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLightnessDefaultGet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Lighting/LightLightnessDefaultGet.swift
@@ -31,7 +31,7 @@
 import Foundation
 
 public struct LightLightnessDefaultGet: AcknowledgedGenericMessage {
-    public static let opCode: UInt32 = 0x8254
+    public static let opCode: UInt32 = 0x8255
     public static let responseType: StaticMeshMessage.Type = LightLightnessDefaultStatus.self
     
     public var parameters: Data? {


### PR DESCRIPTION
According to the Mesh Model Bluetooth® Specification the LightLightnessDefaultGet opCode should be 0x8255

<img width="748" alt="Bildschirmfoto 2022-08-01 um 10 58 12" src="https://user-images.githubusercontent.com/31277375/182112485-917646b6-20c2-43c2-a8bb-123025d6560e.png">
