### PR TITLE
Setting default feature values to Unknown and Enabled for Low Power case

### DIFF
--- a/nRFMeshProvision/Classes/Mesh Model/NodeFeatures.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/NodeFeatures.swift
@@ -149,18 +149,15 @@ public class NodeFeaturesState: Codable {
     /// This method creates the Node Features State object based on the
     /// feature bit-field from the Page 0 of the Composition Data.
     ///
-    /// - important: Mind, that it has to convert "supported" state into
-    ///              either "not enabled" or "enabled". The "not enabled" is
-    ///              chosen in this implementation. This does not mean, that
-    ///              the feature is actually not enabled. To get the actual
-    ///              value, use Config ... Get messages.
     /// - parameter mask: Features field from the Page 0 of the Compositon Page.
-    /// - seeAlso:   https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/pull/414
     internal init(mask: UInt16) {
-        self.relay    = mask & 0x01 == 0 ? .notSupported : .notEnabled
-        self.proxy    = mask & 0x02 == 0 ? .notSupported : .notEnabled
-        self.friend   = mask & 0x04 == 0 ? .notSupported : .notEnabled
-        self.lowPower = mask & 0x08 == 0 ? .notSupported : .notEnabled
+        // The state of the following features is unknown until the corresponding
+        // Config ... Get message is sent.
+        self.relay    = mask & 0x01 == 0 ? .notSupported : nil
+        self.proxy    = mask & 0x02 == 0 ? .notSupported : nil
+        self.friend   = mask & 0x04 == 0 ? .notSupported : nil
+        // The Low Power feature if supported is enabled and cannot be disabled.
+        self.lowPower = mask & 0x08 == 0 ? .notSupported : .enabled
     }
 }
 


### PR DESCRIPTION
This PR fixes a long lasting issue, improved also in #414, related to how Node features are presented after receiving Composition Data. 
Before they were all marked as `.notEnabled` despite their state was unknown.

This PR fixes that by setting the features values to `nil` (Unknown) for:
* Proxy
* Relay
* Friend

and to `.enabled` for: 
* Low Power

if they are supported.

To read the states of the unknown features use *Config XXX Get* messages.