### PR TITLE
Allow oob input generation to be configured, version 2

### DIFF
--- a/Documentation.docc/nRFMeshProvision.md
+++ b/Documentation.docc/nRFMeshProvision.md
@@ -316,6 +316,7 @@ provisioning procedure.
 - ``OutputAction``
 - ``OutputOobActions``
 - ``InputAction``
+- ``InputActionValueGenerator``
 - ``InputOobActions``
 - ``StaticOobType``
 

--- a/nRFMeshProvision/Classes/Provisioning/Oob.swift
+++ b/nRFMeshProvision/Classes/Provisioning/Oob.swift
@@ -95,13 +95,41 @@ public enum OutputAction: UInt8 {
 }
 
 /// The user will have to enter the input action on the device.
-/// For example, if the device supports `.push`, user will be asked to
+/// For example, if the device supports ``InputAction/push``, user will be asked to
 /// press a button on the device required number of times.
 public enum InputAction: UInt8 {
     case push               = 0
     case twist              = 1
     case inputNumeric       = 2
     case inputAlphanumeric  = 3
+}
+
+/// This object should generate a random alphanumeric or a random number of given sizes.
+///
+/// The value generator is used in Provisioning with an Input Action used as OOB.
+///
+/// The default implementation provides random values. It should only be overriden
+/// if you need to know the values in advance, for example for testing.
+open class InputActionValueGenerator {
+    /// This method should generate a random alphanumeric capitalize string of given size.
+    ///
+    /// For example, for `size` equal to 3 the output can be "3Z8".
+    ///
+    /// - parameter size: Required length of the returned String.
+    /// - returns: The random alphanumeric String.
+    func randomAlphanumeric(size: UInt8) -> String {
+        return String.random(length: size)
+    }
+    
+    /// This method should generate a random integer of at most given length.
+    ///
+    /// For example, for the `size` equal to 2 the maximum returned value is 99.
+    ///
+    /// - parameter size: The maximum supported length of the integer.
+    /// - returns: A random integer of maximum given length.
+    func randomInt(size: UInt8) -> UInt {
+        return UInt.random(length: size)
+    }
 }
 
 /// A set of supported Static Out-Of-Band types.
@@ -264,4 +292,25 @@ extension InputOobActions: CustomDebugStringConvertible {
             .joined(separator: ", ")
     }
     
+}
+
+private extension String {
+    
+    /// Generates a random string of numerics and capital English letters
+    /// with given length.
+    static func random(length: UInt8) -> String {
+        let letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        return String((0..<length).map { _ in letters.randomElement()! })
+    }
+    
+}
+
+private extension UInt {
+    
+    /// Generates a random integer with at most `length` digits.
+    static func random(length digits: UInt8) -> UInt {
+        let upperbound = UInt(pow(10.0, Double(digits)))
+        return UInt.random(in: 1..<upperbound)
+    }
+
 }

--- a/nRFMeshProvision/Classes/Provisioning/ProvisioningManager.swift
+++ b/nRFMeshProvision/Classes/Provisioning/ProvisioningManager.swift
@@ -85,6 +85,15 @@ public class ProvisioningManager {
     /// the Provisioning Capabilities have been received and such address was found.
     public private(set) var suggestedUnicastAddress: Address?
     
+    /// This generator will be used for Input Actions to generate a random
+    /// alphanumeric or integer value, depending on the chosen action.
+    ///
+    /// The default implementation is sufficient for most cases. Use your own
+    /// implementation if you need to know the value beforehand.
+    /// - since: 3.3.0
+    /// - seeAlso: https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/pull/435
+    public var inputActionValueGenerator: InputActionValueGenerator = InputActionValueGenerator()
+    
     /// The Network Key to be sent to the device during provisioning.
     /// Setting this property is mandatory before calling
     /// ``provision(usingAlgorithm:publicKey:authenticationMethod:)``.
@@ -517,10 +526,10 @@ private extension ProvisioningManager {
         case let .inputOob(action: action, size: size):
             switch action {
             case .inputAlphanumeric:
-                let random = randomString(length: UInt(size))
+                let random = inputActionValueGenerator.randomAlphanumeric(size: size)
                 authAction = .displayAlphanumeric(random)
             case .push, .twist, .inputNumeric:
-                let random = randomInt(length: UInt(size))
+                let random = inputActionValueGenerator.randomInt(size: size)
                 authAction = .displayNumber(random, inputAction: action)
             }
             delegate?.authenticationActionRequired(authAction!)
@@ -552,23 +561,4 @@ private extension ProvisioningManager {
         state = .ready
     }
     
-}
-
-// MARK: - Helper methods
-
-private extension ProvisioningManager {
-    
-    /// Generates a random string of numerics and capital English letters
-    /// with given length.
-    func randomString(length: UInt) -> String {
-        let letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-        return String((0..<length).map{ _ in letters.randomElement()! })
-    }
-    
-    /// Generates a random integer with at most `length` digits.
-    func randomInt(length: UInt) -> UInt {
-        let upperbound = UInt(pow(10.0, Double(length)))
-        return UInt.random(in: 1..<upperbound)
-    }
-
 }


### PR DESCRIPTION
This PR does what #435 started, but using the second proposed approach.

