### PR TITLE
Provisioning Security Improvements

### DIFF
--- a/Example/Source/View Controllers/Network/Configuration/ConfigurationViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/ConfigurationViewController.swift
@@ -205,6 +205,8 @@ class ConfigurationViewController: ProgressViewController {
                 if let featuresCell = cell as? NodeFeaturesCell {
                    featuresCell.node = node
                 }
+            case 5:
+                cell.detailTextLabel?.text = "\(node.security)"
             default:
                 break
             }
@@ -549,7 +551,8 @@ private extension IndexPath {
     ]
     static let detailsTitles = [
         "Company Identifier", "Product Identifier", "Product Version",
-        "Replay Protection Count", nil // Node Features is using its own cell.
+        "Replay Protection Count", nil, // Node Features is using its own cell.
+        "Security"
     ]
     static let switchesTitles = [
         "Configured", "Excluded"

--- a/Example/Source/View Controllers/Settings/EditKeyViewController.swift
+++ b/Example/Source/View Controllers/Settings/EditKeyViewController.swift
@@ -127,7 +127,7 @@ class EditKeyViewController: UITableViewController {
         case IndexPath.keySection where isApplicationKey:
             return 3 // Key, Old Key, Key Index
         case IndexPath.keySection:
-            return isNewKey ? 3 : 5 // Key, Old Key, Key Index [, Phase, Last modified ]
+            return isNewKey ? 3 : 6 // Key, Old Key, Key Index [, Phase, Min Security, Last modified ]
         case IndexPath.boundKeySection:
             let network = MeshNetworkManager.instance.meshNetwork!
             return network.networkKeys.count
@@ -187,6 +187,12 @@ class EditKeyViewController: UITableViewController {
             cell.textLabel?.text = "Phase"
             let phase = (key as? NetworkKey)?.phase ?? KeyRefreshPhase.normalOperation
             cell.detailTextLabel?.text = "\(phase)"
+            cell.selectionStyle = .none
+        } else if indexPath.isMinSecurity {
+            cell = tableView.dequeueReusableCell(withIdentifier: "detailCell", for: indexPath)
+            cell.textLabel?.text = "Minimum Security"
+            let minSecurity = (key as? NetworkKey)?.minSecurity ?? .secure
+            cell.detailTextLabel?.text = "\(minSecurity)"
             cell.selectionStyle = .none
         } else if indexPath.isLastModified {
             cell = tableView.dequeueReusableCell(withIdentifier: "detailCell", for: indexPath)
@@ -380,9 +386,14 @@ private extension IndexPath {
         return section == IndexPath.keySection && row == 3
     }
     
+    /// Returns whether the IndexPath points to Network Key min security.
+    var isMinSecurity: Bool {
+        return section == IndexPath.keySection && row == 4
+    }
+    
     /// Returns whether the IndexPath points to Network Key last modified timestamp.
     var isLastModified: Bool {
-        return section == IndexPath.keySection && row == 4
+        return section == IndexPath.keySection && row == 5
     }
     
     /// Returns whether the IndexPath points to Bound Network Key Index.

--- a/Example/Tests/Exporting.swift
+++ b/Example/Tests/Exporting.swift
@@ -124,6 +124,7 @@ class Exporting: XCTestCase {
         
         // Setup Nodes in the kitchen.
         let kitchenLightSwitch = Node(name: "Kitchen Light Switch", uuid: UUID(), deviceKey: Data.random128BitKey(),
+                                      security: .secure,
                                       andAssignedNetworkKey: primaryNetworkKey!, andAddress: 0x0002)
         kitchenLightSwitch.add(elements: [
             Element(name: "Left button", location: .left,
@@ -141,6 +142,7 @@ class Exporting: XCTestCase {
         ])
         
         let kitchenLight = Node(name: "Kitchen Light", uuid: UUID(), deviceKey: Data.random128BitKey(),
+                                security: .secure,
                                 andAssignedNetworkKey: primaryNetworkKey!, andAddress: 0x0004)
         kitchenLight.add(element:
             Element(name: "Main Element", location: .left,
@@ -154,6 +156,7 @@ class Exporting: XCTestCase {
             )
         )
         let led = Node(name: "LED", uuid: UUID(), deviceKey: Data.random128BitKey(),
+                       security: .secure,
                        andAssignedNetworkKey: primaryNetworkKey!, andAddress: 0x0005)
         led.add(element:
             Element(name: "Main Element", location: .left,
@@ -247,6 +250,7 @@ class Exporting: XCTestCase {
         
         // Configure Lock.
         let lock = Node(name: "Door Lock", uuid: UUID(), deviceKey: Data.random128BitKey(),
+                        security: .insecure,
                         andAssignedNetworkKey: primaryNetworkKey!, andAddress: 0x0010)
         lock.add(element: Element(name: "Main Element", location: .main,
                                   models: [
@@ -277,6 +281,7 @@ class Exporting: XCTestCase {
         
         // Setup Nodes in the guest room.
         let guestSwitch = Node(name: "Guest Room Switch", uuid: UUID(), deviceKey: Data.random128BitKey(),
+                               security: .insecure,
                                andAssignedNetworkKey: primaryNetworkKey!, andAddress: 0x0100)
         guestSwitch.add(element: Element(name: "Toggle Button", location: .main,
                                          models: [
@@ -286,6 +291,7 @@ class Exporting: XCTestCase {
                                          ]))
         
         let guestLight = Node(name: "Guest Light", uuid: UUID(), deviceKey: Data.random128BitKey(),
+                              security: .insecure,
                               andAssignedNetworkKey: primaryNetworkKey!, andAddress: 0x0101)
         guestLight.add(element: Element(name: "Main Element", location: .unknown,
                        models: [

--- a/Example/nRF Mesh.xcodeproj/project.pbxproj
+++ b/Example/nRF Mesh.xcodeproj/project.pbxproj
@@ -1458,7 +1458,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/nRF Mesh_Example.app/nRF Mesh_Example";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/nRF Mesh.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/nRF Mesh";
 			};
 			name = Debug;
 		};
@@ -1481,7 +1481,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/nRFMeshProvision_Tests-Bridging-Header.h";
 				SWIFT_PRECOMPILE_BRIDGING_HEADER = NO;
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/nRF Mesh_Example.app/nRF Mesh_Example";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/nRF Mesh.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/nRF Mesh";
 			};
 			name = Release;
 		};

--- a/nRFMeshProvision/Classes/Legacy/MeshState.swift
+++ b/nRFMeshProvision/Classes/Legacy/MeshState.swift
@@ -77,6 +77,9 @@ internal struct MeshState: Codable {
         let index: KeyIndex = keyIndex.asUInt16 & 0x0FFF
         let networkKey = try! NetworkKey(name: "Primary Network Key", index: index, key: netKey)
         networkKey.phase = flags[0] & 0x80 == 0x80 ? .usingNewKeys : .normalOperation
+        // The Key's minimum security cannot be guaranteed for legacy network
+        // as Nodes' security level was not stored.
+        networkKey.lowerSecurity()
         return networkKey
     }
     

--- a/nRFMeshProvision/Classes/Legacy/MeshState.swift
+++ b/nRFMeshProvision/Classes/Legacy/MeshState.swift
@@ -104,6 +104,7 @@ internal struct MeshState: Codable {
             if old.isValid {
                 let node = Node(name: old.nodeName, uuid: old.uuid,
                                 deviceKey: old.deviceKey,
+                                security: .insecure,
                                 andAssignedNetworkKey: networkKey,
                                 andAddress: old.unicastAddress)
                 node.companyIdentifier = old.cid

--- a/nRFMeshProvision/Classes/Mesh Model/NetworkKey.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/NetworkKey.swift
@@ -144,6 +144,8 @@ public class NetworkKey: Key, Codable {
         self.name        = name
         self.index       = index
         self.key         = key
+        // Initially, a Network Key is consideded secure, as there are no Nodes
+        // that know it other than the Provisioner's one.
         self.minSecurity = .secure
         self.timestamp   = Date()
         
@@ -223,6 +225,19 @@ public class NetworkKey: Key, Codable {
         try container.encode(minSecurity, forKey: .minSecurity)
         try container.encode(timestamp, forKey: .timestamp)
     }
+}
+
+public extension NetworkKey {
+    
+    /// This method lowers the minimum security level of the Network Key to
+    /// ``Security/insecure``.
+    ///
+    /// - seeAlso: ``Security``
+    /// - seeAlso: ``NetworkKey/minSecurity``
+    func lowerSecurity() {
+        minSecurity = .insecure
+    }
+    
 }
 
 // MARK: - Operators

--- a/nRFMeshProvision/Classes/Mesh Model/Node.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Node.swift
@@ -305,15 +305,18 @@ public class Node: Codable {
     ///   - unprovisionedDevice: The newly provisioned device.
     ///   - n: Number of Elements on the new Node.
     ///   - deviceKey: The Device Key.
+    ///   - security: The Node's security. A Node is considered secure if it was
+    ///               provisioned using a OOB Public Key.
     ///   - networkKey: The Network Key.
     ///   - address: The Unicast Address to be assigned to the Node.
     internal convenience init(for unprovisionedDevice: UnprovisionedDevice,
                               with n: UInt8, elementsDeviceKey deviceKey: Data,
+                              security: Security,
                               andAssignedNetworkKey networkKey: NetworkKey,
                               andAddress address: Address) {
         self.init(name: unprovisionedDevice.name, uuid: unprovisionedDevice.uuid,
-                  deviceKey: deviceKey, andAssignedNetworkKey: networkKey,
-                  andAddress: address)
+                  deviceKey: deviceKey, security: security,
+                  andAssignedNetworkKey: networkKey, andAddress: address)
         // Elements will be queried with Composition Data.
         // Let's just add n empty Elements to reserve addresses.
         for _ in 0..<n {
@@ -321,13 +324,13 @@ public class Node: Codable {
         }
     }
     
-    internal init(name: String?, uuid: UUID, deviceKey: Data,
+    internal init(name: String?, uuid: UUID, deviceKey: Data, security: Security,
                   andAssignedNetworkKey networkKey: NetworkKey, andAddress address: Address) {
         self.uuid = uuid
         self.name = name
         self.primaryUnicastAddress = address
         self.deviceKey = deviceKey
-        self.security  = .secure
+        self.security  = security
         // Composition Data were not obtained.
         self.isConfigComplete = false
         

--- a/nRFMeshProvision/Classes/Mesh Model/Node.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Node.swift
@@ -718,7 +718,8 @@ internal extension Node {
     }
     
     /// Sets the Network Keys to the Node.
-    /// This will overwrite the previous keys.
+    ///
+    /// This method overwrites previous keys.
     ///
     /// - parameter networkKeys: The Network Keys to set.
     func set(networkKeys: [NetworkKey]) {
@@ -726,7 +727,8 @@ internal extension Node {
     }
     
     /// Sets the Network Keys with given indexes to the Node.
-    /// This will overwrite the previous keys.
+    ///
+    /// This method overwrites previous keys.
     ///
     /// - parameter networkKeyIndexes: The Network Key indexes to set.
     func set(networkKeysWithIndexes networkKeyIndexes: [KeyIndex]) {
@@ -779,7 +781,8 @@ internal extension Node {
     }
     
     /// Sets the Application Keys with given indexes to the Node.
-    /// This will overwrite the previous keys.
+    ///
+    /// This method overwrites previous keys.
     ///
     /// - parameter applicationKeyIndexes: The Application Key indexes to set.
     func set(applicationKeysWithIndexes applicationKeyIndexes: [KeyIndex]) {
@@ -789,6 +792,7 @@ internal extension Node {
     }
     
     /// Sets the Application Keys with given indexes to the Node.
+    ///
     /// This will overwrite the previous keys bound to the given
     /// Network Key.
     ///

--- a/nRFMeshProvision/Classes/Mesh Model/Node.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Node.swift
@@ -267,7 +267,8 @@ public class Node: Codable {
         }
     }
     
-    /// Initializes the Provisioner's node.
+    /// Initializes the Provisioner's Node.
+    ///
     /// The Provisioner's node has the same name and node UUID as the Provisioner.
     ///
     /// - parameter provisioner: The Provisioner for which the node is added.
@@ -298,6 +299,7 @@ public class Node: Codable {
     }
     
     /// Initializes a Node for given unprovisioned device.
+    ///
     /// The Node will have the same UUID as the device in the advertising
     /// packet.
     ///
@@ -391,18 +393,19 @@ public class Node: Codable {
         }
     }
     
-    /// Creates a low security Node with given Device Key, Network Key and Unicast Address.
+    /// Creates an insecure Node with given Device Key, Network Key and Unicast Address.
+    ///
     /// Usually, a Node is added to a network during provisioning. However, for debug
     /// purposes, or to add an already provisioned Node, one can use this method.
-    /// A Node created this way will have security set to `.low`.
+    /// A Node created this way will have security set to ``Security/insecure``.
     ///
-    /// Use `meshNetwork.add(node: Node)` to add the Node. Other parameters must be
+    /// Use ``MeshNetwork/add(node:)`` to add the Node. Other parameters must be
     /// read from the Node using Configuration messages.
     ///
     /// - parameters:
     ///   - name: Optional Node name.
     ///   - n: Number of Elements. Elements must be read using
-    ///        `ConfigCompositionDataGet` message.
+    ///        ``ConfigCompositionDataGet`` message.
     ///   - deviceKey: The 128-bit Device Key.
     ///   - networkKey: The Network Key known to this device.
     ///   - address: The primary Unicast Address of the Node.

--- a/nRFMeshProvision/Classes/Provisioning/ProvisioningData.swift
+++ b/nRFMeshProvision/Classes/Provisioning/ProvisioningData.swift
@@ -47,8 +47,13 @@ internal class ProvisioningData {
     private(set) var provisionerPublicKey: Data!
     
     /// The Confirmation Inputs is built over the provisioning process.
-    /// It is composed for: Provisioning Invite PDU, Provisioning Capabilities PDU,
-    /// Provisioning Start PDU, Provisioner's Public Key and device's Public Key.
+    ///
+    /// It is composed of (in that order):
+    /// - Provisioning Invite PDU,
+    /// - Provisioning Capabilities PDU,
+    /// - Provisioning Start PDU,
+    /// - Provisioner's Public Key,
+    /// - device's Public Key.
     private var confirmationInputs: Data = Data(capacity: 1 + 11 + 5 + 64 + 64)
     
     func prepare(for network: MeshNetwork, networkKey: NetworkKey, unicastAddress: Address) {
@@ -87,7 +92,9 @@ internal extension ProvisioningData {
     }
     
     /// Call this method when the device Public Key has been
-    /// obtained. This must be called after generating keys.
+    /// obtained.
+    ///
+    /// This must be called after generating keys.
     ///
     /// - parameter key: The device Public Key.
     /// - throws: This method throws when generating ECDH Secure

--- a/nRFMeshProvision/Classes/Provisioning/ProvisioningData.swift
+++ b/nRFMeshProvision/Classes/Provisioning/ProvisioningData.swift
@@ -96,7 +96,11 @@ internal extension ProvisioningData {
         guard let _ = privateKey else {
             throw ProvisioningError.invalidState
         }
-        sharedSecret = try Crypto.calculateSharedSecret(privateKey: privateKey, publicKey: key)
+        do {
+            sharedSecret = try Crypto.calculateSharedSecret(privateKey: privateKey, publicKey: key)
+        } catch {
+            throw ProvisioningError.invalidPublicKey
+        }
     }
     
     /// Call this method when the Auth Value has been obtained.

--- a/nRFMeshProvision/Classes/Provisioning/ProvisioningManager.swift
+++ b/nRFMeshProvision/Classes/Provisioning/ProvisioningManager.swift
@@ -269,7 +269,7 @@ public class ProvisioningManager {
             // moment ago. Even if not, it trully has been randomly generated, so it's not
             // an attack.
             do {
-                try provisioningData.provisionerDidObtain(devicePublicKey: key)
+                try provisioningData.provisionerDidObtain(devicePublicKey: key, usingOob: true)
             } catch {
                 state = .fail(error)
                 return
@@ -388,7 +388,7 @@ extension ProvisioningManager: BearerDelegate, BearerDataDelegate {
             }
             provisioningData.accumulate(pdu: data.dropFirst())
             do {
-                try provisioningData.provisionerDidObtain(devicePublicKey: publicKey)
+                try provisioningData.provisionerDidObtain(devicePublicKey: publicKey, usingOob: false)
                 obtainAuthValue()
             } catch {
                 state = .fail(error)
@@ -443,9 +443,11 @@ extension ProvisioningManager: BearerDelegate, BearerDataDelegate {
             
         // The provisioning process is complete.
         case (.provisioning, .complete):
+            let security = provisioningData.security
             let deviceKey = provisioningData.deviceKey!
             let n = provisioningCapabilities!.numberOfElements
             let node = Node(for: unprovisionedDevice, with: n, elementsDeviceKey: deviceKey,
+                            security: security,
                             andAssignedNetworkKey: provisioningData.networkKey,
                             andAddress: provisioningData.unicastAddress)
             do {

--- a/nRFMeshProvision/Classes/Provisioning/ProvisioningManager.swift
+++ b/nRFMeshProvision/Classes/Provisioning/ProvisioningManager.swift
@@ -379,10 +379,10 @@ extension ProvisioningManager: BearerDelegate, BearerDataDelegate {
             
         // Device Public Key has been received.
         case (.provisioning, .publicKey):
-            let publicKey = response.publicKey!
-            // Errata E16350 added an extera check whether the received Public Key is different
-            // than Provisioner's Public Key.
-            guard publicKey != provisioningData.provisionerPublicKey else {
+            // Errata E16350 added an extra validation whether the received Public Key
+            // is different than Provisioner's one.
+            guard let publicKey = response.publicKey,
+                  publicKey != provisioningData.provisionerPublicKey else {
                 state = .fail(ProvisioningError.invalidPublicKey)
                 return
             }

--- a/nRFMeshProvision/Classes/Provisioning/ProvisioningManager.swift
+++ b/nRFMeshProvision/Classes/Provisioning/ProvisioningManager.swift
@@ -413,7 +413,14 @@ extension ProvisioningManager: BearerDelegate, BearerDataDelegate {
         
         // The Provisioning Confirmation value has been received.
         case (.provisioning, .confirmation):
-            provisioningData.provisionerDidObtain(deviceConfirmation: response.confirmation!)
+            // Errata E16350 added an extra validation whether the received Confirmation
+            // is different than Provisioner's one.
+            guard let confirmation = response.confirmation,
+                  confirmation != provisioningData.provisionerConfirmation else {
+                state = .fail(ProvisioningError.confirmationFailed)
+                return
+            }
+            provisioningData.provisionerDidObtain(deviceConfirmation: confirmation)
             do {
                 let provisioningRandom = ProvisioningRequest.random(provisioningData.provisionerRandom)
                 logger?.v(.provisioning, "Sending \(provisioningRandom)")

--- a/nRFMeshProvision/Classes/Provisioning/ProvisioningState.swift
+++ b/nRFMeshProvision/Classes/Provisioning/ProvisioningState.swift
@@ -52,6 +52,8 @@ public enum ProvisioningError: Error {
     case invalidState
     /// The received PDU is invalid.
     case invalidPdu
+    /// The received Public Key is invalid or equal to Provisioner's Public Key.
+    case invalidPublicKey
     /// Thrown when an unsupported algorithm has been selected for provisioning.
     case unsupportedAlgorithm
     /// Thrown when the Unprovisioned Device is not supported by the manager.
@@ -145,6 +147,8 @@ extension ProvisioningError: LocalizedError {
             return NSLocalizedString("Invalid state", comment: "provisioning")
         case .invalidPdu:
             return NSLocalizedString("Invalid PDU", comment: "provisioning")
+        case .invalidPublicKey:
+            return NSLocalizedString("Invalid or equal Public Key", comment: "provisioning")
         case .unsupportedAlgorithm:
             return NSLocalizedString("Unsupported algorithm", comment: "provisioning")
         case .unsupportedDevice:


### PR DESCRIPTION
This PR implements changes introduced in Errata E16350:
* Check if received Provisionee's Public Key is different than Provisioner's one
* Check if received Provisionee's Confirmation value is different than Provisioner's one
* Setting Node's `security` to `.insecure` if provisioned using an insecure way (without OOB Public Key)

Additionally, this PR displays "Security" and "Minimum Security" fields for Nodes and Network Keys respectively in nRF Mesh sample app.