### PR TITLE
Support for Mesh 1.1 (Part 1: Provisioning)

### DIFF
--- a/Documentation.docc/nRFMeshProvision.md
+++ b/Documentation.docc/nRFMeshProvision.md
@@ -318,7 +318,7 @@ provisioning procedure.
 - ``InputAction``
 - ``InputActionValueGenerator``
 - ``InputOobActions``
-- ``StaticOobType``
+- ``OobType``
 
 ### Mesh Network
 

--- a/Example/Source/UI/Base.lproj/Network.storyboard
+++ b/Example/Source/UI/Base.lproj/Network.storyboard
@@ -319,18 +319,18 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailButton" indentationWidth="10" reuseIdentifier="switch" id="2HO-VY-kvg" customClass="SwitchCell" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="324" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="324" width="414" height="43"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2HO-VY-kvg" id="jOf-kh-Gdy">
-                                    <rect key="frame" x="0.0" y="0.0" width="370" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="370" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0bP-aX-r7S">
-                                            <rect key="frame" x="313" y="6.5" width="51" height="31"/>
+                                            <rect key="frame" x="313" y="6" width="51" height="31"/>
                                             <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </switch>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mg0-0v-t3c">
-                                            <rect key="frame" x="20" y="11" width="33" height="21.5"/>
+                                            <rect key="frame" x="20" y="11" width="33" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -842,21 +842,21 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="switch" id="ukA-iV-k75" customClass="SwitchCell" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="686" width="414" height="43"/>
+                                <rect key="frame" x="0.0" y="686" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ukA-iV-k75" id="q0I-rL-LSs">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P1w-ws-FGk">
-                                            <rect key="frame" x="345" y="6" width="51" height="31"/>
+                                            <rect key="frame" x="345" y="6.5" width="51" height="31"/>
                                             <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                             <connections>
                                                 <action selector="switchDidChange:" destination="ukA-iV-k75" eventType="valueChanged" id="PJe-b6-sbf"/>
                                             </connections>
                                         </switch>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pqx-lg-qPZ">
-                                            <rect key="frame" x="20" y="11" width="33" height="21"/>
+                                            <rect key="frame" x="20" y="11" width="33" height="21.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -1120,32 +1120,42 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="BAq-5b-9tR" detailTextLabel="pS5-Y5-QgE" style="IBUITableViewCellStyleSubtitle" id="yy7-AU-JwL">
-                                        <rect key="frame" x="0.0" y="316" width="414" height="55.5"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="yy7-AU-JwL">
+                                        <rect key="frame" x="0.0" y="316" width="414" height="55"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yy7-AU-JwL" id="NYW-m7-WPo">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Supported Algorithms" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="BAq-5b-9tR">
-                                                    <rect key="frame" x="20" y="10" width="167.5" height="20.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Supported Algorithms" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cfT-Dp-gYP">
+                                                    <rect key="frame" x="20" y="8" width="374" height="21"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="21" id="aca-ym-Ufg"/>
+                                                    </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Loading..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="pS5-Y5-QgE">
-                                                    <rect key="frame" x="20" y="31.5" width="56" height="14.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Loading..." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hot-WG-3vm">
+                                                    <rect key="frame" x="20" y="31" width="374" height="15"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="cfT-Dp-gYP" firstAttribute="top" secondItem="NYW-m7-WPo" secondAttribute="topMargin" constant="-3" id="7U6-jC-dSi"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="cfT-Dp-gYP" secondAttribute="trailing" id="Cam-I0-jIG"/>
+                                                <constraint firstItem="Hot-WG-3vm" firstAttribute="top" secondItem="cfT-Dp-gYP" secondAttribute="bottom" constant="2" id="NGi-dy-INo"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="Hot-WG-3vm" secondAttribute="bottom" constant="-2" id="V9D-zF-L3W"/>
+                                                <constraint firstItem="cfT-Dp-gYP" firstAttribute="leading" secondItem="NYW-m7-WPo" secondAttribute="leadingMargin" id="eWG-UZ-iHU"/>
+                                                <constraint firstItem="Hot-WG-3vm" firstAttribute="leading" secondItem="cfT-Dp-gYP" secondAttribute="leading" id="gYp-qV-33y"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="Hot-WG-3vm" secondAttribute="trailing" id="plW-UJ-4jm"/>
+                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="SdP-NS-3LU" detailTextLabel="zDh-JJ-bBg" style="IBUITableViewCellStyleSubtitle" id="eZz-wJ-sSf">
-                                        <rect key="frame" x="0.0" y="371.5" width="414" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="371" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eZz-wJ-sSf" id="JU7-kU-7e4">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -1168,28 +1178,38 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="MAo-QP-eik" detailTextLabel="Qdh-uv-1ef" style="IBUITableViewCellStyleSubtitle" id="zIh-z7-aCQ">
-                                        <rect key="frame" x="0.0" y="427" width="414" height="55.5"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="zIh-z7-aCQ">
+                                        <rect key="frame" x="0.0" y="426.5" width="414" height="56"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zIh-z7-aCQ" id="RvA-5b-yC4">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="56"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="OOB Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MAo-QP-eik">
-                                                    <rect key="frame" x="20" y="10" width="78" height="20.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OOB Types" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SBC-M4-cx3">
+                                                    <rect key="frame" x="20" y="9" width="374" height="21"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="21" id="s6z-fu-Gxf"/>
+                                                    </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Loading..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Qdh-uv-1ef">
-                                                    <rect key="frame" x="20" y="31.5" width="56" height="14.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Loading..." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NQg-lv-UK2">
+                                                    <rect key="frame" x="20" y="32" width="374" height="15"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="NQg-lv-UK2" firstAttribute="top" secondItem="SBC-M4-cx3" secondAttribute="bottom" constant="2" id="4hG-ze-A6f"/>
+                                                <constraint firstAttribute="bottomMargin" secondItem="NQg-lv-UK2" secondAttribute="bottom" constant="-2" id="HYQ-ik-YXw"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="SBC-M4-cx3" secondAttribute="trailing" id="LGG-aE-fr2"/>
+                                                <constraint firstItem="SBC-M4-cx3" firstAttribute="top" secondItem="RvA-5b-yC4" secondAttribute="topMargin" constant="-2" id="QuH-up-qR6"/>
+                                                <constraint firstItem="NQg-lv-UK2" firstAttribute="leading" secondItem="SBC-M4-cx3" secondAttribute="leading" id="Tbf-Ea-c2R"/>
+                                                <constraint firstItem="SBC-M4-cx3" firstAttribute="leading" secondItem="RvA-5b-yC4" secondAttribute="leadingMargin" id="Yd9-je-4Kg"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="NQg-lv-UK2" secondAttribute="trailing" id="zED-uY-fXF"/>
+                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="eb8-fF-0rX" detailTextLabel="xit-9M-VEk" style="IBUITableViewCellStyleSubtitle" id="yXs-ab-vbS">
@@ -1311,11 +1331,11 @@
                         <outlet property="nameLabel" destination="6zU-SL-IBl" id="RaQ-2T-wIL"/>
                         <outlet property="networkKeyCell" destination="Ndg-0Q-WKP" id="eoi-0Q-Pg1"/>
                         <outlet property="networkKeyLabel" destination="jB2-Ks-5Wg" id="G06-A9-2iG"/>
-                        <outlet property="oobTypeLabel" destination="Qdh-uv-1ef" id="w7c-di-6ky"/>
+                        <outlet property="oobTypeLabel" destination="NQg-lv-UK2" id="HSI-XP-cgR"/>
                         <outlet property="outputOobSizeLabel" destination="xit-9M-VEk" id="OUn-Oi-aSn"/>
                         <outlet property="provisionButton" destination="QVW-Ct-Tf7" id="Jrn-Ox-fyk"/>
                         <outlet property="publicKeyTypeLabel" destination="zDh-JJ-bBg" id="yeg-Hd-EDU"/>
-                        <outlet property="supportedAlgorithmsLabel" destination="pS5-Y5-QgE" id="9fM-jm-2KW"/>
+                        <outlet property="supportedAlgorithmsLabel" destination="Hot-WG-3vm" id="rgY-zG-hLx"/>
                         <outlet property="supportedInputOobActionsLabel" destination="98S-j6-Bn7" id="816-rf-uLr"/>
                         <outlet property="supportedOutputOobActionsLabel" destination="6SF-mc-Wie" id="bs8-vi-bl3"/>
                         <outlet property="unicastAddressLabel" destination="iOG-Yh-pyA" id="m7q-bu-gCf"/>

--- a/Example/Source/UI/Base.lproj/Network.storyboard
+++ b/Example/Source/UI/Base.lproj/Network.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eYe-6v-26u">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eYe-6v-26u">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,33 +11,33 @@
         <!--Provision Device-->
         <scene sceneID="yKm-Cw-E5m">
             <objects>
-                <tableViewController id="9xq-E9-AJj" customClass="ScannerTableViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="9xq-E9-AJj" customClass="ScannerTableViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="56" estimatedRowHeight="56" sectionHeaderHeight="18" sectionFooterHeight="18" id="gG4-Ob-e5u">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="peripheralCell" id="9GQ-tl-ciy" customClass="DeviceCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="32" width="414" height="56"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="peripheralCell" id="9GQ-tl-ciy" customClass="DeviceCell" customModule="nRF_Mesh" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="38" width="414" height="56"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="9GQ-tl-ciy" id="5b8-E0-tR7">
-                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="56"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383.5" height="56"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZMJ-H6-Pq4">
-                                            <rect key="frame" x="20" y="9" width="311.5" height="21"/>
+                                            <rect key="frame" x="20" y="9" width="309.5" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7P7-iB-CcF">
-                                            <rect key="frame" x="20" y="32" width="311.5" height="15"/>
+                                            <rect key="frame" x="20" y="32" width="309.5" height="15"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="rssi_4" translatesAutoresizingMaskIntoConstraints="NO" id="agq-KS-7m0">
-                                            <rect key="frame" x="339.5" y="11" width="38" height="34"/>
+                                            <rect key="frame" x="337.5" y="11" width="38" height="34"/>
                                             <color key="tintColor" systemColor="labelColor"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="38" id="brG-JP-Fhu"/>
@@ -103,14 +103,14 @@
         <!--Device Name-->
         <scene sceneID="lXM-vc-FyC">
             <objects>
-                <tableViewController id="DVn-IC-M3j" customClass="ConfigurationViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="DVn-IC-M3j" customClass="ConfigurationViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="leW-nt-pA6">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="756"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="752"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="normal" textLabel="Jbt-7J-8NZ" detailTextLabel="ki6-Ug-3Hi" style="IBUITableViewCellStyleValue1" id="DFQ-f2-a6e">
-                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="38" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="DFQ-f2-a6e" id="h6H-CM-7Og">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -134,7 +134,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="key" textLabel="pfO-uy-sDC" detailTextLabel="JAd-Fh-EOT" style="IBUITableViewCellStyleValue1" id="Muk-1J-LqO">
-                                <rect key="frame" x="0.0" y="75.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="81.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Muk-1J-LqO" id="9yF-pp-m1N">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -158,7 +158,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="subtitle" textLabel="k0t-Br-ZKs" detailTextLabel="pwS-G1-VKl" style="IBUITableViewCellStyleSubtitle" id="K7A-oW-n9C">
-                                <rect key="frame" x="0.0" y="119" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="125" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="K7A-oW-n9C" id="QM5-AY-8zZ">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -181,8 +181,8 @@
                                     </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="action" id="lc6-Lu-n3M" customClass="ActionCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="174.5" width="414" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="action" id="lc6-Lu-n3M" customClass="ActionCell" customModule="nRF_Mesh" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="180.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lc6-Lu-n3M" id="WjU-Yf-R69">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -216,8 +216,8 @@
                                     <outlet property="title" destination="UTY-9G-OJi" id="jbB-pi-F0f"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="features" rowHeight="100" id="6AP-t4-Gpt" customClass="NodeFeaturesCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="218" width="414" height="100"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="features" rowHeight="100" id="6AP-t4-Gpt" customClass="NodeFeaturesCell" customModule="nRF_Mesh" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="224" width="414" height="100"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="6AP-t4-Gpt" id="KJN-Ia-0oy">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
@@ -318,19 +318,19 @@
                                     <outlet property="relayLabel" destination="sjI-FS-oi4" id="rWb-TS-mh8"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailButton" indentationWidth="10" reuseIdentifier="switch" id="2HO-VY-kvg" customClass="SwitchCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="318" width="414" height="43"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailButton" indentationWidth="10" reuseIdentifier="switch" id="2HO-VY-kvg" customClass="SwitchCell" customModule="nRF_Mesh" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="324" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2HO-VY-kvg" id="jOf-kh-Gdy">
-                                    <rect key="frame" x="0.0" y="0.0" width="373.5" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="370" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0bP-aX-r7S">
-                                            <rect key="frame" x="316.5" y="6" width="51" height="31"/>
+                                            <rect key="frame" x="313" y="6.5" width="51" height="31"/>
                                             <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </switch>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mg0-0v-t3c">
-                                            <rect key="frame" x="20" y="11" width="33" height="21"/>
+                                            <rect key="frame" x="20" y="11" width="33" height="21.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -373,14 +373,14 @@
         <!--Element-->
         <scene sceneID="sEc-09-OCR">
             <objects>
-                <tableViewController id="2Zq-WA-bzR" customClass="ElementViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="2Zq-WA-bzR" customClass="ElementViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="vx7-UB-vSf">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="756"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="752"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="normal" textLabel="22d-4K-pnc" detailTextLabel="BR9-L1-jg9" style="IBUITableViewCellStyleValue1" id="4fI-CB-qLc">
-                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="38" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="4fI-CB-qLc" id="OR6-9E-Aym">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -404,10 +404,10 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="subtitle" textLabel="PGf-uh-Rft" detailTextLabel="jIJ-kc-vTG" style="IBUITableViewCellStyleSubtitle" id="mbs-ys-par">
-                                <rect key="frame" x="0.0" y="75.5" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="81.5" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mbs-ys-par" id="Q6p-0e-jmY">
-                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="55.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383.5" height="55.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="PGf-uh-Rft">
@@ -447,14 +447,14 @@
         <!--Model-->
         <scene sceneID="jYL-jD-XSI">
             <objects>
-                <tableViewController id="veF-nS-gn0" customClass="ModelViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="veF-nS-gn0" customClass="ModelViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="huL-bC-LUM">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="756"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="752"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="normal" textLabel="3p5-Ls-7HB" detailTextLabel="WZp-yu-SUw" style="IBUITableViewCellStyleValue1" id="iMu-ff-fDV">
-                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="38" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iMu-ff-fDV" id="Txb-p3-m6q">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -478,7 +478,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="key" textLabel="Ivw-Zk-1Ri" detailTextLabel="J04-h7-HNa" imageView="SVn-ht-AO0" style="IBUITableViewCellStyleSubtitle" id="otu-JZ-HV0">
-                                <rect key="frame" x="0.0" y="75.5" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="81.5" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="otu-JZ-HV0" id="NgI-An-9RZ">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -505,11 +505,11 @@
                                     </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="destination" rowHeight="123" id="Spq-Ja-fLm" customClass="PublicationCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="131" width="414" height="123"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="destination" rowHeight="123" id="Spq-Ja-fLm" customClass="PublicationCell" customModule="nRF_Mesh" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="137" width="414" height="123"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Spq-Ja-fLm" id="kqG-5g-2cX">
-                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="123"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383.5" height="123"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_flag_24pt" translatesAutoresizingMaskIntoConstraints="NO" id="8EH-nP-ZvK">
@@ -517,13 +517,13 @@
                                             <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Element 1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Drg-5i-a3Q">
-                                            <rect key="frame" x="60" y="11" width="317.5" height="20.5"/>
+                                            <rect key="frame" x="60" y="11" width="315.5" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Node 1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dMG-tt-lVv">
-                                            <rect key="frame" x="60" y="31.5" width="317.5" height="14.5"/>
+                                            <rect key="frame" x="60" y="31.5" width="315.5" height="14.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
@@ -533,19 +533,19 @@
                                             <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="749" text="Application Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="81q-vD-0YQ">
-                                            <rect key="frame" x="60" y="73" width="317.5" height="24"/>
+                                            <rect key="frame" x="60" y="73" width="315.5" height="24"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Bound to Network Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FUD-56-vax">
-                                            <rect key="frame" x="60" y="97" width="325.5" height="15"/>
+                                            <rect key="frame" x="60" y="97" width="323.5" height="15"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Using" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qDA-7q-kry">
-                                            <rect key="frame" x="60" y="52" width="317.5" height="15"/>
+                                            <rect key="frame" x="60" y="52" width="315.5" height="15"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
@@ -585,11 +585,11 @@
                                     <outlet property="keyLabel" destination="81q-vD-0YQ" id="ZES-eL-Y1L"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="heartbeatPublication" rowHeight="123" id="099-xq-uYk" customClass="HeartbeatPublicationCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="254" width="414" height="123"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="heartbeatPublication" rowHeight="123" id="099-xq-uYk" customClass="HeartbeatPublicationCell" customModule="nRF_Mesh" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="260" width="414" height="123"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="099-xq-uYk" id="LS7-zd-726">
-                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="123"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383.5" height="123"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_flag_24pt" translatesAutoresizingMaskIntoConstraints="NO" id="ARs-oW-tub">
@@ -597,13 +597,13 @@
                                             <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Unknown Group" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lod-En-hHF">
-                                            <rect key="frame" x="60" y="11" width="317.5" height="20.5"/>
+                                            <rect key="frame" x="60" y="11" width="315.5" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="0xC003" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vC4-n2-xDA">
-                                            <rect key="frame" x="60" y="31.5" width="317.5" height="14.5"/>
+                                            <rect key="frame" x="60" y="31.5" width="315.5" height="14.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
@@ -613,7 +613,7 @@
                                             <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="749" text="Network Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qfz-DV-SrY">
-                                            <rect key="frame" x="60" y="72" width="317.5" height="40"/>
+                                            <rect key="frame" x="60" y="72" width="315.5" height="40"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="40" id="hno-i2-n7I"/>
                                             </constraints>
@@ -622,7 +622,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Using" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4J9-Hb-Wcs">
-                                            <rect key="frame" x="60" y="52" width="317.5" height="14"/>
+                                            <rect key="frame" x="60" y="52" width="315.5" height="14"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
@@ -659,7 +659,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="group" textLabel="1oJ-fF-jyJ" detailTextLabel="Ezb-Bc-f95" imageView="hHF-iP-OqZ" style="IBUITableViewCellStyleSubtitle" id="ZHd-AD-r5e">
-                                <rect key="frame" x="0.0" y="377" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="383" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZHd-AD-r5e" id="erD-pz-EdV">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -686,8 +686,8 @@
                                     </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="value" id="ewv-CT-3vO" customClass="SensorValueCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="432.5" width="414" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="value" id="ewv-CT-3vO" customClass="SensorValueCell" customModule="nRF_Mesh" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="438.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ewv-CT-3vO" id="kUc-HY-AEY">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -724,11 +724,11 @@
                                     <outlet property="valueLabel" destination="2me-zg-1ES" id="adi-4B-jpM"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="heartbeatSubscription" rowHeight="117" id="7eN-W8-bl6" customClass="HeartbeatSubscriptionCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="476" width="414" height="117"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="heartbeatSubscription" rowHeight="117" id="7eN-W8-bl6" customClass="HeartbeatSubscriptionCell" customModule="nRF_Mesh" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="482" width="414" height="117"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="7eN-W8-bl6" id="Sv5-p2-DUR">
-                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="117"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383.5" height="117"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ic_flag_24pt" translatesAutoresizingMaskIntoConstraints="NO" id="NZg-b9-D6t">
@@ -736,7 +736,7 @@
                                             <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="749" text="Source" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hcK-RU-q0h">
-                                            <rect key="frame" x="60" y="11" width="317.5" height="40"/>
+                                            <rect key="frame" x="60" y="11" width="315.5" height="40"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="40" id="5Nr-0m-KyS"/>
                                             </constraints>
@@ -745,7 +745,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="To" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ScZ-JV-Cgi">
-                                            <rect key="frame" x="60" y="51" width="317.5" height="14"/>
+                                            <rect key="frame" x="60" y="51" width="315.5" height="14"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
@@ -755,13 +755,13 @@
                                             <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Unknown Group" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="My7-dn-jPO">
-                                            <rect key="frame" x="60" y="71" width="317.5" height="20.5"/>
+                                            <rect key="frame" x="60" y="71" width="315.5" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="0xC003" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aRE-0e-eEj">
-                                            <rect key="frame" x="60" y="91.5" width="317.5" height="14.5"/>
+                                            <rect key="frame" x="60" y="91.5" width="315.5" height="14.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
@@ -797,7 +797,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="action" textLabel="Wih-3i-ZYO" style="IBUITableViewCellStyleDefault" id="Coq-iZ-Cul">
-                                <rect key="frame" x="0.0" y="593" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="599" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Coq-iZ-Cul" id="A6y-Hp-Rsk">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -813,8 +813,8 @@
                                     </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="rightAction" id="Q6u-8W-cen" customClass="RightActionCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="636.5" width="414" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="rightAction" id="Q6u-8W-cen" customClass="RightActionCell" customModule="nRF_Mesh" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="642.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Q6u-8W-cen" id="tVO-gC-OXg">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -841,22 +841,22 @@
                                     <outlet property="rightActionButton" destination="SAT-fQ-1mT" id="gEn-fg-MTI"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="switch" id="ukA-iV-k75" customClass="SwitchCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="680" width="414" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="switch" id="ukA-iV-k75" customClass="SwitchCell" customModule="nRF_Mesh" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="686" width="414" height="43"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ukA-iV-k75" id="q0I-rL-LSs">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P1w-ws-FGk">
-                                            <rect key="frame" x="345" y="6.5" width="51" height="31"/>
+                                            <rect key="frame" x="345" y="6" width="51" height="31"/>
                                             <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                             <connections>
                                                 <action selector="switchDidChange:" destination="ukA-iV-k75" eventType="valueChanged" id="PJe-b6-sbf"/>
                                             </connections>
                                         </switch>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pqx-lg-qPZ">
-                                            <rect key="frame" x="20" y="11" width="33" height="21.5"/>
+                                            <rect key="frame" x="20" y="11" width="33" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -898,14 +898,14 @@
         <!--Network Keys-->
         <scene sceneID="zEH-h7-IDJ">
             <objects>
-                <tableViewController id="LqZ-nU-tB4" customClass="NodeNetworkKeysViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="LqZ-nU-tB4" customClass="NodeNetworkKeysViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="fXj-KT-bpj">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="756"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="752"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="cell" textLabel="eER-lh-FO1" imageView="5cf-Bn-ahg" style="IBUITableViewCellStyleDefault" id="U6F-4M-EjA">
-                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="38" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="U6F-4M-EjA" id="iY3-jw-MX0">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -949,14 +949,14 @@
         <!--Add Network Key-->
         <scene sceneID="nLn-P0-wXh">
             <objects>
-                <tableViewController id="cX5-sm-RrT" customClass="NodeAddNetworkKeyViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="cX5-sm-RrT" customClass="NodeAddNetworkKeyViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="UWR-TN-h4y">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" textLabel="Cc5-FL-aJy" imageView="orq-cS-Lg1" style="IBUITableViewCellStyleDefault" id="2dn-lH-BB6">
-                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="38" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2dn-lH-BB6" id="fQ1-Yt-RnR">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -1005,9 +1005,9 @@
         <!--Device Capabilities-->
         <scene sceneID="YeI-q3-8jR">
             <objects>
-                <tableViewController id="ZgT-Kd-tKj" customClass="ProvisioningViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="ZgT-Kd-tKj" customClass="ProvisioningViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="8UJ-Md-fVn">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <sections>
@@ -1017,7 +1017,7 @@
                                         <rect key="frame" x="0.0" y="18" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Gww-KH-IFf" id="my3-lv-2W1">
-                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="383.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="c7K-fm-78b">
@@ -1028,7 +1028,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="6zU-SL-IBl">
-                                                    <rect key="frame" x="333.5" y="12" width="44" height="20.5"/>
+                                                    <rect key="frame" x="331.5" y="12" width="44" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -1042,10 +1042,10 @@
                             <tableViewSection headerTitle="Provisioning data" id="PXD-VG-fTb">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="sJ7-Xf-3XG" detailTextLabel="iOG-Yh-pyA" style="IBUITableViewCellStyleValue1" id="skW-yF-7H1">
-                                        <rect key="frame" x="0.0" y="111.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="117.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="skW-yF-7H1" id="wb9-d5-HyN">
-                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="383.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Unicast Address" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="sJ7-Xf-3XG">
@@ -1056,7 +1056,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="iOG-Yh-pyA">
-                                                    <rect key="frame" x="333.5" y="12" width="44" height="20.5"/>
+                                                    <rect key="frame" x="331.5" y="12" width="44" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -1066,10 +1066,10 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="tnA-cs-K5w" detailTextLabel="jB2-Ks-5Wg" style="IBUITableViewCellStyleValue1" id="Ndg-0Q-WKP">
-                                        <rect key="frame" x="0.0" y="155" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="161" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ndg-0Q-WKP" id="8aB-K7-Nni">
-                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="383.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Network Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="tnA-cs-K5w">
@@ -1080,7 +1080,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jB2-Ks-5Wg">
-                                                    <rect key="frame" x="333.5" y="12" width="44" height="20.5"/>
+                                                    <rect key="frame" x="331.5" y="12" width="44" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -1097,7 +1097,7 @@
                             <tableViewSection headerTitle="Device Capabilities" id="af4-PB-fZt">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="Oqg-7c-iJ0" detailTextLabel="E9e-8N-Sbw" style="IBUITableViewCellStyleSubtitle" id="X4R-XT-NZP">
-                                        <rect key="frame" x="0.0" y="248.5" width="414" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="260.5" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="X4R-XT-NZP" id="idM-7j-BIS">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -1121,7 +1121,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="BAq-5b-9tR" detailTextLabel="pS5-Y5-QgE" style="IBUITableViewCellStyleSubtitle" id="yy7-AU-JwL">
-                                        <rect key="frame" x="0.0" y="304" width="414" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="316" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yy7-AU-JwL" id="NYW-m7-WPo">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -1145,7 +1145,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="SdP-NS-3LU" detailTextLabel="zDh-JJ-bBg" style="IBUITableViewCellStyleSubtitle" id="eZz-wJ-sSf">
-                                        <rect key="frame" x="0.0" y="359.5" width="414" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="371.5" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eZz-wJ-sSf" id="JU7-kU-7e4">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -1169,14 +1169,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="MAo-QP-eik" detailTextLabel="Qdh-uv-1ef" style="IBUITableViewCellStyleSubtitle" id="zIh-z7-aCQ">
-                                        <rect key="frame" x="0.0" y="415" width="414" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="427" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zIh-z7-aCQ" id="RvA-5b-yC4">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Static OOB Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MAo-QP-eik">
-                                                    <rect key="frame" x="20" y="10" width="126" height="20.5"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="OOB Type" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="MAo-QP-eik">
+                                                    <rect key="frame" x="20" y="10" width="78" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1193,7 +1193,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="eb8-fF-0rX" detailTextLabel="xit-9M-VEk" style="IBUITableViewCellStyleSubtitle" id="yXs-ab-vbS">
-                                        <rect key="frame" x="0.0" y="470.5" width="414" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="482.5" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yXs-ab-vbS" id="21N-Ac-V6X">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -1217,7 +1217,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="UHQ-mH-G4A" detailTextLabel="6SF-mc-Wie" style="IBUITableViewCellStyleSubtitle" id="r10-EK-VFc">
-                                        <rect key="frame" x="0.0" y="526" width="414" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="538" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="r10-EK-VFc" id="K8t-gu-4ze">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -1241,7 +1241,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="FYj-2z-A6L" detailTextLabel="Sef-42-c2U" style="IBUITableViewCellStyleSubtitle" id="cDY-r8-cnx">
-                                        <rect key="frame" x="0.0" y="581.5" width="414" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="593.5" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cDY-r8-cnx" id="zuh-i6-uLf">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -1265,7 +1265,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="3cl-hR-g1F" detailTextLabel="98S-j6-Bn7" style="IBUITableViewCellStyleSubtitle" id="V9Y-Uy-SAb">
-                                        <rect key="frame" x="0.0" y="637" width="414" height="55.5"/>
+                                        <rect key="frame" x="0.0" y="649" width="414" height="55.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="V9Y-Uy-SAb" id="dYF-2R-tkK">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -1311,10 +1311,10 @@
                         <outlet property="nameLabel" destination="6zU-SL-IBl" id="RaQ-2T-wIL"/>
                         <outlet property="networkKeyCell" destination="Ndg-0Q-WKP" id="eoi-0Q-Pg1"/>
                         <outlet property="networkKeyLabel" destination="jB2-Ks-5Wg" id="G06-A9-2iG"/>
+                        <outlet property="oobTypeLabel" destination="Qdh-uv-1ef" id="w7c-di-6ky"/>
                         <outlet property="outputOobSizeLabel" destination="xit-9M-VEk" id="OUn-Oi-aSn"/>
                         <outlet property="provisionButton" destination="QVW-Ct-Tf7" id="Jrn-Ox-fyk"/>
                         <outlet property="publicKeyTypeLabel" destination="zDh-JJ-bBg" id="yeg-Hd-EDU"/>
-                        <outlet property="staticOobTypeLabel" destination="Qdh-uv-1ef" id="Prn-1J-dNf"/>
                         <outlet property="supportedAlgorithmsLabel" destination="pS5-Y5-QgE" id="9fM-jm-2KW"/>
                         <outlet property="supportedInputOobActionsLabel" destination="98S-j6-Bn7" id="816-rf-uLr"/>
                         <outlet property="supportedOutputOobActionsLabel" destination="6SF-mc-Wie" id="bs8-vi-bl3"/>
@@ -1328,14 +1328,14 @@
         <!--Network Key-->
         <scene sceneID="wH7-zW-7Gu">
             <objects>
-                <tableViewController id="R5G-E0-yxI" customClass="NetworkKeySelectionViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="R5G-E0-yxI" customClass="NetworkKeySelectionViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="HdE-8G-m3a">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="subtitleCell" textLabel="UuD-A9-ecN" detailTextLabel="JJO-K5-FWi" imageView="SK2-Gc-j8W" style="IBUITableViewCellStyleSubtitle" id="kUW-jo-TIK">
-                                <rect key="frame" x="0.0" y="32" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="38" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kUW-jo-TIK" id="ZVc-L3-gUW">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -1377,12 +1377,12 @@
         <!--Network-->
         <scene sceneID="ZsB-wW-0YK">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="eYe-6v-26u" customClass="RootViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="eYe-6v-26u" customClass="RootViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Network" image="tab_network_outline_black_24pt" id="WGr-j5-REi"/>
                     <toolbarItems/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" largeTitles="YES" id="HLq-Tv-FRO">
-                        <rect key="frame" x="0.0" y="44" width="414" height="96"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <color key="barTintColor" red="0.0" green="0.66274509803921566" blue="0.80784313725490198" alpha="1" colorSpace="calibratedRGB"/>
@@ -1405,17 +1405,17 @@
         <!--Network-->
         <scene sceneID="BVU-ZG-meK">
             <objects>
-                <tableViewController id="tod-VS-GXt" customClass="NetworkViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="tod-VS-GXt" customClass="NetworkViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="120" estimatedRowHeight="120" sectionHeaderHeight="18" sectionFooterHeight="18" id="01s-7F-LfS">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="804"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="node" rowHeight="120" id="0EL-zf-FEG" customClass="NodeViewCell" customModule="nRFMeshProvision_Example" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="32" width="414" height="120"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="node" rowHeight="120" id="0EL-zf-FEG" customClass="NodeViewCell" customModule="nRF_Mesh" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="38" width="414" height="120"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0EL-zf-FEG" id="1ez-9g-bU1">
-                                    <rect key="frame" x="0.0" y="0.0" width="385.5" height="120"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383.5" height="120"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="mesh-icon" translatesAutoresizingMaskIntoConstraints="NO" id="Txo-PC-sVO">
@@ -1426,7 +1426,7 @@
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Device name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="98E-5m-rAh">
-                                            <rect key="frame" x="84" y="11" width="293.5" height="21"/>
+                                            <rect key="frame" x="84" y="11" width="291.5" height="21"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -1456,13 +1456,13 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="18L-cV-20F">
-                                            <rect key="frame" x="153.5" y="40" width="224" height="16"/>
+                                            <rect key="frame" x="153.5" y="40" width="222" height="16"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fus-yD-CnI">
-                                            <rect key="frame" x="153.5" y="56" width="224" height="16"/>
+                                            <rect key="frame" x="153.5" y="56" width="222" height="16"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="16" id="PMh-X3-P1F"/>
                                             </constraints>
@@ -1471,7 +1471,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="htL-Ix-2vE">
-                                            <rect key="frame" x="153.5" y="72" width="224" height="16"/>
+                                            <rect key="frame" x="153.5" y="72" width="222" height="16"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="16" id="P7c-JG-sJd"/>
                                             </constraints>
@@ -1480,7 +1480,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ukb-VS-Bpo">
-                                            <rect key="frame" x="153.5" y="88" width="224" height="16"/>
+                                            <rect key="frame" x="153.5" y="88" width="222" height="16"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="16" id="uXf-Lr-Pjk"/>
                                             </constraints>
@@ -1581,14 +1581,14 @@
         <!--Application Keys-->
         <scene sceneID="CsG-Ha-Y8Z">
             <objects>
-                <tableViewController id="Sjk-ZU-4jx" customClass="NodeAppKeysViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="Sjk-ZU-4jx" customClass="NodeAppKeysViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="ahW-QQ-MfF">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="756"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="752"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="cell" textLabel="3Fa-PP-psK" detailTextLabel="zTB-JB-wwc" imageView="J4L-Hn-dT8" style="IBUITableViewCellStyleSubtitle" id="Gow-zA-0ZK">
-                                <rect key="frame" x="0.0" y="32" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="38" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Gow-zA-0ZK" id="Pwt-a2-aFR">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -1639,14 +1639,14 @@
         <!--Scenes-->
         <scene sceneID="r7T-YO-qUK">
             <objects>
-                <tableViewController id="iFA-vA-bir" customClass="NodeScenesViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="iFA-vA-bir" customClass="NodeScenesViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="gsL-7F-j2O">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="756"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="752"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="sceneCell" textLabel="SWv-IP-7wd" imageView="dGK-qC-n0P" style="IBUITableViewCellStyleDefault" id="zr5-Ou-dXe">
-                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="38" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zr5-Ou-dXe" id="jsA-VO-KNN">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -1666,7 +1666,7 @@
                                     </subviews>
                                 </tableViewCellContentView>
                                 <connections>
-                                    <segue destination="ug0-BF-sBy" kind="custom" identifier="recall" customClass="DialogSegue" customModule="nRFMeshProvision_Example" customModuleProvider="target" id="L07-86-kjP"/>
+                                    <segue destination="ug0-BF-sBy" kind="custom" identifier="recall" customClass="DialogSegue" customModule="nRF_Mesh" customModuleProvider="target" id="L07-86-kjP"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>
@@ -1690,14 +1690,14 @@
         <!--Add Application Key-->
         <scene sceneID="3PU-26-TxV">
             <objects>
-                <tableViewController id="GDE-7I-UDz" customClass="NodeAddAppKeyViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="GDE-7I-UDz" customClass="NodeAddAppKeyViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="nZN-Qq-nWY">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" textLabel="c6l-QB-tkL" detailTextLabel="xYK-ff-zZ5" imageView="v5K-qu-dhX" style="IBUITableViewCellStyleSubtitle" id="4Lv-n1-Nkc">
-                                <rect key="frame" x="0.0" y="32" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="38" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="4Lv-n1-Nkc" id="DkE-0E-6Pj">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -1753,14 +1753,14 @@
         <!--Store Scene-->
         <scene sceneID="xPn-Hl-uAf">
             <objects>
-                <tableViewController id="isQ-cy-GnG" customClass="NodeStoreSceneViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="isQ-cy-GnG" customClass="NodeStoreSceneViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="2lN-Pp-5Ti">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="sceneCell" textLabel="zCR-XQ-kge" imageView="fEr-9c-k7n" style="IBUITableViewCellStyleDefault" id="29G-HU-a10">
-                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="38" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="29G-HU-a10" id="LwF-Ud-wiq">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -1859,14 +1859,14 @@
         <!--Bind Application Key-->
         <scene sceneID="D1S-lD-UYG">
             <objects>
-                <tableViewController id="aUc-wL-Vs0" customClass="ModelBindAppKeyViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="aUc-wL-Vs0" customClass="ModelBindAppKeyViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="QTV-qB-34R">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="cell" textLabel="asV-mb-ygX" imageView="LzD-OQ-CSA" style="IBUITableViewCellStyleDefault" id="DxK-cQ-ZuD">
-                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="38" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="DxK-cQ-ZuD" id="3lu-9U-GNm">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -1915,14 +1915,14 @@
         <!--Subscribe-->
         <scene sceneID="FHI-sr-Ai4">
             <objects>
-                <tableViewController id="qj8-rY-EMa" customClass="SubscribeViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="qj8-rY-EMa" customClass="SubscribeViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="ZCH-U2-rnQ">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="group" textLabel="qGJ-q6-tac" imageView="2uI-i4-AHX" style="IBUITableViewCellStyleDefault" id="9xQ-3Q-vvq">
-                                <rect key="frame" x="0.0" y="32" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="38" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="9xQ-3Q-vvq" id="33E-IW-2hh">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -1943,7 +1943,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="action" textLabel="IHh-sT-StB" style="IBUITableViewCellStyleDefault" id="Dcg-1z-usk">
-                                <rect key="frame" x="0.0" y="75.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="81.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Dcg-1z-usk" id="Fjf-KM-mdd">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -2087,7 +2087,7 @@
         <!--Scene-->
         <scene sceneID="NiA-Pu-gyJ">
             <objects>
-                <tableViewController id="VlM-PZ-cNw" customClass="NodeSceneRecallViewController" customModule="nRFMeshProvision_Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="VlM-PZ-cNw" customClass="NodeSceneRecallViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="static" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="Kyu-Ke-azo">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -2096,7 +2096,7 @@
                             <tableViewSection id="yiL-Cp-kym">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="switch" rowHeight="70" id="6JR-Pa-8mI">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="70"/>
+                                        <rect key="frame" x="0.0" y="50" width="414" height="70"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="6JR-Pa-8mI" id="Dhc-vd-XmA">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="70"/>
@@ -2126,7 +2126,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="transitionTime" id="IDK-S0-dUM">
-                                        <rect key="frame" x="0.0" y="114.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="120" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="IDK-S0-dUM" id="Dhs-Bg-JpK">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -2158,7 +2158,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="delay" id="1ik-da-nMU">
-                                        <rect key="frame" x="0.0" y="158.5" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="164" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1ik-da-nMU" id="eTZ-fb-EUc">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -2227,7 +2227,7 @@
                 <navigationController id="ug0-BF-sBy" sceneMemberID="viewController">
                     <value key="contentSizeForViewInPopover" type="size" width="0.0" height="220"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="e91-z5-P43">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <textAttributes key="titleTextAttributes">
                             <color key="textColor" red="0.0" green="0.66274509800000003" blue="0.80784313730000001" alpha="1" colorSpace="calibratedRGB"/>
@@ -2259,7 +2259,7 @@
         <image name="rssi_4" width="128" height="128"/>
         <image name="tab_network_outline_black_24pt" width="24" height="24"/>
         <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Example/Source/Utils/UIViewController+Alert.swift
+++ b/Example/Source/Utils/UIViewController+Alert.swift
@@ -44,7 +44,8 @@ extension Selector {
     static let groupAddressRequired = #selector(UIViewController.groupAddressRequired(_:))
     static let scene = #selector(UIViewController.sceneOptional(_:))
     static let sceneRequired = #selector(UIViewController.sceneRequired(_:))
-    static let keyRequired = #selector(UIViewController.keyRequired(_:))
+    static let key16Required = #selector(UIViewController.key16Required(_:))
+    static let key32Required = #selector(UIViewController.key32Required(_:))
     static let publicKeyRequired = #selector(UIViewController.publicKeyRequired(_:))
     static let ttlRequired = #selector(UIViewController.ttlRequired(_:))
     
@@ -234,8 +235,8 @@ extension UIViewController {
                 textField.keyboardType           = .alphabet
                 textField.autocapitalizationType = .allCharacters
                 
-                textField.addTarget(self, action: .keyRequired, for: .editingChanged)
-                textField.addTarget(self, action: .keyRequired, for: .editingDidBegin)
+                textField.addTarget(self, action: .key16Required, for: .editingChanged)
+                textField.addTarget(self, action: .key16Required, for: .editingDidBegin)
             }
             alert!.addAction(UIAlertAction(title: "OK", style: .default) { _ in
                 if let handler = handler,
@@ -393,12 +394,23 @@ extension UIViewController {
         return false
     }
     
-    @objc func keyRequired(_ textField: UITextField) {
+    @objc func key16Required(_ textField: UITextField) {
         let alert = getAlert(from: textField)
         
         if let text = textField.text {
             // A valid key is 16 bytes long (128-bit).
-            alert.setValid(Data(hex: text).count == 16)
+            alert.setValid(text.count == 32 && Data(hex: text).count == 16)
+        } else {
+            alert.setValid(false)
+        }
+    }
+    
+    @objc func key32Required(_ textField: UITextField) {
+        let alert = getAlert(from: textField)
+        
+        if let text = textField.text {
+            // A valid key is 32 bytes long (256-bit).
+            alert.setValid(text.count == 64 && Data(hex: text).count == 32)
         } else {
             alert.setValid(false)
         }
@@ -409,7 +421,7 @@ extension UIViewController {
         
         if let text = textField.text {
             // A valid key is 2 * 32 bytes long.
-            alert.setValid(Data(hex: text).count == 64)
+            alert.setValid(text.count == 128 && Data(hex: text).count == 64)
         } else {
             alert.setValid(false)
         }

--- a/Example/Source/View Controllers/Network/Provisioning/OobSelector.swift
+++ b/Example/Source/View Controllers/Network/Provisioning/OobSelector.swift
@@ -60,10 +60,12 @@ extension OobSelector where Self: UIViewController {
         }
         
         let alert = UIAlertController(title: "Select OOB Type", message: nil, preferredStyle: .actionSheet)
-        alert.addAction(UIAlertAction(title: "No OOB", style: .destructive) { _ in
-            callback(.noOob)
-        })
-        if capabilities.staticOobType.contains(.staticOobInformationAvailable) {
+        if !capabilities.oobType.contains(.onlyOobAuthenticatedProvisioningSupported) {
+            alert.addAction(UIAlertAction(title: "No OOB", style: .destructive) { _ in
+                callback(.noOob)
+            })
+        }
+        if capabilities.oobType.contains(.staticOobInformationAvailable) {
             alert.addAction(UIAlertAction(title: "Static OOB", style: .default) { _ in
                 callback(.staticOob)
             })

--- a/Example/Source/View Controllers/Network/Provisioning/ProvisioningViewController.swift
+++ b/Example/Source/View Controllers/Network/Provisioning/ProvisioningViewController.swift
@@ -275,7 +275,7 @@ private extension ProvisioningViewController {
         // Start provisioning.
         presentStatusDialog(message: "Provisioning...") {
             do {
-                try self.provisioningManager.provision(usingAlgorithm:       .fipsP256EllipticCurve,
+                try self.provisioningManager.provision(usingAlgorithm:       capabilities.algorithms.best,
                                                        publicKey:            self.publicKey!,
                                                        authenticationMethod: self.authenticationMethod!)
             } catch {

--- a/Example/Source/View Controllers/Network/Provisioning/ProvisioningViewController.swift
+++ b/Example/Source/View Controllers/Network/Provisioning/ProvisioningViewController.swift
@@ -45,7 +45,7 @@ class ProvisioningViewController: UITableViewController {
     @IBOutlet weak var elementsCountLabel: UILabel!
     @IBOutlet weak var supportedAlgorithmsLabel: UILabel!
     @IBOutlet weak var publicKeyTypeLabel: UILabel!
-    @IBOutlet weak var staticOobTypeLabel: UILabel!
+    @IBOutlet weak var oobTypeLabel: UILabel!
     @IBOutlet weak var outputOobSizeLabel: UILabel!
     @IBOutlet weak var supportedOutputOobActionsLabel: UILabel!
     @IBOutlet weak var inputOobSizeLabel: UILabel!
@@ -248,11 +248,12 @@ private extension ProvisioningViewController {
         }
         publicKey = publicKey ?? .noOobPublicKey
         
-        // If any of OOB methods is supported, if should be chosen.
-        let staticOobNotSupported = capabilities.staticOobType.isEmpty
-        let outputOobNotSupported = capabilities.outputOobActions.isEmpty
-        let inputOobNotSupported  = capabilities.inputOobActions.isEmpty
-        guard (staticOobNotSupported && outputOobNotSupported && inputOobNotSupported) || authenticationMethod != nil else {
+        // If any of OOB methods is supported, it should be chosen.
+        let staticOobSupported = capabilities.oobType.contains(.staticOobInformationAvailable)
+        let outputOobSupported = !capabilities.outputOobActions.isEmpty
+        let inputOobSupported  = !capabilities.inputOobActions.isEmpty
+        let anyOobSupported = staticOobSupported || outputOobSupported || inputOobSupported
+        guard !anyOobSupported || authenticationMethod != nil else {
             presentOobOptionsDialog(for: provisioningManager, from: provisionButton) { [weak self] method in
                 guard let self = self else { return }
                 self.authenticationMethod = method
@@ -349,7 +350,7 @@ extension ProvisioningViewController: ProvisioningDelegate {
                 self.elementsCountLabel.text = "\(capabilities.numberOfElements)"
                 self.supportedAlgorithmsLabel.text = "\(capabilities.algorithms)"
                 self.publicKeyTypeLabel.text = "\(capabilities.publicKeyType)"
-                self.staticOobTypeLabel.text = "\(capabilities.staticOobType)"
+                self.oobTypeLabel.text = "\(capabilities.oobType)"
                 self.outputOobSizeLabel.text = "\(capabilities.outputOobSize)"
                 self.supportedOutputOobActionsLabel.text = "\(capabilities.outputOobActions)"
                 self.inputOobSizeLabel.text = "\(capabilities.inputOobSize)"

--- a/Example/Source/View Controllers/Network/Provisioning/ProvisioningViewController.swift
+++ b/Example/Source/View Controllers/Network/Provisioning/ProvisioningViewController.swift
@@ -240,7 +240,8 @@ private extension ProvisioningViewController {
         // If the device's Public Key is available OOB, it should be read.
         let publicKeyNotAvailable = capabilities.publicKeyType.isEmpty
         guard publicKeyNotAvailable || publicKey != nil else {
-            presentOobPublicKeyDialog(for: unprovisionedDevice) { publicKey in
+            presentOobPublicKeyDialog(for: unprovisionedDevice) { [weak self] publicKey in
+                guard let self = self else { return }
                 self.publicKey = publicKey
                 self.startProvisioning()
             }
@@ -273,7 +274,8 @@ private extension ProvisioningViewController {
         }
         
         // Start provisioning.
-        presentStatusDialog(message: "Provisioning...") {
+        presentStatusDialog(message: "Provisioning...") { [weak self] in
+            guard let self = self else { return }
             do {
                 try self.provisioningManager.provision(usingAlgorithm:       capabilities.algorithms.best,
                                                        publicKey:            self.publicKey!,

--- a/Example/Source/View Controllers/Network/Provisioning/ProvisioningViewController.swift
+++ b/Example/Source/View Controllers/Network/Provisioning/ProvisioningViewController.swift
@@ -277,7 +277,7 @@ private extension ProvisioningViewController {
         presentStatusDialog(message: "Provisioning...") { [weak self] in
             guard let self = self else { return }
             do {
-                try self.provisioningManager.provision(usingAlgorithm:       capabilities.algorithms.best,
+                try self.provisioningManager.provision(usingAlgorithm:       capabilities.algorithms.strongest,
                                                        publicKey:            self.publicKey!,
                                                        authenticationMethod: self.authenticationMethod!)
             } catch {

--- a/Example/Source/View Controllers/Network/Provisioning/ProvisioningViewController.swift
+++ b/Example/Source/View Controllers/Network/Provisioning/ProvisioningViewController.swift
@@ -412,10 +412,18 @@ extension ProvisioningViewController: ProvisioningDelegate {
     func authenticationActionRequired(_ action: AuthAction) {
         switch action {
         case let .provideStaticKey(callback: callback):
+            guard let capabilities = provisioningManager.provisioningCapabilities else {
+                return
+            }
+            let algorithm = capabilities.algorithms.strongest
+            
             self.dismissStatusDialog {
-                let message = "Enter 16-character hexadecimal string."
+                let requiredSize = algorithm == .BTM_ECDH_P256_HMAC_SHA256_AES_CCM ? 32 : 16
+                let type: Selector = algorithm == .BTM_ECDH_P256_HMAC_SHA256_AES_CCM ? .key32Required : .key16Required
+                
+                let message = "Enter \(requiredSize)-character hexadecimal string."
                 self.presentTextAlert(title: "Static OOB Key", message: message,
-                                      type: .keyRequired, cancelHandler: nil) { hex in
+                                      type: type, cancelHandler: nil) { hex in
                     callback(Data(hex: hex))
                 }
             }

--- a/Example/Source/View Controllers/Network/Provisioning/ProvisioningViewController.swift
+++ b/Example/Source/View Controllers/Network/Provisioning/ProvisioningViewController.swift
@@ -350,14 +350,17 @@ extension ProvisioningViewController: ProvisioningDelegate {
                 
             case .capabilitiesReceived(let capabilities):
                 self.elementsCountLabel.text = "\(capabilities.numberOfElements)"
-                self.supportedAlgorithmsLabel.text = "\(capabilities.algorithms)"
+                self.supportedAlgorithmsLabel.text = "\(capabilities.algorithms)".toLines
                 self.publicKeyTypeLabel.text = "\(capabilities.publicKeyType)"
-                self.oobTypeLabel.text = "\(capabilities.oobType)"
+                self.oobTypeLabel.text = "\(capabilities.oobType)".toLines
                 self.outputOobSizeLabel.text = "\(capabilities.outputOobSize)"
                 self.supportedOutputOobActionsLabel.text = "\(capabilities.outputOobActions)"
                 self.inputOobSizeLabel.text = "\(capabilities.inputOobSize)"
                 self.supportedInputOobActionsLabel.text = "\(capabilities.inputOobActions)"
                 
+                // This is needed to refresh constraints after filling new values.
+                self.tableView.reloadData()
+    		            
                 // If the Unicast Address was set to automatic (nil), it should be
                 // set to the correct value by now, as we know the number of elements.
                 let addressValid = self.provisioningManager.isUnicastAddressValid == true
@@ -476,6 +479,18 @@ private extension IndexPath {
     /// Returns whether the IndexPath point to the Unicast Address settings.
     var isUnicastAddress: Bool {
         return section == 1 && row == 0
+    }
+    
+}
+
+private extension String {
+    
+    // Replaces ", " to new line.
+    //
+    // The `debugDescription` in the library returns values separated
+    // with commas.
+    var toLines: String {
+        return replacingOccurrences(of: ", ", with: "\n")
     }
     
 }

--- a/Example/Tests/CryptoTest.swift
+++ b/Example/Tests/CryptoTest.swift
@@ -38,9 +38,11 @@ class CryptoTest: XCTestCase {
     let label    = UUID(uuidString: "12345678-1234-1234-1234-12345678ABCD")!
 
     func testRandom() throws {
-        let random = Crypto.generateRandom()
+        let random_16 = Crypto.generateRandom(sizeInBits: 128)
+        XCTAssertEqual(random_16.count, 16)
         
-        XCTAssertEqual(random.count, 16)
+        let random_32 = Crypto.generateRandom(sizeInBits: 256)
+        XCTAssertEqual(random_32.count, 32)
     }
 
     func testVirtualLabel() throws {
@@ -164,6 +166,168 @@ class CryptoTest: XCTestCase {
         
         let k4 = Crypto.calculateAid(from: key)
         XCTAssertEqual(k4, expectedAID)
+    }
+    
+    // Test based on Provisioning Sample Data 8.17.1 and 8.17.2 from Mesh Profile 1.1.
+    func testCalculatingSharedSecret() throws {
+        // Received Public Key (X + Y)
+        let provisionerPublicKey = Data(hex: "2c31a47b5779809ef44cb5eaaf5c3e43d5f8faad4a8794cb987e9b03745c78dd919512183898dfbecd52e2408e43871fd021109117bd3ed4eaf8437743715d4f")
+        // Known Private and Public Keys
+        let provisioneePublicKey = Data(hex: "f465e43ff23d3f1b9dc7dfc04da8758184dbc966204796eccf0d6cf5e16500cc0201d048bcbbd899eeefc424164e33c201c2b010ca6b4d43a8a155cad8ecb279")
+        let provisioneePrivateKey = Data(hex: "529aa0670d72cd6497502ed473502b037e8803b5c60829a5a3caa219505530ba")
+        
+        // Convert Provisionee Private key from Data to SecKey.
+        let parameters = [kSecAttrKeyType : kSecAttrKeyTypeECSECPrimeRandom,
+                    kSecAttrKeySizeInBits : 256,
+                          kSecAttrKeyClass: kSecAttrKeyClassPrivate] as CFDictionary
+        
+        var error: Unmanaged<CFError>?
+        let secKey = SecKeyCreateWithData(Data([0x04]) + provisioneePublicKey + provisioneePrivateKey as CFData, parameters, &error)
+        XCTAssertNil(error)
+        guard error == nil else {
+            throw error!.takeRetainedValue()
+        }
+        
+        // Calculate the Shared Secret using Provisionee Private Key and Provisioner Public Key.
+        let secret = try Crypto.calculateSharedSecret(privateKey: secKey!, publicKey: provisionerPublicKey)
+        
+        // Verify the Shared Secret.
+        let expectedSecret = Data(hex: "ab85843a2f6d883f62e5684b38e307335fe6e1945ecd19604105c6f23221eb69")
+        XCTAssertEqual(secret, expectedSecret)
+    }
+    
+    // Test based on Provisioning Sample Data 8.17.1 from Mesh Profile 1.1.
+    func testCalculatingConfirmationValuesUsingCMAC_AES128() throws {
+        // Data required to for ConfirmationInputs.
+        let provisioningInvite = Data(hex: "00")
+        let provisioningCapabilities = Data(hex: "0100010000000000000000")
+        let provisioningStart = Data(hex: "0000000000")
+        let provisionerPublicKey = Data(hex: "2c31a47b5779809ef44cb5eaaf5c3e43d5f8faad4a8794cb987e9b03745c78dd919512183898dfbecd52e2408e43871fd021109117bd3ed4eaf8437743715d4f")
+        let provisioneePublicKey = Data(hex: "f465e43ff23d3f1b9dc7dfc04da8758184dbc966204796eccf0d6cf5e16500cc0201d048bcbbd899eeefc424164e33c201c2b010ca6b4d43a8a155cad8ecb279")
+        
+        // Create Confirmation Inputs.
+        let confirmationInputs = provisioningInvite + provisioningCapabilities + provisioningStart + provisionerPublicKey + provisioneePublicKey
+        
+        // AuthValue is `.noOob`.
+        let authValue = Data(hex: "00000000000000000000000000000000")
+        // Shared Secret calculated using the method tested in the previous test.
+        let sharedSecret = Data(hex: "ab85843a2f6d883f62e5684b38e307335fe6e1945ecd19604105c6f23221eb69")
+        
+        // Calculate Provisioner Confirmation.
+        let provisionerRandom = Data(hex: "8b19ac31d58b124c946209b5db1021b9")
+        let confirmationProvisioner = Crypto.calculateConfirmation(confirmationInputs: confirmationInputs,
+                                                        sharedSecret: sharedSecret,
+                                                        random: provisionerRandom, authValue: authValue,
+                                                        using: .BTM_ECDH_P256_CMAC_AES128_AES_CCM)
+        
+        let expectedConfirmationProvisioner = Data(hex: "b38a114dfdca1fe153bd2c1e0dc46ac2")
+        XCTAssertEqual(confirmationProvisioner, expectedConfirmationProvisioner, "Received: \(confirmationProvisioner.hex)")
+        
+        // Calculate Device Confirmation.
+        let provisioneeRandom = Data(hex: "55a2a2bca04cd32ff6f346bd0a0c1a3a")
+        let confirmationDevice = Crypto.calculateConfirmation(confirmationInputs: confirmationInputs,
+                                                        sharedSecret: sharedSecret,
+                                                        random: provisioneeRandom, authValue: authValue,
+                                                        using: .BTM_ECDH_P256_CMAC_AES128_AES_CCM)
+        
+        let expectedConfirmationDevice = Data(hex: "eeba521c196b52cc2e37aa40329f554e")
+        XCTAssertEqual(confirmationDevice, expectedConfirmationDevice, "Received: \(confirmationDevice.hex)")
+    }
+    
+    // Test based on Provisioning Sample Data 8.17.2 from Mesh Profile 1.1.
+    func testCalculatingConfirmationValuesUsingHMAC_SHA256() throws {
+        // Data required to for ConfirmationInputs.
+        let provisioningInvite = Data(hex: "00")
+        let provisioningCapabilities = Data(hex: "0100030001000000000000")
+        let provisioningStart = Data(hex: "0100010000")
+        let provisionerPublicKey = Data(hex: "2c31a47b5779809ef44cb5eaaf5c3e43d5f8faad4a8794cb987e9b03745c78dd919512183898dfbecd52e2408e43871fd021109117bd3ed4eaf8437743715d4f")
+        let provisioneePublicKey = Data(hex: "f465e43ff23d3f1b9dc7dfc04da8758184dbc966204796eccf0d6cf5e16500cc0201d048bcbbd899eeefc424164e33c201c2b010ca6b4d43a8a155cad8ecb279")
+        
+        // Create Confirmation Inputs.
+        let confirmationInputs = provisioningInvite + provisioningCapabilities + provisioningStart + provisionerPublicKey + provisioneePublicKey
+        
+        // AuthValue is 32-byte Static OOB.
+        let authValue = Data(hex: "906d73a3c7a7cb3ff730dca68a46b9c18d673f50e078202311473ebbe253669f")
+        // Shared Secret calculated using the method tested in the previous test.
+        let sharedSecret = Data(hex: "ab85843a2f6d883f62e5684b38e307335fe6e1945ecd19604105c6f23221eb69")
+        
+        // Calculate Provisioner Confirmation.
+        let provisionerRandom = Data(hex: "36f968b94a13000e64b223576390db6bcc6d62f02617c369ee3f5b3e89df7e1f")
+        let confirmationProvisioner = Crypto.calculateConfirmation(confirmationInputs: confirmationInputs,
+                                                        sharedSecret: sharedSecret,
+                                                        random: provisionerRandom, authValue: authValue,
+                                                        using: .BTM_ECDH_P256_HMAC_SHA256_AES_CCM)
+        
+        let expectedConfirmationProvisioner = Data(hex: "c99b54617ae646f5f32cf7e1ea6fcc49fd69066078eba9580fa6c7031833e6c8")
+        XCTAssertEqual(confirmationProvisioner, expectedConfirmationProvisioner)
+        
+        // Calculate Device Confirmation.
+        let provisioneeRandom = Data(hex: "5b9b1fc6a64b2de8bece53187ee989c6566db1fc7dc8580a73dafdd6211d56a5")
+        let confirmationDevice = Crypto.calculateConfirmation(confirmationInputs: confirmationInputs,
+                                                        sharedSecret: sharedSecret,
+                                                        random: provisioneeRandom, authValue: authValue,
+                                                        using: .BTM_ECDH_P256_HMAC_SHA256_AES_CCM)
+        
+        let expectedConfirmationDevice = Data(hex: "56e3722d291373d38c995d6f942c02928c96abb015c233557d7974b6e2df662b")
+        XCTAssertEqual(confirmationDevice, expectedConfirmationDevice)
+    }
+    
+    // Test based on Provisioning Sample Data 8.17.2 from Mesh Profile 1.1.
+    func testCalculatingKeys() throws {
+        // Data required to for ConfirmationInputs.
+        let provisioningInvite = Data(hex: "00")
+        let provisioningCapabilities = Data(hex: "0100030001000000000000")
+        let provisioningStart = Data(hex: "0100010000")
+        let provisionerPublicKey = Data(hex: "2c31a47b5779809ef44cb5eaaf5c3e43d5f8faad4a8794cb987e9b03745c78dd919512183898dfbecd52e2408e43871fd021109117bd3ed4eaf8437743715d4f")
+        let provisioneePublicKey = Data(hex: "f465e43ff23d3f1b9dc7dfc04da8758184dbc966204796eccf0d6cf5e16500cc0201d048bcbbd899eeefc424164e33c201c2b010ca6b4d43a8a155cad8ecb279")
+        
+        // Create Confirmation Inputs.
+        let confirmationInputs = provisioningInvite + provisioningCapabilities + provisioningStart + provisionerPublicKey + provisioneePublicKey
+        
+        // Shared Secret calculated using the method tested in the previous test.
+        let sharedSecret = Data(hex: "ab85843a2f6d883f62e5684b38e307335fe6e1945ecd19604105c6f23221eb69")
+        
+        // Random Values.
+        let provisionerRandom = Data(hex: "36f968b94a13000e64b223576390db6bcc6d62f02617c369ee3f5b3e89df7e1f")
+        let provisioneeRandom = Data(hex: "5b9b1fc6a64b2de8bece53187ee989c6566db1fc7dc8580a73dafdd6211d56a5")
+        
+        // Calculate keys.
+        let keys = Crypto.calculateKeys(confirmationInputs: confirmationInputs,
+                                        sharedSecret: sharedSecret,
+                                        provisionerRandom: provisionerRandom,
+                                        deviceRandom: provisioneeRandom,
+                                        using: .BTM_ECDH_P256_HMAC_SHA256_AES_CCM)
+        
+        let expectedDeviceKey = Data(hex: "2770852a737cf05d8813768f22af3a2d")
+        XCTAssertEqual(keys.deviceKey, expectedDeviceKey)
+        
+        let expectedSessionKey = Data(hex: "df4a494da3d45405e402f1d6a6cea338")
+        XCTAssertEqual(keys.sessionKey, expectedSessionKey)
+        
+        let expectedSessionNonce = Data(hex: "11b987db2ae41fbb9e96b80446")
+        XCTAssertEqual(keys.sessionNonce, expectedSessionNonce)
+    }
+    
+    // Test based on Provisioning Sample Data 8.17.2 from Mesh Profile 1.1.
+    func testEncryptingKeys() throws {
+        let flags = Data(hex: "00")
+        let ivIndex: UInt32 = 0x01020304
+        let key = Data(hex: "efb2255e6422d330088e09bb015ed707")
+        let index: KeyIndex = 0x0567
+        let sessionNonce = Data(hex: "11b987db2ae41fbb9e96b80446")
+        let unicastAddress: Address = 0x0b0c
+        let sessionKey = Data(hex: "df4a494da3d45405e402f1d6a6cea338")
+        
+        // Combined data.
+        let data = key + index.bigEndian + flags + ivIndex.bigEndian + unicastAddress.bigEndian
+        
+        // Encrypt data using the session key and nonce.
+        let encryptedData = Crypto.encrypt(provisioningData: data,
+                                           usingSessionKey: sessionKey, andNonce: sessionNonce)
+        
+        let expectedEncryptedData = Data(hex: "f9df98cbb736be1f600659ac4c37821a82db31e410a03de769")
+        let expectedMIC = Data(hex: "3a2a0428fbdaf321")
+        XCTAssertEqual(encryptedData, expectedEncryptedData + expectedMIC)
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Model/NetworkKey.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/NetworkKey.swift
@@ -154,7 +154,7 @@ public class NetworkKey: Key, Codable {
     
     /// Creates the primary Network Key for a mesh network.
     internal convenience init() {
-        try! self.init(name: "Primary Network Key", index: 0, key: Crypto.generateRandom())
+        try! self.init(name: "Primary Network Key", index: 0, key: Data.random128BitKey())
     }
     
     private func regenerateKeyDerivatives() {

--- a/nRFMeshProvision/Classes/Provisioning/Algorithm.swift
+++ b/nRFMeshProvision/Classes/Provisioning/Algorithm.swift
@@ -36,12 +36,12 @@ public enum Algorithm {
     /// shared secret.
     ///
     /// This has been replaced with ``Algorithm/BTM_ECDH_P256_CMAC_AES128_AES_CCM``.
-    @available(*, renamed: "BTM_ECDH_P256_CMAC_AES128_AES_CCM")
+    @available(*, deprecated, renamed: "BTM_ECDH_P256_CMAC_AES128_AES_CCM")
     case fipsP256EllipticCurve
-    /// BTM ECDH P256_CMAC_AES128_AES_CCM algorithm will be used to calculate the
+    /// BTM ECDH P256 CMAC AES128 AES CCM algorithm will be used to calculate the
     /// shared secret.
     case BTM_ECDH_P256_CMAC_AES128_AES_CCM
-    /// BTM ECDH BTM_ECDH_P256_HMAC_SHA256_AES_CCM algorithm will be used to calculate the
+    /// BTM ECDH P256 HMAC SHA256 AES CCM algorithm will be used to calculate the
     /// shared secret.
     ///
     /// This algorithm must be supported by devices claming support with Mesh Protocol 1.1.
@@ -79,7 +79,7 @@ public struct Algorithms: OptionSet {
     public let rawValue: UInt16
     
     /// BTM_ECDH_P256_CMAC_AES128_AES_CCM algorithm is supported.
-    @available(*, renamed: "BTM_ECDH_P256_CMAC_AES128_AES_CCM")
+    @available(*, deprecated, renamed: "BTM_ECDH_P256_CMAC_AES128_AES_CCM")
     public static let fipsP256EllipticCurve = Algorithms(rawValue: 1 << 0)
     /// BTM_ECDH_P256_CMAC_AES128_AES_CCM algorithm is supported.
     public static let BTM_ECDH_P256_CMAC_AES128_AES_CCM = Algorithms(rawValue: 1 << 0)

--- a/nRFMeshProvision/Classes/Provisioning/Algorithm.swift
+++ b/nRFMeshProvision/Classes/Provisioning/Algorithm.swift
@@ -91,7 +91,7 @@ public struct Algorithms: OptionSet {
     }
     
     /// Returns the strongest provisioning algorithm supported by the device.
-    public var best: Algorithm {
+    public var strongest: Algorithm {
         if contains(.BTM_ECDH_P256_HMAC_SHA256_AES_CCM) {
             return .BTM_ECDH_P256_HMAC_SHA256_AES_CCM
         }

--- a/nRFMeshProvision/Classes/Provisioning/Algorithm.swift
+++ b/nRFMeshProvision/Classes/Provisioning/Algorithm.swift
@@ -34,11 +34,28 @@ import Foundation
 public enum Algorithm {
     /// FIPS P-256 Elliptic Curve algorithm will be used to calculate the
     /// shared secret.
+    ///
+    /// This has been replaced with ``Algorithm/BTM_ECDH_P256_CMAC_AES128_AES_CCM``.
+    @available(*, renamed: "BTM_ECDH_P256_CMAC_AES128_AES_CCM")
     case fipsP256EllipticCurve
+    /// BTM ECDH P256_CMAC_AES128_AES_CCM algorithm will be used to calculate the
+    /// shared secret.
+    case BTM_ECDH_P256_CMAC_AES128_AES_CCM
+    /// BTM ECDH BTM_ECDH_P256_HMAC_SHA256_AES_CCM algorithm will be used to calculate the
+    /// shared secret.
+    ///
+    /// This algorithm must be supported by devices claming support with Mesh Protocol 1.1.
+    ///
+    /// - since: Mesh Protocol 1.1.
+    case BTM_ECDH_P256_HMAC_SHA256_AES_CCM
     
     var value: Data {
         switch self {
-        case .fipsP256EllipticCurve: return Data([0])
+        case .fipsP256EllipticCurve,
+             .BTM_ECDH_P256_CMAC_AES128_AES_CCM:
+            return Data([0])
+        case .BTM_ECDH_P256_HMAC_SHA256_AES_CCM:
+            return Data([1])
         }
     }
 }
@@ -47,8 +64,11 @@ extension Algorithm: CustomDebugStringConvertible {
     
     public var debugDescription: String {
         switch self {
-        case .fipsP256EllipticCurve:
-            return "FIPS P-256 Elliptic Curve"
+        case .fipsP256EllipticCurve,
+             .BTM_ECDH_P256_CMAC_AES128_AES_CCM:
+            return "BTM ECDH P256 CMAC AES128 AES CCM"
+        case .BTM_ECDH_P256_HMAC_SHA256_AES_CCM:
+            return "BTM ECDH P256 HMAC SHA256 AES CCM"
         }
     }
     
@@ -58,13 +78,25 @@ extension Algorithm: CustomDebugStringConvertible {
 public struct Algorithms: OptionSet {
     public let rawValue: UInt16
     
-    /// FIPS P-256 Elliptic Curve algorithm is supported.
+    /// BTM_ECDH_P256_CMAC_AES128_AES_CCM algorithm is supported.
+    @available(*, renamed: "BTM_ECDH_P256_CMAC_AES128_AES_CCM")
     public static let fipsP256EllipticCurve = Algorithms(rawValue: 1 << 0)
+    /// BTM_ECDH_P256_CMAC_AES128_AES_CCM algorithm is supported.
+    public static let BTM_ECDH_P256_CMAC_AES128_AES_CCM = Algorithms(rawValue: 1 << 0)
+    /// BTM_ECDH_P256_HMAC_SHA256_AES_CCM algorithm is supported.
+    public static let BTM_ECDH_P256_HMAC_SHA256_AES_CCM = Algorithms(rawValue: 1 << 1)
     
     public init(rawValue: UInt16) {
         self.rawValue = rawValue
     }
     
+    /// Returns the strongest provisioning algorithm supported by the device.
+    public var best: Algorithm {
+        if contains(.BTM_ECDH_P256_HMAC_SHA256_AES_CCM) {
+            return .BTM_ECDH_P256_HMAC_SHA256_AES_CCM
+        }
+        return .BTM_ECDH_P256_CMAC_AES128_AES_CCM
+    }
 }
 
 extension Algorithms: CustomDebugStringConvertible {
@@ -73,7 +105,10 @@ extension Algorithms: CustomDebugStringConvertible {
         if rawValue == 0 {
             return "None"
         }
-        return [(.fipsP256EllipticCurve, "FIPS P-256 Elliptic Curve")]
+        return [
+            (.BTM_ECDH_P256_CMAC_AES128_AES_CCM, "BTM ECDH P256 CMAC AES128 AES CCM"),
+            (.BTM_ECDH_P256_HMAC_SHA256_AES_CCM, "BTM ECDH P256 HMAC SHA256 AES CCM")
+            ]
             .compactMap { (option, name) in contains(option) ? name : nil }
             .joined(separator: ", ")
     }

--- a/nRFMeshProvision/Classes/Provisioning/Algorithm.swift
+++ b/nRFMeshProvision/Classes/Provisioning/Algorithm.swift
@@ -58,6 +58,16 @@ public enum Algorithm {
             return Data([1])
         }
     }
+    
+    var length: Int {
+        switch self {
+        case .fipsP256EllipticCurve,
+             .BTM_ECDH_P256_CMAC_AES128_AES_CCM:
+            return 128
+        case .BTM_ECDH_P256_HMAC_SHA256_AES_CCM:
+            return 256
+        }
+    }
 }
 
 extension Algorithm: CustomDebugStringConvertible {

--- a/nRFMeshProvision/Classes/Provisioning/Oob.swift
+++ b/nRFMeshProvision/Classes/Provisioning/Oob.swift
@@ -132,12 +132,16 @@ open class InputActionValueGenerator {
     }
 }
 
-/// A set of supported Static Out-Of-Band types.
-public struct StaticOobType: OptionSet {
+/// A set of supported Out-Of-Band types.
+public struct OobType: OptionSet {
     public let rawValue: UInt8
     
     /// Static OOB Information is available.
-    public static let staticOobInformationAvailable = StaticOobType(rawValue: 1 << 0)
+    public static let staticOobInformationAvailable = OobType(rawValue: 1 << 0)
+    /// Only OOB authenticated provisioning supported.
+    ///
+    /// - since: Mesh Protocol 1.1.
+    public static let onlyOobAuthenticatedProvisioningSupported = OobType(rawValue: 1 << 1)
     
     public init(rawValue: UInt8) {
         self.rawValue = rawValue
@@ -244,14 +248,17 @@ extension InputAction: CustomDebugStringConvertible {
     
 }
 
-extension StaticOobType: CustomDebugStringConvertible {
+extension OobType: CustomDebugStringConvertible {
     
     public var debugDescription: String {
         if rawValue == 0 {
             return "None"
         }
-        return [(.staticOobInformationAvailable, "Static OOB Information Available")]
-            .compactMap { (option, name) in contains(option) ? name : nil }
+        return [
+            (.staticOobInformationAvailable, "Static OOB Information Available"),
+            (.onlyOobAuthenticatedProvisioningSupported, "Only OOB Authenticated Provisioning Supported")
+            ]
+            .compactMap { option, name in contains(option) ? name : nil }
             .joined(separator: ", ")
     }
     

--- a/nRFMeshProvision/Classes/Provisioning/ProvisioningCapabilities.swift
+++ b/nRFMeshProvision/Classes/Provisioning/ProvisioningCapabilities.swift
@@ -40,7 +40,7 @@ public struct ProvisioningCapabilities {
     /// Supported public key types.
     public let publicKeyType:    PublicKeyType
     /// Supported static OOB Types.
-    public let staticOobType:    StaticOobType
+    public let oobType:          OobType
     /// Maximum size of Output OOB supported.
     public let outputOobSize:    UInt8
     /// Supported Output OOB Actions.
@@ -57,7 +57,7 @@ public struct ProvisioningCapabilities {
         numberOfElements = data.read(fromOffset: 1)
         algorithms       = Algorithms(data: data, offset: 2)
         publicKeyType    = PublicKeyType(data: data, offset: 4)
-        staticOobType    = StaticOobType(data: data, offset: 5)
+        oobType          = OobType(data: data, offset: 5)
         outputOobSize    = data.read(fromOffset: 6)
         outputOobActions = OutputOobActions(data: data, offset: 7)
         inputOobSize     = data.read(fromOffset: 9)
@@ -72,7 +72,7 @@ extension ProvisioningCapabilities: CustomDebugStringConvertible {
         Number of elements: \(numberOfElements)
         Algorithms: \(algorithms)
         Public Key Type: \(publicKeyType)
-        Static OOB Type: \(staticOobType)
+        OOB Type: \(oobType)
         Output OOB Size: \(outputOobSize)
         Output OOB Actions: \(outputOobActions)
         Input OOB Size: \(inputOobSize)

--- a/nRFMeshProvision/Classes/Provisioning/ProvisioningPdu.swift
+++ b/nRFMeshProvision/Classes/Provisioning/ProvisioningPdu.swift
@@ -149,7 +149,7 @@ internal struct ProvisioningResponse {
         }
     }
     
-    var isValid: Bool {
+    func isValid(forAlgorithm algorithm: Algorithm?) -> Bool {
         switch type {
         case .capabilities:
             return capabilities != nil
@@ -158,9 +158,13 @@ internal struct ProvisioningResponse {
         case .inputComplete, .complete:
             return true
         case .confirmation:
-            return confirmation != nil && confirmation!.count == 16
+            guard let algorithm = algorithm else { return false }
+            let sizeInBytes = algorithm.length >> 3
+            return confirmation != nil && confirmation!.count == sizeInBytes
         case .random:
-            return random != nil && random!.count == 16
+            guard let algorithm = algorithm else { return false }
+            let sizeInBytes = algorithm.length >> 3
+            return random != nil && random!.count == sizeInBytes
         case .failed:
             return error != nil
         default:
@@ -211,7 +215,8 @@ extension ProvisioningRequest: CustomDebugStringConvertible {
 extension ProvisioningResponse: CustomDebugStringConvertible {
     
     var debugDescription: String {
-        guard isValid else {
+        guard isValid(forAlgorithm: .BTM_ECDH_P256_CMAC_AES128_AES_CCM) ||
+              isValid(forAlgorithm: .BTM_ECDH_P256_HMAC_SHA256_AES_CCM) else {
             return "Invalid response of type: \(type)"
         }
         switch type {

--- a/nRFMeshProvision/Classes/Provisioning/ProvisioningState.swift
+++ b/nRFMeshProvision/Classes/Provisioning/ProvisioningState.swift
@@ -98,6 +98,9 @@ public enum RemoteProvisioningError: UInt8 {
     case unexpectedError = 7
     /// The device cannot assign consecutive unicast addresses to all elements.
     case cannotAssignAddresses = 8
+    /// The Data block contains values that cannot be accepted because of
+    /// general constraints.
+    case invalidData = 9
 }
 
 /// A set of authentication actions aiming to strengthen device provisioniong
@@ -164,16 +167,7 @@ extension ProvisioningError: LocalizedError {
         case .confirmationFailed:
             return NSLocalizedString("Confirmation failed", comment: "provisioning")
         case let .remoteError(error):
-            switch error {
-            case .invalidPdu:              return NSLocalizedString("Invalid PDU", comment: "provisioning")
-            case .invalidFormat:           return NSLocalizedString("Invalid format", comment: "provisioning")
-            case .unexpectedPdu:           return NSLocalizedString("Unexpected PDU", comment: "provisioning")
-            case .confirmationFailed:      return NSLocalizedString("Confirmation failed", comment: "provisioning")
-            case .outOfResources:          return NSLocalizedString("Out of resources", comment: "provisioning")
-            case .decryptionFailed:        return NSLocalizedString("Decryption failed", comment: "provisioning")
-            case .unexpectedError:         return NSLocalizedString("Unexpected error", comment: "provisioning")
-            case .cannotAssignAddresses:  return NSLocalizedString("Cannot assign addresses", comment: "provisioning")
-            }
+            return NSLocalizedString(error.debugDescription, comment: "provisioning")
         case let .keyGenerationFailed(status):
             return NSLocalizedString("Key generation failed with status \(status)", comment: "provisioning")
         }
@@ -201,6 +195,8 @@ extension RemoteProvisioningError: CustomDebugStringConvertible {
             return "Unexpected error"
         case .cannotAssignAddresses:
             return "Cannot assign addresses"
+        case .invalidData:
+            return "Invalid data"
         }
     }
     

--- a/nRFMeshProvision/Classes/Type Extensions/Data+Keys.swift
+++ b/nRFMeshProvision/Classes/Type Extensions/Data+Keys.swift
@@ -34,7 +34,12 @@ public extension Data {
     
     /// Returns a random 128-bit long key.
     static func random128BitKey() -> Data {
-        return Crypto.generateRandom()
+        return Crypto.generateRandom(sizeInBits: 128)
+    }
+    
+    /// Returns a random 256-bit long key.
+    static func random256BitKey() -> Data {
+        return Crypto.generateRandom(sizeInBits: 256)
     }
     
 }


### PR DESCRIPTION
This PR adds support for new features added in [Mesh Protocol 1.1](https://www.bluetooth.com/specifications/specs/mesh-protocol-1-1/).

## Completed
- [x] New provisioning algorithm: HMAC SHA 256 ed0259cd128110e6f6bc4b66c27de337176ef6a5
- [x] New provisioning error: invalid data 64c354de7e4ad99e1d8fbca9d0242b759cd35473

## Remaining (not in scope of this PR)
- [ ] Remote provisioning
- [ ] Certificate-based provisioning
- [ ] Private beacons
- [ ] I don't know what else

## Breaking changes:
- Enum `StaticOobType` was renamed to `OobType` with new value added.
- Algorithm `.fipsP256EllipticCurve` was deprecated and renamed to `.BTM_ECDH_P256_CMAC_AES128_AES_CCM`.
- The length of Static OOB Key for the new algorithm is 32 bytes, not 16 like for the legacy one.