### PR TITLE
Support for Mesh 1.1 (Part 2: Private beacons)

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		5204D26757066D8C6B6C6696A07DF5DE /* MeshNodeEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C761AB3A924F8FA31079749C9DD606C /* MeshNodeEntry.swift */; };
 		5298C00B6C7DA3382FA31FB3B0EF2826 /* PKCS5.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6529BEEF734D4D9F2920046F56965C4 /* PKCS5.swift */; };
 		52C1CE59297EAD310024DB92 /* PrivateBeacon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C1CE58297EAD310024DB92 /* PrivateBeacon.swift */; };
+		52C1CE5B298000720024DB92 /* NetworkBeaconPdu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C1CE5A298000720024DB92 /* NetworkBeaconPdu.swift */; };
 		5338E50DC8D7B6977F90D5375B7A82D1 /* ConfigNodeResetStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32019C109C91B2F3A7C7820712D2A348 /* ConfigNodeResetStatus.swift */; };
 		535FA970A49C4AC40847416AD23D6C0E /* SensorDescriptorStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC5FEC3B624A649D72085D0F629E364 /* SensorDescriptorStatus.swift */; };
 		54C7B0CFF20B468743131E1077152526 /* RemoveAddressesFromFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CCB373620F516C453F665485B9B72E /* RemoveAddressesFromFilter.swift */; };
@@ -709,6 +710,7 @@
 		51B542A657751A6647ED0C2B1E331F3F /* ConfigVendorModelAppList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigVendorModelAppList.swift; sourceTree = "<group>"; };
 		52C0F063AB492BB2D1FE84FCAE53164D /* LightCTLTemperatureRangeSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightCTLTemperatureRangeSet.swift; sourceTree = "<group>"; };
 		52C1CE58297EAD310024DB92 /* PrivateBeacon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateBeacon.swift; sourceTree = "<group>"; };
+		52C1CE5A298000720024DB92 /* NetworkBeaconPdu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkBeaconPdu.swift; sourceTree = "<group>"; };
 		52E161FE177AF095BA55247B132B8C2D /* Oob.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Oob.swift; sourceTree = "<group>"; };
 		5309874A90AA23CE4DBDB5BE48808F97 /* CompositionElement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CompositionElement.swift; sourceTree = "<group>"; };
 		5427BFDA8338A7437D8154638B5B99DD /* LightCTLTemperatureRangeStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightCTLTemperatureRangeStatus.swift; sourceTree = "<group>"; };
@@ -1901,9 +1903,10 @@
 				63DAAED4125D5ECC3038006DA7CB1606 /* BeaconPdu.swift */,
 				F1B92E125B44E1EBDBC14DC54EC22AF5 /* NetworkLayer.swift */,
 				E463522203E906B7BEDE0DBF8F6663D7 /* NetworkPdu.swift */,
+				52C1CE5A298000720024DB92 /* NetworkBeaconPdu.swift */,
 				B57552A55608AF68809C8A77EF370E55 /* SecureNetworkBeacon.swift */,
-				95840766EF5C4A1C78F17FF11AECDDE7 /* UnprovisionedDeviceBeacon.swift */,
 				52C1CE58297EAD310024DB92 /* PrivateBeacon.swift */,
+				95840766EF5C4A1C78F17FF11AECDDE7 /* UnprovisionedDeviceBeacon.swift */,
 			);
 			path = "Network Layer";
 			sourceTree = "<group>";
@@ -2441,6 +2444,7 @@
 				6A4E9DDD5E0243A3F1828A3D416D43A1 /* LightLightnessLinearStatus.swift in Sources */,
 				12957916BFDA8E96C3E4D9AF0A45C606 /* LightLightnessRangeGet.swift in Sources */,
 				C72A9E6527A979445CCD82A06CE03FDA /* LightLightnessRangeSet.swift in Sources */,
+				52C1CE5B298000720024DB92 /* NetworkBeaconPdu.swift in Sources */,
 				82F498EBCCFB4FAC6E76977BA2AF9FEE /* LightLightnessRangeSetUnacknowledged.swift in Sources */,
 				9211DBF5A16FEF6C1121343A44AF3753 /* LightLightnessRangeStatus.swift in Sources */,
 				A414BDEBE265752BD618D18D14AD9DE8 /* LightLightnessSet.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -224,7 +224,7 @@
 		6ACB53DAF666C83ECC18167C1118C711 /* SetFilterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EB4816D4C86A33BA9FF79BC3ECEB742 /* SetFilterType.swift */; };
 		6AEEE97FB85D82A5F0D0C8B5C7D36471 /* LightLCOccupancyModeSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2012322013CAB14E5B6F5472E53A136 /* LightLCOccupancyModeSet.swift */; };
 		6BD1BE5FD32860B18195389D92C6DBF0 /* PKCS7Padding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4412314BE5386EC383D083237F9B961B /* PKCS7Padding.swift */; };
-		6C192BAB9B6A271C80CCFC025D2DE569 /* NodeIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49CB0CB9737D07B8B13469FB83B6074 /* NodeIdentity.swift */; };
+		6C192BAB9B6A271C80CCFC025D2DE569 /* NodeIdentityState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49CB0CB9737D07B8B13469FB83B6074 /* NodeIdentityState.swift */; };
 		6C1F80FE4F1DA06C6AAFB8A1B1641732 /* LightHSLTargetGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 350046A530CAC1B9CFF66AE985C50D46 /* LightHSLTargetGet.swift */; };
 		6C2906432D097D3331ACA54CAEB0BEE0 /* ExportConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09832A57DF98892C3530EC998483EC07 /* ExportConfiguration.swift */; };
 		6C8331341F87B3DF78B6FA1D658559A7 /* GenericOnPowerUpSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8C5BB4AEE974A7181980D8A3F54C7A /* GenericOnPowerUpSetUnacknowledged.swift */; };
@@ -957,7 +957,7 @@
 		D3D5CAA885ED32421F91FFA572970F60 /* CTR.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CTR.swift; path = Sources/CryptoSwift/BlockMode/CTR.swift; sourceTree = "<group>"; };
 		D4746AF53668A76C8E9C8C22550CBE4D /* ConfigCompositionDataStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigCompositionDataStatus.swift; sourceTree = "<group>"; };
 		D4845C49D32E3FF467B089BEA990D42A /* LightLightnessRangeSetUnacknowledged.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightLightnessRangeSetUnacknowledged.swift; sourceTree = "<group>"; };
-		D49CB0CB9737D07B8B13469FB83B6074 /* NodeIdentity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NodeIdentity.swift; sourceTree = "<group>"; };
+		D49CB0CB9737D07B8B13469FB83B6074 /* NodeIdentityState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NodeIdentityState.swift; sourceTree = "<group>"; };
 		D4EFD804DDFEF2EE9090DB4F36E39E25 /* GenericOnOffGet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericOnOffGet.swift; sourceTree = "<group>"; };
 		D4F9AD85F8B56CBA9D7547DB16351AA3 /* Pods-nRF Mesh.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-nRF Mesh.debug.xcconfig"; sourceTree = "<group>"; };
 		D584212530DD07DED49CF9E0E09A3A38 /* ApplicationKey+NetworkKey.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ApplicationKey+NetworkKey.swift"; sourceTree = "<group>"; };
@@ -1467,7 +1467,7 @@
 				B359891752BA5B1C0E3FA2EE6D1D2A29 /* NetworkKey.swift */,
 				5857DDF47AB5DFBD3D2031E728F5E876 /* Node.swift */,
 				4133D14BA9E43DA5738AD64C30503EC1 /* NodeFeatures.swift */,
-				D49CB0CB9737D07B8B13469FB83B6074 /* NodeIdentity.swift */,
+				D49CB0CB9737D07B8B13469FB83B6074 /* NodeIdentityState.swift */,
 				1FF644C417FDD4558C922B9660D025D2 /* OnPowerUp.swift */,
 				FEC37D4B2AC79FD72299452C85669A2D /* Provisioner.swift */,
 				343A754B6B1F884829945DCD3AF2EE81 /* Publish.swift */,
@@ -2495,7 +2495,7 @@
 				2F944E7529BC52AE92FC09065E6FD1DE /* Node+Provisioner.swift in Sources */,
 				36310EB8EC72F27543439F25F4AAEDAA /* Node+Scenes.swift in Sources */,
 				ACB1B28A6F5B23ABAE198366E219B846 /* NodeFeatures.swift in Sources */,
-				6C192BAB9B6A271C80CCFC025D2DE569 /* NodeIdentity.swift in Sources */,
+				6C192BAB9B6A271C80CCFC025D2DE569 /* NodeIdentityState.swift in Sources */,
 				E1ABA618DBE02AC3505204BC932CE54A /* nRFMeshProvision-dummy.m in Sources */,
 				7D1EE75BE6B93CE5540BA927F5A4FC98 /* OnPowerUp.swift in Sources */,
 				19F6D942EA9BE04CF6A65782109579ED /* Oob.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -178,6 +178,8 @@
 		5298C00B6C7DA3382FA31FB3B0EF2826 /* PKCS5.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6529BEEF734D4D9F2920046F56965C4 /* PKCS5.swift */; };
 		52C1CE59297EAD310024DB92 /* PrivateBeacon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C1CE58297EAD310024DB92 /* PrivateBeacon.swift */; };
 		52C1CE5B298000720024DB92 /* NetworkBeaconPdu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C1CE5A298000720024DB92 /* NetworkBeaconPdu.swift */; };
+		52C1CE5D2980205D0024DB92 /* NodeIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C1CE5C2980205D0024DB92 /* NodeIdentity.swift */; };
+		52C1CE5F2980207A0024DB92 /* NetworkIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C1CE5E2980207A0024DB92 /* NetworkIdentity.swift */; };
 		5338E50DC8D7B6977F90D5375B7A82D1 /* ConfigNodeResetStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32019C109C91B2F3A7C7820712D2A348 /* ConfigNodeResetStatus.swift */; };
 		535FA970A49C4AC40847416AD23D6C0E /* SensorDescriptorStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC5FEC3B624A649D72085D0F629E364 /* SensorDescriptorStatus.swift */; };
 		54C7B0CFF20B468743131E1077152526 /* RemoveAddressesFromFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CCB373620F516C453F665485B9B72E /* RemoveAddressesFromFilter.swift */; };
@@ -711,6 +713,8 @@
 		52C0F063AB492BB2D1FE84FCAE53164D /* LightCTLTemperatureRangeSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightCTLTemperatureRangeSet.swift; sourceTree = "<group>"; };
 		52C1CE58297EAD310024DB92 /* PrivateBeacon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateBeacon.swift; sourceTree = "<group>"; };
 		52C1CE5A298000720024DB92 /* NetworkBeaconPdu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkBeaconPdu.swift; sourceTree = "<group>"; };
+		52C1CE5C2980205D0024DB92 /* NodeIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeIdentity.swift; sourceTree = "<group>"; };
+		52C1CE5E2980207A0024DB92 /* NetworkIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkIdentity.swift; sourceTree = "<group>"; };
 		52E161FE177AF095BA55247B132B8C2D /* Oob.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Oob.swift; sourceTree = "<group>"; };
 		5309874A90AA23CE4DBDB5BE48808F97 /* CompositionElement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CompositionElement.swift; sourceTree = "<group>"; };
 		5427BFDA8338A7437D8154638B5B99DD /* LightCTLTemperatureRangeStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightCTLTemperatureRangeStatus.swift; sourceTree = "<group>"; };
@@ -1464,6 +1468,8 @@
 				1B310809A4BD83750BE730606B53A6C9 /* MeshNetwork.swift */,
 				B24CAE7B505771A6D2964A6C658C9796 /* MeshUUID.swift */,
 				24BC18965C93D738F5E69DBB04F17F2F /* Model.swift */,
+				52C1CE5E2980207A0024DB92 /* NetworkIdentity.swift */,
+                52C1CE5C2980205D0024DB92 /* NodeIdentity.swift */,
 				B359891752BA5B1C0E3FA2EE6D1D2A29 /* NetworkKey.swift */,
 				5857DDF47AB5DFBD3D2031E728F5E876 /* Node.swift */,
 				4133D14BA9E43DA5738AD64C30503EC1 /* NodeFeatures.swift */,
@@ -2443,6 +2449,7 @@
 				09AB5463B2777E6299912AFC5D2A06B9 /* LightLightnessLinearSetUnacknowledged.swift in Sources */,
 				6A4E9DDD5E0243A3F1828A3D416D43A1 /* LightLightnessLinearStatus.swift in Sources */,
 				12957916BFDA8E96C3E4D9AF0A45C606 /* LightLightnessRangeGet.swift in Sources */,
+				52C1CE5F2980207A0024DB92 /* NetworkIdentity.swift in Sources */,
 				C72A9E6527A979445CCD82A06CE03FDA /* LightLightnessRangeSet.swift in Sources */,
 				52C1CE5B298000720024DB92 /* NetworkBeaconPdu.swift in Sources */,
 				82F498EBCCFB4FAC6E76977BA2AF9FEE /* LightLightnessRangeSetUnacknowledged.swift in Sources */,
@@ -2535,6 +2542,7 @@
 				5FB95C9360B06E97E0D505211E8F4612 /* SceneStore.swift in Sources */,
 				038142185D9048FFA7871E59BF380E8E /* SceneStoreUnacknowledged.swift in Sources */,
 				B61ED07E42C3A05C737F79715A66ECFD /* SchedulerActionGet.swift in Sources */,
+				52C1CE5D2980205D0024DB92 /* NodeIdentity.swift in Sources */,
 				5D09F10DE19101759EB703049D7014C4 /* SchedulerActionSet.swift in Sources */,
 				9294E26BF6AE7F494C113D886C5DAA73 /* SchedulerActionSetUnacknowledged.swift in Sources */,
 				0DFE7461C54031872560F198C6768DE1 /* SchedulerActionStatus.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		4F41A81DAE6ACA08CA98C9F0F9532050 /* String+FoundationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA464A9A50BADCB332245C1238E5F0CB /* String+FoundationExtension.swift */; };
 		5204D26757066D8C6B6C6696A07DF5DE /* MeshNodeEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C761AB3A924F8FA31079749C9DD606C /* MeshNodeEntry.swift */; };
 		5298C00B6C7DA3382FA31FB3B0EF2826 /* PKCS5.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6529BEEF734D4D9F2920046F56965C4 /* PKCS5.swift */; };
+		52C1CE59297EAD310024DB92 /* PrivateBeacon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C1CE58297EAD310024DB92 /* PrivateBeacon.swift */; };
 		5338E50DC8D7B6977F90D5375B7A82D1 /* ConfigNodeResetStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32019C109C91B2F3A7C7820712D2A348 /* ConfigNodeResetStatus.swift */; };
 		535FA970A49C4AC40847416AD23D6C0E /* SensorDescriptorStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EC5FEC3B624A649D72085D0F629E364 /* SensorDescriptorStatus.swift */; };
 		54C7B0CFF20B468743131E1077152526 /* RemoveAddressesFromFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CCB373620F516C453F665485B9B72E /* RemoveAddressesFromFilter.swift */; };
@@ -707,6 +708,7 @@
 		51546F12A683A01A9AD6EBADD449AB11 /* Cryptor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cryptor.swift; path = Sources/CryptoSwift/Cryptor.swift; sourceTree = "<group>"; };
 		51B542A657751A6647ED0C2B1E331F3F /* ConfigVendorModelAppList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigVendorModelAppList.swift; sourceTree = "<group>"; };
 		52C0F063AB492BB2D1FE84FCAE53164D /* LightCTLTemperatureRangeSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightCTLTemperatureRangeSet.swift; sourceTree = "<group>"; };
+		52C1CE58297EAD310024DB92 /* PrivateBeacon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivateBeacon.swift; sourceTree = "<group>"; };
 		52E161FE177AF095BA55247B132B8C2D /* Oob.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Oob.swift; sourceTree = "<group>"; };
 		5309874A90AA23CE4DBDB5BE48808F97 /* CompositionElement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CompositionElement.swift; sourceTree = "<group>"; };
 		5427BFDA8338A7437D8154638B5B99DD /* LightCTLTemperatureRangeStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightCTLTemperatureRangeStatus.swift; sourceTree = "<group>"; };
@@ -1901,6 +1903,7 @@
 				E463522203E906B7BEDE0DBF8F6663D7 /* NetworkPdu.swift */,
 				B57552A55608AF68809C8A77EF370E55 /* SecureNetworkBeacon.swift */,
 				95840766EF5C4A1C78F17FF11AECDDE7 /* UnprovisionedDeviceBeacon.swift */,
+				52C1CE58297EAD310024DB92 /* PrivateBeacon.swift */,
 			);
 			path = "Network Layer";
 			sourceTree = "<group>";
@@ -2379,6 +2382,7 @@
 				6CFF23CB0E51A94C6B1ED845FA55AB68 /* LightCTLSetUnackowledged.swift in Sources */,
 				B61E4812F14C2EE16433192F18CDC1E3 /* LightCTLStatus.swift in Sources */,
 				59DA4204867707CB6E290A695F48680F /* LightCTLTemperatureGet.swift in Sources */,
+				52C1CE59297EAD310024DB92 /* PrivateBeacon.swift in Sources */,
 				2454DB90FCAB4C6AFE3CF445EA07FC30 /* LightCTLTemperatureRangeGet.swift in Sources */,
 				5E98D8E75A013B560FD845880A0859AC /* LightCTLTemperatureRangeSet.swift in Sources */,
 				6A1FC3A3D5B547E8E39F2E45F1249C78 /* LightCTLTemperatureRangeSetUnacknowledged.swift in Sources */,

--- a/Example/Source/Mesh Network/NetworkConnection.swift
+++ b/Example/Source/Mesh Network/NetworkConnection.swift
@@ -182,9 +182,9 @@ extension NetworkConnection: CBCentralManagerDelegate {
     
     func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral,
                         advertisementData: [String : Any], rssi RSSI: NSNumber) {
-        // Is it a Network ID beacon?
-        if let networkId = advertisementData.networkId {
-            guard meshNetwork.matches(networkId: networkId) else {
+        // Is it a Network ID or Private Network Identity beacon?
+        if let networkIdentity = advertisementData.networkIdentity {
+            guard meshNetwork.matches(networkIdentity: networkIdentity) else {
                 // A Node from another mesh network.
                 return
             }

--- a/Example/Source/View Controllers/Network/Configuration/ModelViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/ModelViewController.swift
@@ -47,7 +47,7 @@ class ModelViewController: ProgressViewController {
     /// and only when the value has been read.
     private var sensorValues: [SensorValue]?
     /// Node Identity values per Network Key. Pull to Refresh current states.
-    private var nodeIdentityStates: [(key: NetworkKey, state: NodeIdentity?)]!
+    private var nodeIdentityStates: [(key: NetworkKey, state: NodeIdentityState?)]!
     /// This is a helper counter to iterate over Node Identity states while
     /// loading them from the Node. It is reinitialized to 0 on Pull To Refresh
     /// and incremented with every status received until all identity states are

--- a/Example/Source/View Controllers/Proxy/ProxySelectorViewController.swift
+++ b/Example/Source/View Controllers/Proxy/ProxySelectorViewController.swift
@@ -136,16 +136,16 @@ extension ProxySelectorViewController: CBCentralManagerDelegate {
                         advertisementData: [String : Any], rssi RSSI: NSNumber) {
         guard let meshNetwork = meshNetwork else { return }
         
-        // Is it a Network ID beacon?
-        if let networkId = advertisementData.networkId {
-            guard meshNetwork.matches(networkId: networkId) else {
+        // Is it a Network ID or Private Network Identity beacon?
+        if let networkIdentity = advertisementData.networkIdentity {
+            guard meshNetwork.matches(networkIdentity: networkIdentity) else {
                 // A Node from another mesh network.
                 return
             }
         } else {
-            // Is it a Node Identity beacon?
+            // Is it a Node Identity or Private Node Identity beacon?
             guard let nodeIdentity = advertisementData.nodeIdentity,
-                meshNetwork.matches(hash: nodeIdentity.hash, random: nodeIdentity.random) else {
+                  meshNetwork.matches(nodeIdentity: nodeIdentity) else {
                 // A Node from another mesh network.
                 return
             }

--- a/Example/Tests/CryptoTest.swift
+++ b/Example/Tests/CryptoTest.swift
@@ -170,6 +170,34 @@ class CryptoTest: XCTestCase {
         XCTAssertEqual(k4, expectedAID)
     }
     
+    // Test based on Provisioning Sample Data 8.4.6.1 from Mesh Profile 1.1.
+    func testPrivateBeacon_IVUpdateInProgress() throws {
+        let privateBeaconPdu = Data(hex: "02435f18f85cf78a3121f58478a561e488e7cbf3174f022a514741")
+        let key = Data(hex: "6be76842460b2d3a5850d4698409f1bb")
+        
+        // Deobfuscate and authenticate the Private beacon.
+        let privateBeaconData = Crypto.decodeAndAuthenticate(privateBeacon: privateBeaconPdu, usingPrivateBeaconKey: key)
+        
+        XCTAssertNotNil(privateBeaconData)
+        XCTAssertEqual(privateBeaconData?.keyRefreshFlag, false)
+        XCTAssertEqual(privateBeaconData?.ivIndex.updateActive, true)
+        XCTAssertEqual(privateBeaconData?.ivIndex.index, 0x1010abcd)
+    }
+    
+    // Test based on Provisioning Sample Data 8.4.6.2 from Mesh Profile 1.1.
+    func testPrivateBeacon_IVUpdateComplete() throws {
+        let privateBeaconPdu = Data(hex: "021b998f82927535ea6f3076f422ce827408ab2f0ffb94cf97f881")
+        let key = Data(hex: "ca478cdac626b7a8522d7272dd124f26")
+        
+        // Deobfuscate and authenticate the Private beacon.
+        let privateBeaconData = Crypto.decodeAndAuthenticate(privateBeacon: privateBeaconPdu, usingPrivateBeaconKey: key)
+        
+        XCTAssertNotNil(privateBeaconData)
+        XCTAssertEqual(privateBeaconData?.keyRefreshFlag, false)
+        XCTAssertEqual(privateBeaconData?.ivIndex.updateActive, false)
+        XCTAssertEqual(privateBeaconData?.ivIndex.index, 0x00000000)
+    }
+    
     // Test based on Provisioning Sample Data 8.17.1 and 8.17.2 from Mesh Profile 1.1.
     func testCalculatingSharedSecret() throws {
         // Received Public Key (X + Y)

--- a/Example/Tests/CryptoTest.swift
+++ b/Example/Tests/CryptoTest.swift
@@ -198,6 +198,17 @@ class CryptoTest: XCTestCase {
         XCTAssertEqual(privateBeaconData?.ivIndex.index, 0x00000000)
     }
     
+    // Test based on Provisioning Sample Data 8.4.6.2 from Mesh Profile 1.1, with modified Authentication Tag.
+    func testPrivateBeacon_Invalid() throws {
+        let privateBeaconPdu = Data(hex: "021b998f82927535ea6f3076f422ce827408ab0123456789ABCDEF")
+        let key = Data(hex: "ca478cdac626b7a8522d7272dd124f26")
+        
+        // Deobfuscate and authenticate the Private beacon.
+        let privateBeaconData = Crypto.decodeAndAuthenticate(privateBeacon: privateBeaconPdu, usingPrivateBeaconKey: key)
+        
+        XCTAssertNil(privateBeaconData)
+    }
+    
     // Test based on Provisioning Sample Data 8.17.1 and 8.17.2 from Mesh Profile 1.1.
     func testCalculatingSharedSecret() throws {
         // Received Public Key (X + Y)

--- a/Example/Tests/CryptoTest.swift
+++ b/Example/Tests/CryptoTest.swift
@@ -136,18 +136,20 @@ class CryptoTest: XCTestCase {
     func testKeyDerivatives() throws {
         let key = Data(hex: "f7a2a44f8e8a8029064f173ddc1e2b00")
         
-        let expectedNID           = UInt8(0x7F)
-        let expectedEncryptionKey = Data(hex: "9f589181a0f50de73c8070c7a6d27f46")
-        let expectedPrivacyKey    = Data(hex: "4c715bd4a64b938f99b453351653124f")
-        let expectedIdentityKey   = Data(hex: "877DE1A131C87A8C6767E655061963A7")
-        let expectedBeaconKey     = Data(hex: "CCAE3C53A3BB6FAB728EE94A390DC91F")
+        let expectedNID              = UInt8(0x7F)
+        let expectedEncryptionKey    = Data(hex: "9f589181a0f50de73c8070c7a6d27f46")
+        let expectedPrivacyKey       = Data(hex: "4c715bd4a64b938f99b453351653124f")
+        let expectedIdentityKey      = Data(hex: "877DE1A131C87A8C6767E655061963A7")
+        let expectedBeaconKey        = Data(hex: "CCAE3C53A3BB6FAB728EE94A390DC91F")
+        let expectedPrivateBeaconKey = Data(hex: "6be76842460b2d3a5850d4698409f1bb")
         
-        let (n, e, p, i, b) = Crypto.calculateKeyDerivatives(from: key)
-        XCTAssertEqual(n, expectedNID)
-        XCTAssertEqual(e, expectedEncryptionKey)
-        XCTAssertEqual(p, expectedPrivacyKey)
-        XCTAssertEqual(i, expectedIdentityKey)
-        XCTAssertEqual(b, expectedBeaconKey)
+        let (nid, ek, pk, ik, bk, pbk) = Crypto.calculateKeyDerivatives(from: key)
+        XCTAssertEqual(nid, expectedNID)
+        XCTAssertEqual(ek,  expectedEncryptionKey)
+        XCTAssertEqual(pk,  expectedPrivacyKey)
+        XCTAssertEqual(ik,  expectedIdentityKey)
+        XCTAssertEqual(bk,  expectedBeaconKey)
+        XCTAssertEqual(pbk, expectedPrivateBeaconKey)
     }
     
     func testNetworkId() throws {

--- a/nRFMeshProvision/Classes/Crypto/Crypto.swift
+++ b/nRFMeshProvision/Classes/Crypto/Crypto.swift
@@ -163,7 +163,15 @@ internal class Crypto {
         return authenticationValue == hash
     }
     
-    static func decodeAndAuthenticate(privateBeacon pdu: Data, usingPrivateBeaconKey key: Data) -> (keyRefreshFlag: Bool, ivIndex: IvIndex)? {
+    /// Decodes and authenticates the received Private beacon using the given Private
+    /// Beacon Key.
+    ///
+    /// - parameters:
+    ///   - pdu: The received PDU.
+    ///   - key: The Private Beacon Key generated from a Network Key.
+    /// - returns: Network information obtained from the beacon.
+    static func decodeAndAuthenticate(privateBeacon pdu: Data,
+                                      usingPrivateBeaconKey key: Data) -> (keyRefreshFlag: Bool, ivIndex: IvIndex)? {
         // Byte 0 of the PDU is the Beacon Type (0x02).
         let random = pdu.subdata(in: 1..<14)
         let obfuscatedData = pdu.subdata(in: 14..<19)

--- a/nRFMeshProvision/Classes/Crypto/Crypto.swift
+++ b/nRFMeshProvision/Classes/Crypto/Crypto.swift
@@ -98,19 +98,28 @@ internal class Crypto {
     
     /// Calculates key derivatives from the given Network Key.
     ///
+    /// The derivatives are:
+    /// - NID (LSB, 7 bits),
+    /// - Encryption Key (128 bits),
+    /// - Privacy Key (128 bits),
+    /// - Identity Key (128 bits),
+    /// - Beacon Key (128 bits)
+    /// - Private Beacon Key (128 bits).
+    ///
     /// - parameter key: The Network Key.
-    /// - returns: NID (7 bits), Encryption Key (128 bits) and Privacy Key (128 bits),
-    ///            Identity Key (128 bits) and Beacon Key (128 bits).
+    /// - returns: Key derivatives.
     static func calculateKeyDerivatives(from key: Data)
-                -> (nid: UInt8, encryptionKey: Data, privacyKey: Data, identityKey: Data, beaconKey: Data) {
+                -> (nid: UInt8, encryptionKey: Data, privacyKey: Data, identityKey: Data, beaconKey: Data, privateBeaconKey: Data) {
         let P = Data([0x69, 0x64, 0x31, 0x32, 0x38, 0x01]) // "id128" || 0x01
         let saltIK = calculateS1("nkik".data(using: .utf8)!)
         let identityKey = calculateK1(withN: key, salt: saltIK, andP: P)
         let saltBK = calculateS1("nkbk".data(using: .utf8)!)
         let beaconKey = calculateK1(withN: key, salt: saltBK, andP: P)
+        let saltPK = calculateS1("nkpk".data(using: .utf8)!)
+        let privateBeaconKey = calculateK1(withN: key, salt: saltPK, andP: P)
         
         let (nid, encryptionKey, privacyKey) = calculateK2(withN: key, andP: Data([0x00]))
-        return (nid, encryptionKey, privacyKey, identityKey, beaconKey)
+        return (nid, encryptionKey, privacyKey, identityKey, beaconKey, privateBeaconKey)
     }
     
     /// Generates the Network ID based on the given 128-bit key.

--- a/nRFMeshProvision/Classes/Layers/Network Layer/BeaconPdu.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/BeaconPdu.swift
@@ -33,6 +33,7 @@ import Foundation
 internal enum BeaconType: UInt8 {
     case unprovisionedDevice = 0
     case secureNetwork       = 1
+    case privateBeacon       = 2
 }
 
 internal protocol BeaconPdu {

--- a/nRFMeshProvision/Classes/Layers/Network Layer/NetworkBeaconPdu.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/NetworkBeaconPdu.swift
@@ -1,0 +1,182 @@
+/*
+* Copyright (c) 2023, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+internal protocol NetworkBeaconPdu: BeaconPdu {
+    /// The Network Key related to this Secure Network beacon.
+    var networkKey: NetworkKey { get }
+    /// A flag indicating whether the Secure Network beacon has been
+    /// secured using the new Network Key during Key Refresh Procedure.
+    var validForKeyRefreshProcedure: Bool { get }
+    /// Key Refresh flag value.
+    ///
+    /// When this flag is active, the Node shall set the Key Refresh
+    /// Phase for this Network Key to ``KeyRefreshPhase/usingNewKeys``.
+    /// When in this phase, the Node shall only transmit messages and
+    /// Secure Network beacons using the new keys, shall receive messages
+    /// using the old keys and the new keys, and shall only receive
+    /// Secure Network beacons secured using the new Network Key.
+    var keyRefreshFlag: Bool { get }
+    /// The IV Index carried by this Secure Network beacon.
+    var ivIndex: IvIndex { get }
+    
+    /// Creates beacon PDU object from received PDU.
+    ///
+    /// - parameters:
+    ///   - pdu: The data received from mesh network.
+    ///   - networkKey: The Network Key to validate the beacon.
+    /// - returns: The beacon object, or `nil` if the data are invalid.
+    init?(decode pdu: Data, usingNetworkKey networkKey: NetworkKey)
+}
+
+internal extension NetworkBeaconPdu {
+    
+    /// This method returns whether the received network beacon can override the current IV Index.
+    ///
+    /// The following restrictions apply:
+    /// 1. Normal Operation state must last for at least 96 hours.
+    /// 2. IV Update In Progress state must take at least 96 hours and may not be longer than 144h.
+    /// 3. IV Index must not decrease.
+    /// 4. If received Secure Network beacon or Private beacon has IV Index greater than current
+    ///    IV Index + 1, the device will go into IV Index Recovery procedure. In this state,
+    ///    the 96h rule does not apply and the IV Index or IV Update Active flag may change before 96 hours.
+    /// 5. If received Secure Network beacon or Private beacon has IV Index greater than current
+    ///    IV Index + 42, the beacon should be ignored (unless a setting
+    ///    ``MeshNetworkManager/ivUpdateTestMode`` is set to disable this rule).
+    /// 6. The node shall not execute more than one IV Index Recovery within a period of 192 hours.
+    ///
+    /// Note: Library versions before 2.2.2 did not store the last IV Index, so the date and IV Recovery
+    ///       flag are optional.
+    ///
+    /// - parameters:
+    ///   - target: The IV Index to compare.
+    ///   - date: The date of the most recent transition to the current IV Index.
+    ///   - ivRecoveryActive: True if the IV Recovery procedure was used to restore
+    ///                       the IV Index on the previous connection.
+    ///   - ivTestMode: True, if IV Update test mode is enabled; false otherwise.
+    ///   - ivRecoveryOver42Allowed: Whether the IV Index Recovery procedure should be limited
+    ///                              to allow maximum increase of IV Index by 42.
+    /// - returns: True, if the network information can be applied; false otherwise.
+    /// - since: 2.2.2
+    /// - seeAlso: Bluetooth Mesh Profile 1.0.1, section 3.10.5.
+    func canOverwrite(ivIndex target: IvIndex, updatedAt date: Date?,
+                      withIvRecovery ivRecoveryActive: Bool,
+                      testMode: Bool,
+                      andUnlimitedIvRecoveryAllowed ivRecoveryOver42Allowed: Bool) -> Bool {
+        // IV Index must increase, or, in case it's equal to the current one,
+        // the IV Update Active flag must change from true to false.
+        // The new index must not be greater than the current one + 42,
+        // unless this rule is disabled.
+        guard (ivIndex.index > target.index &&
+                (ivRecoveryOver42Allowed || ivIndex.index <= target.index + 42)
+              ) ||
+              (ivIndex.index == target.index &&
+                (target.updateActive || !ivIndex.updateActive)
+              ) else {
+            return false
+        }
+        // Staring from version 2.2.2 the date will not be nil.
+        if let date = date {
+            // Let's define a "state" as a pair of IV and IV Update Active flag.
+            // "States" change as follows:
+            // 1. IV = X,   IVUA = false (Normal Operation)
+            // 2. IV = X+1, IVUA = true  (Update In Progress)
+            // 3. IV = X+1, IVUA = false (Normal Operation)
+            // 4. IV = X+2, IVUA = true  (Update In Progress)
+            // 5. ...
+            
+            // Calculate number of states between the state defined by the target
+            // IV Index and this Secure Network Beacon.
+            let stateDiff = Int(ivIndex.index - target.index) * 2 - 1
+                + (target.updateActive ? 1 : 0)
+                + (ivIndex.updateActive ? 0 : 1)
+                - (ivRecoveryActive || testMode ? 1 : 0) // this may set stateDiff = -1
+            
+            // Each "state" must last for at least 96 hours.
+            // Calculate the minimum number of hours that had to pass since last state
+            // change for the beacon to be assumed valid.
+            // If more has passed, it's also valid, as Normal Operation has no maximum
+            // time duration.
+            let numberOfHoursRequired = stateDiff * 96
+            
+            // Get the number of hours since the state changed last time.
+            let numberOfHoursSinceDate = Int(-date.timeIntervalSinceNow / 3600)
+            
+            // The node shall not execute more than one IV Index Recovery within a
+            // period of 192 hours.
+            if ivRecoveryActive && stateDiff > 1 && numberOfHoursSinceDate < 192 {
+                return false
+            }
+            
+            return numberOfHoursSinceDate >= numberOfHoursRequired
+        }
+        // Before version 2.2.2 the timestamp was not stored.
+        // The initial Secure Network beacon or Private beacon is assumed to be valid.
+        return true
+    }
+    
+}
+
+internal struct NetworkBeaconDecoder {
+    private init() {}
+    
+    /// This method goes over all Network Keys in the mesh network and tries
+    /// to parse the beacon.
+    ///
+    /// - parameters:
+    ///   - pdu:         The received PDU.
+    ///   - meshNetwork: The mesh network for which the PDU should be decoded.
+    /// - returns: The beacon object.
+    static func decode(_ pdu: Data, for meshNetwork: MeshNetwork) -> NetworkBeaconPdu? {
+        guard pdu.count > 1, let beaconType = BeaconType(rawValue: pdu[0]) else {
+            return nil
+        }
+        switch beaconType {
+        case .secureNetwork:
+            for networkKey in meshNetwork.networkKeys {
+                if let beacon = SecureNetworkBeacon(decode: pdu, usingNetworkKey: networkKey) {
+                    return beacon
+                }
+            }
+            return nil
+        case .privateBeacon:
+            for networkKey in meshNetwork.networkKeys {
+                if let beacon = PrivateBeacon(decode: pdu, usingNetworkKey: networkKey) {
+                    return beacon
+                }
+            }
+            return nil
+        default:
+            return nil
+        }
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Layers/Network Layer/PrivateBeacon.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/PrivateBeacon.swift
@@ -64,16 +64,22 @@ internal struct PrivateBeacon: BeaconPdu {
         }
         
         // Try to decode and authentice the Private beacon using current Private Beacon Key.
-        var privateBeaconData = Crypto.decodeAndAuthenticate(privateBeacon: pdu, usingPrivateBeaconKey: networkKey.keys.privateBeaconKey)
+        var privateBeaconData = Crypto.decodeAndAuthenticate(
+            privateBeacon: pdu,
+            usingPrivateBeaconKey: networkKey.keys.privateBeaconKey
+        )
         
         // If the beacon failed to be authenticated, and the old key exists, use that one.
         if privateBeaconData == nil,
            case .keyDistribution = networkKey.phase,
            let oldKeys = networkKey.oldKeys {
-            privateBeaconData = Crypto.decodeAndAuthenticate(privateBeacon: pdu, usingPrivateBeaconKey: oldKeys.privateBeaconKey)
+            privateBeaconData = Crypto.decodeAndAuthenticate(
+                privateBeacon: pdu,
+                usingPrivateBeaconKey: oldKeys.privateBeaconKey
+            )
         }
         
-        // If the beacon stil failed to be authenticated, discard it.
+        // If the beacon still failed to be authenticated, discard it.
         guard let privateBeaconData = privateBeaconData else {
             return nil
         }

--- a/nRFMeshProvision/Classes/Layers/Network Layer/PrivateBeacon.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/PrivateBeacon.swift
@@ -30,25 +30,12 @@
 
 import Foundation
 
-internal struct PrivateBeacon: BeaconPdu {
+internal struct PrivateBeacon: NetworkBeaconPdu {
     let pdu: Data
     let beaconType: BeaconType = .privateBeacon
-    
-    /// The Network Key related to this Secure Network beacon.
     let networkKey: NetworkKey
-    /// A flag indicating whether the Secure Network beacon has been
-    /// secured using the new Network Key during Key Refresh Procedure.
     let validForKeyRefreshProcedure: Bool
-    /// Key Refresh flag value.
-    ///
-    /// When this flag is active, the Node shall set the Key Refresh
-    /// Phase for this Network Key to ``KeyRefreshPhase/usingNewKeys``.
-    /// When in this phase, the Node shall only transmit messages and
-    /// Secure Network beacons using the new keys, shall receive messages
-    /// using the old keys and the new keys, and shall only receive
-    /// Secure Network beacons secured using the new Network Key.
     let keyRefreshFlag: Bool
-    /// The IV Index carried by this Private beacon.
     let ivIndex: IvIndex
     
     /// Creates Private beacon PDU object from received PDU.
@@ -70,6 +57,8 @@ internal struct PrivateBeacon: BeaconPdu {
         )
         
         // If the beacon failed to be authenticated, and the old key exists, use that one.
+        // During Key Refresh Procedure when in Phase 1 (key distribution) the
+        // Private beacon may be decoded using the old Network Key.
         if privateBeaconData == nil,
            case .keyDistribution = networkKey.phase,
            let oldKeys = networkKey.oldKeys {
@@ -90,4 +79,12 @@ internal struct PrivateBeacon: BeaconPdu {
         self.ivIndex = privateBeaconData.ivIndex
         self.validForKeyRefreshProcedure = networkKey.oldKey != nil
     }
+}
+
+extension PrivateBeacon: CustomDebugStringConvertible {
+    
+    var debugDescription: String {
+        return "Private Beacon beacon (Network ID: \(networkKey.networkId.hex), \(ivIndex), Key Refresh Flag: \(keyRefreshFlag))"
+    }
+    
 }

--- a/nRFMeshProvision/Classes/Layers/Network Layer/PrivateBeacon.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/PrivateBeacon.swift
@@ -1,0 +1,87 @@
+/*
+* Copyright (c) 2023, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+internal struct PrivateBeacon: BeaconPdu {
+    let pdu: Data
+    let beaconType: BeaconType = .privateBeacon
+    
+    /// The Network Key related to this Secure Network beacon.
+    let networkKey: NetworkKey
+    /// A flag indicating whether the Secure Network beacon has been
+    /// secured using the new Network Key during Key Refresh Procedure.
+    let validForKeyRefreshProcedure: Bool
+    /// Key Refresh flag value.
+    ///
+    /// When this flag is active, the Node shall set the Key Refresh
+    /// Phase for this Network Key to ``KeyRefreshPhase/usingNewKeys``.
+    /// When in this phase, the Node shall only transmit messages and
+    /// Secure Network beacons using the new keys, shall receive messages
+    /// using the old keys and the new keys, and shall only receive
+    /// Secure Network beacons secured using the new Network Key.
+    let keyRefreshFlag: Bool
+    /// The IV Index carried by this Private beacon.
+    let ivIndex: IvIndex
+    
+    /// Creates Private beacon PDU object from received PDU.
+    ///
+    /// - parameters:
+    ///   - pdu: The data received from mesh network.
+    ///   - networkKey: The Network Key to validate the beacon.
+    /// - returns: The beacon object, or `nil` if the data are invalid.
+    init?(decode pdu: Data, usingNetworkKey networkKey: NetworkKey) {
+        self.pdu = pdu
+        guard pdu.count == 27, pdu[0] == 2 else {
+            return nil
+        }
+        
+        // Try to decode and authentice the Private beacon using current Private Beacon Key.
+        var privateBeaconData = Crypto.decodeAndAuthenticate(privateBeacon: pdu, usingPrivateBeaconKey: networkKey.keys.privateBeaconKey)
+        
+        // If the beacon failed to be authenticated, and the old key exists, use that one.
+        if privateBeaconData == nil,
+           case .keyDistribution = networkKey.phase,
+           let oldKeys = networkKey.oldKeys {
+            privateBeaconData = Crypto.decodeAndAuthenticate(privateBeacon: pdu, usingPrivateBeaconKey: oldKeys.privateBeaconKey)
+        }
+        
+        // If the beacon stil failed to be authenticated, discard it.
+        guard let privateBeaconData = privateBeaconData else {
+            return nil
+        }
+        
+        // The beacon is authenticated.
+        self.networkKey = networkKey
+        self.keyRefreshFlag = privateBeaconData.keyRefreshFlag
+        self.ivIndex = privateBeaconData.ivIndex
+        self.validForKeyRefreshProcedure = networkKey.oldKey != nil
+    }
+}

--- a/nRFMeshProvision/Classes/Layers/Network Layer/SecureNetworkBeacon.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/SecureNetworkBeacon.swift
@@ -30,28 +30,13 @@
 
 import Foundation
 
-internal struct SecureNetworkBeacon: BeaconPdu {
+internal struct SecureNetworkBeacon: NetworkBeaconPdu {
     let pdu: Data
     let beaconType: BeaconType = .secureNetwork
-    
-    /// The Network Key related to this Secure Network beacon.
     let networkKey: NetworkKey
-    /// A flag indicating whether the Secure Network beacon has been
-    /// secured using the new Network Key during Key Refresh Procedure.
     let validForKeyRefreshProcedure: Bool
-    /// Key Refresh flag value.
-    ///
-    /// When this flag is active, the Node shall set the Key Refresh
-    /// Phase for this Network Key to ``KeyRefreshPhase/usingNewKeys``.
-    /// When in this phase, the Node shall only transmit messages and
-    /// Secure Network beacons using the new keys, shall receive messages
-    /// using the old keys and the new keys, and shall only receive
-    /// Secure Network beacons secured using the new Network Key.
     let keyRefreshFlag: Bool
-    /// The IV Index carried by this Secure Network beacon.
     let ivIndex: IvIndex
-    /// Contains the value of the Network ID.
-    let networkId: Data
     
     /// Creates Secure Network beacon PDU object from received PDU.
     ///
@@ -66,9 +51,9 @@ internal struct SecureNetworkBeacon: BeaconPdu {
         }
         keyRefreshFlag = pdu[1] & 0x01 != 0
         let updateActive = pdu[1] & 0x02 != 0
-        networkId = pdu.subdata(in: 2..<10)
-        let index = CFSwapInt32BigToHost(pdu.read(fromOffset: 10))
-        ivIndex = IvIndex(index: index, updateActive: updateActive)
+        let networkId = pdu.subdata(in: 2..<10)
+        let index: UInt32 = pdu.read(fromOffset: 10)
+        ivIndex = IvIndex(index: index.bigEndian, updateActive: updateActive)
         
         // Authenticate beacon using given Network Key.
         // During Key Refresh Procedure when in Phase 1 (key distribution) the
@@ -95,126 +80,10 @@ internal struct SecureNetworkBeacon: BeaconPdu {
     }
 }
 
-internal extension SecureNetworkBeacon {
-    
-    /// This method returns whether the received Secure Network Beacon can override
-    /// the current IV Index.
-    ///
-    /// The following restrictions apply:
-    /// 1. Normal Operation state must last for at least 96 hours.
-    /// 2. IV Update In Progress state must take at least 96 hours and may not be longer than 144h.
-    /// 3. IV Index must not decrease.
-    /// 4. If received Secure Network Beacon has IV Index greater than current IV Index + 1, the
-    ///   device will go into IV Index Recovery procedure. In this state, the 96h rule does not apply
-    ///   and the IV Index or IV Update Active flag may change before 96 hours.
-    /// 5. If received Secure Network Beacon has IV Index greater than current IV Index + 42, the
-    ///   beacon should be ignored (unless a setting in MeshNetworkManager is set to disable this rule).
-    /// 6. The node shall not execute more than one IV Index Recovery within a period of 192 hours.
-    ///
-    /// Note: Library versions before 2.2.2 did not store the last IV Index, so the date and IV Recovery
-    ///       flag are optional.
-    ///
-    /// - parameters:
-    ///   - target: The IV Index to compare.
-    ///   - date: The date of the most recent transition to the current IV Index.
-    ///   - ivRecoveryActive: True if the IV Recovery procedure was used to restore
-    ///                       the IV Index on the previous connection.
-    ///   - ivTestMode: True, if IV Update test mode is enabled; false otherwise.
-    ///   - ivRecoveryOver42Allowed: Whether the IV Index Recovery procedure should be limited
-    ///                              to allow maximum increase of IV Index by 42.
-    /// - returns: True, if the Secure Network beacon can be applied; false otherwise.
-    /// - since: 2.2.2
-    /// - seeAlso: Bluetooth Mesh Profile 1.0.1, section 3.10.5.
-    func canOverwrite(ivIndex target: IvIndex, updatedAt date: Date?,
-                      withIvRecovery ivRecoveryActive: Bool,
-                      testMode: Bool,
-                      andUnlimitedIvRecoveryAllowed ivRecoveryOver42Allowed: Bool) -> Bool {
-        // IV Index must increase, or, in case it's equal to the current one,
-        // the IV Update Active flag must change from true to false.
-        // The new index must not be greater than the current one + 42,
-        // unless this rule is disabled.
-        guard (ivIndex.index > target.index &&
-                (ivRecoveryOver42Allowed || ivIndex.index <= target.index + 42)
-              ) ||
-              (ivIndex.index == target.index &&
-                (target.updateActive || !ivIndex.updateActive)
-              ) else {
-            return false
-        }
-        // Staring from version 2.2.2 the date will not be nil.
-        if let date = date {
-            // Let's define a "state" as a pair of IV and IV Update Active flag.
-            // "States" change as follows:
-            // 1. IV = X,   IVUA = false (Normal Operation)
-            // 2. IV = X+1, IVUA = true  (Update In Progress)
-            // 3. IV = X+1, IVUA = false (Normal Operation)
-            // 4. IV = X+2, IVUA = true  (Update In Progress)
-            // 5. ...
-            
-            // Calculate number of states between the state defined by the target
-            // IV Index and this Secure Network Beacon.
-            let stateDiff = Int(ivIndex.index - target.index) * 2 - 1
-                + (target.updateActive ? 1 : 0)
-                + (ivIndex.updateActive ? 0 : 1)
-                - (ivRecoveryActive || testMode ? 1 : 0) // this may set stateDiff = -1
-            
-            // Each "state" must last for at least 96 hours.
-            // Calculate the minimum number of hours that had to pass since last state
-            // change for the Secure Network Beacon to be assumed valid.
-            // If more has passed, it's also valid, as Normal Operation has no maximum
-            // time duration.
-            let numberOfHoursRequired = stateDiff * 96
-            
-            // Get the number of hours since the state changed last time.
-            let numberOfHoursSinceDate = Int(-date.timeIntervalSinceNow / 3600)
-            
-            // The node shall not execute more than one IV Index Recovery within a
-            // period of 192 hours.
-            if ivRecoveryActive && stateDiff > 1 && numberOfHoursSinceDate < 192 {
-                return false
-            }
-            
-            return numberOfHoursSinceDate >= numberOfHoursRequired
-        }
-        // Before version 2.2.2 the timestamp was not stored. The initial
-        // Secure Network Beacon is assumed to be valid.
-        return true
-    }
-    
-}
-
-internal extension SecureNetworkBeacon {
-    
-    /// This method goes over all Network Keys in the mesh network and tries
-    /// to parse the beacon.
-    ///
-    /// - parameters:
-    ///   - pdu:         The received PDU.
-    ///   - meshNetwork: The mesh network for which the PDU should be decoded.
-    /// - returns: The beacon object.
-    static func decode(_ pdu: Data, for meshNetwork: MeshNetwork) -> SecureNetworkBeacon? {
-        guard pdu.count > 1, let beaconType = BeaconType(rawValue: pdu[0]) else {
-            return nil
-        }
-        switch beaconType {
-        case .secureNetwork:
-            for networkKey in meshNetwork.networkKeys {
-                if let beacon = SecureNetworkBeacon(decode: pdu, usingNetworkKey: networkKey) {
-                    return beacon
-                }
-            }
-            return nil
-        default:
-            return nil
-        }
-    }
-    
-}
-
 extension SecureNetworkBeacon: CustomDebugStringConvertible {
     
     var debugDescription: String {
-        return "Secure Network beacon (Network ID: \(networkId.hex), \(ivIndex), Key Refresh Flag: \(keyRefreshFlag))"
+        return "Secure Network beacon (Network ID: \(networkKey.networkId.hex), \(ivIndex), Key Refresh Flag: \(keyRefreshFlag))"
     }
     
 }

--- a/nRFMeshProvision/Classes/Layers/Network Layer/SecureNetworkBeacon.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/SecureNetworkBeacon.swift
@@ -42,11 +42,11 @@ internal struct SecureNetworkBeacon: BeaconPdu {
     /// Key Refresh flag value.
     ///
     /// When this flag is active, the Node shall set the Key Refresh
-    /// Phase for this Network Key to `.usingNewKeys`. When in this phase,
-    /// the Node shall only transmit messages and Secure Network beacons
-    /// using the new keys, shall receive messages using the old keys
-    /// and the new keys, and shall only receive Secure Network beacons
-    /// secured using the new Network Key.
+    /// Phase for this Network Key to ``KeyRefreshPhase/usingNewKeys``.
+    /// When in this phase, the Node shall only transmit messages and
+    /// Secure Network beacons using the new keys, shall receive messages
+    /// using the old keys and the new keys, and shall only receive
+    /// Secure Network beacons secured using the new Network Key.
     let keyRefreshFlag: Bool
     /// The IV Index carried by this Secure Network beacon.
     let ivIndex: IvIndex

--- a/nRFMeshProvision/Classes/Layers/Network Layer/UnprovisionedDeviceBeacon.swift
+++ b/nRFMeshProvision/Classes/Layers/Network Layer/UnprovisionedDeviceBeacon.swift
@@ -64,21 +64,22 @@ internal struct UnprovisionedDeviceBeacon: BeaconPdu {
     }
 }
 
-internal extension UnprovisionedDeviceBeacon {
+internal struct UnprovisionedDeviceBeaconDecoder {
+    private init() {}
     
     /// This method goes over all Network Keys in the mesh network and tries
     /// to parse the beacon.
     ///
-    /// - parameter pdu:         The received PDU.
-    /// - parameter meshNetwork: The mesh network for which the PDU should be decoded.
+    /// - parameters:
+    ///   - pdu:         The received PDU.
+    ///   - meshNetwork: The mesh network for which the PDU should be decoded.
     /// - returns: The beacon object.
     static func decode(_ pdu: Data, for meshNetwork: MeshNetwork) -> UnprovisionedDeviceBeacon? {
-        guard pdu.count > 1 else {
+        guard pdu.count > 1, let beaconType = BeaconType(rawValue: pdu[0]) else {
             return nil
         }
-        let beaconType = BeaconType(rawValue: pdu[0])
         switch beaconType {
-        case .some(.unprovisionedDevice):
+        case .unprovisionedDevice:
             return UnprovisionedDeviceBeacon(decode: pdu)
         default:
             return nil

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigNodeIdentitySet.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigNodeIdentitySet.swift
@@ -41,7 +41,7 @@ public struct ConfigNodeIdentitySet: AcknowledgedConfigMessage, ConfigNetKeyMess
     public let networkKeyIndex: KeyIndex
     /// The Node Identity state determines if a node is advertising with Node Identity
     /// messages on a subnet.
-    public let identity: NodeIdentity
+    public let identity: NodeIdentityState
     
     /// Creates the Config Node Identity Set message.
     ///
@@ -49,7 +49,7 @@ public struct ConfigNodeIdentitySet: AcknowledgedConfigMessage, ConfigNetKeyMess
     ///   - networkKey: The Network Key index for requested subnet.
     ///   - identity:   The Node Identity state determines if a node is advertising with
     ///                 Node Identity messages on a subnet.
-    public init(networkKey: NetworkKey, identity: NodeIdentity) {
+    public init(networkKey: NetworkKey, identity: NodeIdentityState) {
         self.networkKeyIndex = networkKey.index
         self.identity = identity
     }
@@ -59,6 +59,6 @@ public struct ConfigNodeIdentitySet: AcknowledgedConfigMessage, ConfigNetKeyMess
             return nil
         }
         networkKeyIndex = Self.decodeNetKeyIndex(from: parameters, at: 0)
-        identity = NodeIdentity(rawValue: parameters[2]) ?? .notSupported
+        identity = NodeIdentityState(rawValue: parameters[2]) ?? .notSupported
     }
 }

--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigNodeIdentityStatus.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigNodeIdentityStatus.swift
@@ -38,7 +38,7 @@ public struct ConfigNodeIdentityStatus: ConfigNetKeyMessage, ConfigStatusMessage
     }
     
     public let networkKeyIndex: KeyIndex
-    public let identity: NodeIdentity
+    public let identity: NodeIdentityState
     public let status: ConfigMessageStatus
     
     /// Creates a Config Node Identity Status object.
@@ -47,7 +47,7 @@ public struct ConfigNodeIdentityStatus: ConfigNetKeyMessage, ConfigStatusMessage
     ///   - identity: The Node Identity state.
     ///   - networkKey: The Network Key.
     ///   - status: The status.
-    public init(report identity: NodeIdentity,
+    public init(report identity: NodeIdentityState,
                 for networkKey: NetworkKey,
                 with status: ConfigMessageStatus) {
         self.networkKeyIndex = networkKey.index
@@ -75,7 +75,7 @@ public struct ConfigNodeIdentityStatus: ConfigNetKeyMessage, ConfigStatusMessage
         }
         self.status = status
         networkKeyIndex = Self.decodeNetKeyIndex(from: parameters, at: 1)
-        identity = NodeIdentity(rawValue: parameters[3]) ?? .notSupported
+        identity = NodeIdentityState(rawValue: parameters[3]) ?? .notSupported
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Model/NetworkIdentity.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/NetworkIdentity.swift
@@ -1,0 +1,143 @@
+/*
+* Copyright (c) 2023, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import CoreBluetooth
+
+public protocol NetworkIdentity {
+    /// Returns whether the identity matches given ``NetworkKey``.
+    ///
+    /// - parameter networkKey: The Network Key to check.
+    /// - returns: True, if the identity matches the Network Key; false otherwise.
+    func matches(networkKey: NetworkKey) -> Bool
+}
+
+/// Representation of Network ID advertising packet.
+public struct PublicNetworkIdentity: NetworkIdentity {
+    /// The Network ID is 64-bit network identifier derived from the Network Key.
+    public let networkId: Data
+    
+    /// Creates the Network Identity object from Hash and Random values.
+    ///
+    /// - parameter networkId: Identifies the network.
+    public init(networkId: Data) {
+        self.networkId = networkId
+    }
+    
+    /// Creates the Network Identity object from the received advertisement data.
+    ///
+    /// - parameter advertisementData: Received advertisement data.
+    public init?(advertisementData: [String : Any]) {
+        guard let serviceData = advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID : Data],
+              let data = serviceData[MeshProxyService.uuid],
+              data.count > 0 else {
+            return nil
+        }
+        guard data.count == 9 && data[0] == 0x00 else {
+            return nil
+        }
+        self.init(networkId: data.subdata(in: 1..<9))
+    }
+    
+    public func matches(networkKey: NetworkKey) -> Bool {
+        return networkId == networkKey.networkId || networkId == networkKey.oldNetworkId
+    }
+}
+
+/// Representation of Private Network Identity advertising packet.
+public struct PrivateNetworkIdentity: NetworkIdentity {
+    /// Function of the included random number and identity information.
+    public let hash: Data
+    /// 64-bit random number.
+    public let random: Data
+    
+    /// Creates the Network Identity object from Hash and Random values.
+    /// - parameters:
+    ///   - hash: Function of the included random number and identity information.
+    ///   - random: 64-bit random number.
+    public init(hash: Data, random: Data) {
+        self.hash = hash
+        self.random = random
+    }
+    
+    /// Creates the Network Identity object from the received advertisement data.
+    ///
+    /// - parameter advertisementData: Received advertisement data.
+    public init?(advertisementData: [String : Any]) {
+        guard let serviceData = advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID : Data],
+              let data = serviceData[MeshProxyService.uuid],
+              data.count > 0 else {
+            return nil
+        }
+        guard data.count == 17 && data[0] == 0x02 else {
+            return nil
+        }
+        self.init(hash: data.subdata(in: 1..<9), random: data.subdata(in: 9..<17))
+    }
+    
+    public func matches(networkKey: NetworkKey) -> Bool {
+        // Data are: Network ID and 64 bit Random.
+        let data = networkKey.networkId + random
+        let calculatedHash = Crypto.calculateHash(from: data,
+                                                  usingIdentityKey: networkKey.keys.identityKey)
+        if calculatedHash == hash {
+            return true
+        }
+        
+        // If the Key Refresh Procedure is in place, the identity might have been
+        // generated with the old key.
+        if let oldIdentityKey = networkKey.oldKeys?.identityKey,
+           let oldNetworkId = networkKey.oldNetworkId {
+            let oldData = oldNetworkId + random
+            let calculatedHash = Crypto.calculateHash(from: oldData,
+                                                      usingIdentityKey: oldIdentityKey)
+            if calculatedHash == hash {
+                return true
+            }
+        }
+        return false
+    }
+}
+
+extension PublicNetworkIdentity: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return "Network Identity (0x\(networkId.hex))"
+    }
+    
+}
+
+extension PrivateNetworkIdentity: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return "Network Identity (hash: 0x\(hash.hex), random: 0x\(random.hex))"
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Model/NetworkKey.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/NetworkKey.swift
@@ -35,6 +35,8 @@ internal struct NetworkKeyDerivatives {
     let identityKey: Data!
     /// The Beacon Key.
     let beaconKey: Data!
+    /// The Private Beacon Key.
+    let privateBeaconKey: Data!
     /// The Encryption Key.
     let encryptionKey: Data!
     /// The Privacy Key.
@@ -43,7 +45,7 @@ internal struct NetworkKeyDerivatives {
     let nid: UInt8!
     
     init(withKey key: Data) {
-        (nid, encryptionKey, privacyKey, identityKey, beaconKey) =
+        (nid, encryptionKey, privacyKey, identityKey, beaconKey, privateBeaconKey) =
             Crypto.calculateKeyDerivatives(from: key)
     }
 }
@@ -61,10 +63,11 @@ internal struct NetworkKeyDerivatives {
 /// and a set of keys used for for encrypting different types of messages:
 /// * Identity Key
 /// * Beacon Key
+/// * Private Beacon Key
 /// * Encryption Key
 /// * Privacy Key
 ///
-/// The key can be change. Changing the Network Key is a secure way of removing
+/// The key can be changed. Changing the Network Key is a secure way of removing
 /// Nodes from a mesh network. The procedure of changing a Network Key is called
 /// Key Refresh Procedure (KRP). Nodes that are not part of KRP are effectively
 /// excluded from the mesh network and may no longer send messages on given subnet.

--- a/nRFMeshProvision/Classes/Mesh Model/NodeIdentity.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/NodeIdentity.swift
@@ -1,0 +1,170 @@
+/*
+* Copyright (c) 2023, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import CoreBluetooth
+
+/// The Node Identity structure contains information from Node Identity or
+/// Private Node Identity beacon.
+///
+/// It can be used to match advertising device to a specific ``Node`` in the network.
+///
+/// - since: 3.3.0
+public protocol NodeIdentity {
+    /// Returns whether the identity matches given ``Node``.
+    ///
+    /// - parameter node: The Node to check.
+    /// - returns: True, if the identity matches the Node; false otherwise.
+    func matches(node: Node) -> Bool
+}
+
+/// Representation of Node Identity advertising packet.
+public struct PublicNodeIdentity: NodeIdentity {
+    /// Function of the included random number and identity information.
+    public let hash: Data
+    /// 64-bit random number.
+    public let random: Data
+    
+    /// Creates the Node Identity object from Hash and Random values.
+    /// - parameters:
+    ///   - hash: Function of the included random number and identity information.
+    ///   - random: 64-bit random number.
+    public init(hash: Data, random: Data) {
+        self.hash = hash
+        self.random = random
+    }
+    
+    /// Creates the Node Identity object from the received advertisement data.
+    ///
+    /// - parameter advertisementData: Received advertisement data.
+    public init?(advertisementData: [String : Any]) {
+        guard let serviceData = advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID : Data],
+              let data = serviceData[MeshProxyService.uuid] else {
+            return nil
+        }
+        guard data.count == 17, data[0] == 0x01 else {
+            return nil
+        }
+        self.init(hash: data.subdata(in: 1..<9), random: data.subdata(in: 9..<17))
+    }
+    
+    public func matches(node: Node) -> Bool {
+        // Data are: 48 bits of Padding (0s), 64 bit Random and Unicast Address.
+        let data = Data(repeating: 0, count: 6) + random + node.primaryUnicastAddress.bigEndian
+        
+        for networkKey in node.networkKeys {
+            let calculatedHash = Crypto.calculateHash(from: data,
+                                                      usingIdentityKey: networkKey.keys.identityKey)
+            if calculatedHash == hash {
+                return true
+            }
+            // If the Key Refresh Procedure is in place, the identity might have been
+            // generated with the old key.
+            if let oldIdentityKey = networkKey.oldKeys?.identityKey {
+                let calculatedHash = Crypto.calculateHash(from: data,
+                                                          usingIdentityKey: oldIdentityKey)
+                if calculatedHash == hash {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+}
+
+/// Representation of Private Node Identity advertising packet.
+public struct PrivateNodeIdentity: NodeIdentity {
+    /// Function of the included random number and identity information.
+    public let hash: Data
+    /// 64-bit random number.
+    public let random: Data
+    
+    /// Creates the Private Node Identity object from Hash and Random values.
+    /// - parameters:
+    ///   - hash: Function of the included random number and identity information.
+    ///   - random: 64-bit random number.
+    public init(hash: Data, random: Data) {
+        self.hash = hash
+        self.random = random
+    }
+    
+    /// Creates the Private Node Identity object from the received advertisement data.
+    ///
+    /// - parameter advertisementData: Received advertisement data.
+    public init?(advertisementData: [String : Any]) {
+        guard let serviceData = advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID : Data],
+              let data = serviceData[MeshProxyService.uuid] else {
+            return nil
+        }
+        guard data.count == 17, data[0] == 0x03 else {
+            return nil
+        }
+        self.init(hash: data.subdata(in: 1..<9), random: data.subdata(in: 9..<17))
+    }
+    
+    public func matches(node: Node) -> Bool {
+        // Data are: 40 bits of Padding (0s), 0x03, 64 bit Random and Unicast Address.
+        let data = Data(repeating: 0, count: 5) + Data([0x03]) + random + node.primaryUnicastAddress.bigEndian
+        
+        for networkKey in node.networkKeys {
+            let calculatedHash = Crypto.calculateHash(from: data,
+                                                      usingIdentityKey: networkKey.keys.identityKey)
+            if calculatedHash == hash {
+                return true
+            }
+            // If the Key Refresh Procedure is in place, the identity might have been
+            // generated with the old key.
+            if let oldIdentityKey = networkKey.oldKeys?.identityKey {
+                let calculatedHash = Crypto.calculateHash(from: data,
+                                                          usingIdentityKey: oldIdentityKey)
+                if calculatedHash == hash {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+}
+
+extension PublicNodeIdentity: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return "Node Identity (hash: 0x\(hash.hex), 0xrandom: \(random.hex))"
+    }
+    
+}
+
+extension PrivateNodeIdentity: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        return "Private Node Identity (hash: 0x\(hash.hex), random: 0x\(random.hex))"
+    }
+    
+}

--- a/nRFMeshProvision/Classes/Mesh Model/NodeIdentityState.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/NodeIdentityState.swift
@@ -33,7 +33,7 @@ import Foundation
 /// The Node Identity state determines if a node is advertising with Node Identity
 /// messages on a subnet. If the Mesh Proxy Service is exposed, the node can be
 /// configured to advertise with Node Identity on a subnet.
-public enum NodeIdentity: UInt8 {
+public enum NodeIdentityState: UInt8 {
     /// Advertising with Node Identity for a subnet is stopped.
     case stopped      = 0x00
     /// Advertising with Node Identity for a subnet is running.
@@ -42,7 +42,7 @@ public enum NodeIdentity: UInt8 {
     case notSupported = 0x02
 }
 
-extension NodeIdentity: CustomDebugStringConvertible {
+extension NodeIdentityState: CustomDebugStringConvertible {
     
     public var debugDescription: String {
         switch self {

--- a/nRFMeshProvision/Classes/Provisioning/Oob.swift
+++ b/nRFMeshProvision/Classes/Provisioning/Oob.swift
@@ -29,6 +29,7 @@
 */
 
 import Foundation
+import CoreBluetooth
 
 /// Information that points to Out-Of-Band (OOB) information
 /// needed for provisioning.
@@ -49,8 +50,24 @@ public struct OobInformation: OptionSet {
     public static let insideManual   = OobInformation(rawValue: 1 << 14)
     public static let onDevice       = OobInformation(rawValue: 1 << 15)
     
+    /// Creates the object from the raw data.
     public init(rawValue: UInt16) {
         self.rawValue = rawValue
+    }
+    
+    /// Creates the object from the advertisement data.
+    ///
+    /// - parameter advertisementData: Received advertisement data.
+    public init?(advertisementData: [String : Any]) {
+        guard let serviceData = advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID : Data],
+              let data = serviceData[MeshProvisioningService.uuid] else {
+                return nil
+        }
+        guard data.count == 18 else {
+            return nil
+        }
+        
+        rawValue = data.read(fromOffset: 16)
     }
     
 }

--- a/nRFMeshProvision/Classes/Utils/Beacon.swift
+++ b/nRFMeshProvision/Classes/Utils/Beacon.swift
@@ -75,10 +75,27 @@ public extension Dictionary where Key == String, Value == Any {
     
     /// Returns the Network ID from a packet of a provisioned Node
     /// with Proxy capabilities, or `nil` if such value not be parsed.
+    ///
+    /// - note: Before version 3.3.0 this property returned Data object.
+    ///         The API changed was made due to introduction of Private Network Identity
+    ///         advertising packets, which don't contain the Network ID directly,
+    ///         but still can identify a network cryptographicaly.
+    /// - seeAlso: ``NetworkIdentity/matches(networkKey:)``
+    /// - seeAlso: ``MeshNetwork/matches(networkIdentity:)``
+    /// - since: 3.3.0
+    var networkIdentity: NetworkIdentity? {
+        return PublicNetworkIdentity(advertisementData: self) ?? PrivateNetworkIdentity(advertisementData: self)
+    }
+    
+    /// Returns the Network ID from a packet of a provisioned Node
+    /// with Proxy capabilities, or `nil` if such value not be parsed.
+    ///
+    /// - seeAlso: ``MeshNetwork/matches(networkId:)``
+    @available(*, deprecated, renamed: "networkIdentity")
     var networkId: Data? {
         guard let serviceData = self[CBAdvertisementDataServiceDataKey] as? [CBUUID : Data],
               let data = serviceData[MeshProxyService.uuid] else {
-                return nil
+            return nil
         }
         guard data.count == 9, data[0] == 0x00 else {
             return nil
@@ -86,17 +103,14 @@ public extension Dictionary where Key == String, Value == Any {
         return data.subdata(in: 1..<9)
     }
     
-    /// Returns the Hash and Random fields from the Node Identity beacon data
-    /// or `nil` if such value was not parsed.
-    var nodeIdentity: (hash: Data, random: Data)? {
-        guard let serviceData = self[CBAdvertisementDataServiceDataKey] as? [CBUUID : Data],
-            let data = serviceData[MeshProxyService.uuid] else {
-                return nil
-        }
-        guard data.count == 17, data[0] == 0x01 else {
-            return nil
-        }
-        return (hash: data.subdata(in: 1..<9), random: data.subdata(in: 9..<17))
+    /// Returns the Node Identity beacon data or `nil` if such value was not parsed.
+    ///
+    /// - note: Before version 3.3.0 this property returned Hash and Random pair.
+    /// - seeAlso: ``NodeIdentity/matches(node:)``
+    /// - seeAlso: ``MeshNetwork/node(matchingNodeIdentity:)``
+    /// - since: 3.3.0
+    var nodeIdentity: NodeIdentity? {
+        return PublicNodeIdentity(advertisementData: self) ?? PrivateNodeIdentity(advertisementData: self)
     }
 }
 

--- a/nRFMeshProvision/Classes/Utils/Beacon.swift
+++ b/nRFMeshProvision/Classes/Utils/Beacon.swift
@@ -61,16 +61,7 @@ public extension Dictionary where Key == String, Value == Any {
     /// This value is taken from the Service Data with Mesh Provisioning Service
     /// UUID. The last 2 bytes are parsed and returned as ``OobInformation``.
     var oobInformation: OobInformation? {
-        guard let serviceData = self[CBAdvertisementDataServiceDataKey] as? [CBUUID : Data],
-              let data = serviceData[MeshProvisioningService.uuid] else {
-                return nil
-        }
-        guard data.count == 18 else {
-            return nil
-        }
-        
-        let rawValue: UInt16 = data.read(fromOffset: 16)
-        return OobInformation(rawValue: rawValue)
+        return OobInformation(advertisementData: self)
     }
     
     /// Returns the Network ID from a packet of a provisioned Node


### PR DESCRIPTION
This PR adds support for Private Beacons, which are a part of Mesh Protocol 1.1.

Private beacons contain the same information as Secure Network beacons, but are obfuscated using a new Private Beacon key.

Tasks:
- [x] Decoding and authenticating beacons
- [x] Tests
- [x] Applying data from received beacon