### PR TITLE
Modified constructor and property for raw value to public.

### DIFF
--- a/nRFMeshProvision/Classes/Mesh Model/TransitionTime.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/TransitionTime.swift
@@ -51,7 +51,8 @@ public struct TransitionTime {
         return TimeInterval(milliseconds) / 1000.0
     }
     
-    internal var rawValue: UInt8 {
+    /// The raw representation of the transition in a mesh message.
+    public var rawValue: UInt8 {
         return (steps & 0x3F) | (stepResolution.rawValue << 6)
     }
     
@@ -99,7 +100,7 @@ public struct TransitionTime {
         }
     }
     
-    internal init(rawValue: UInt8) {
+    public init(rawValue: UInt8) {
         self.steps = rawValue & 0x3F
         self.stepResolution = StepResolution(rawValue: rawValue >> 6)!
     }


### PR DESCRIPTION
Enables custom implementations of vendor messages to use transition time without their own bit-twiddling.

I must have fat-fingered the original PR or something, cause it got force-pushed into an empty variant and closed. But since you wanted it to be split in two anyway.... :)