### PR TITLE
Transition time improvements

### DIFF
--- a/Example/Source/Mesh Network/GenericDefaultTransitionTimeClientDelegate.swift
+++ b/Example/Source/Mesh Network/GenericDefaultTransitionTimeClientDelegate.swift
@@ -45,6 +45,12 @@ class GenericDefaultTransitionTimeClientDelegate: ModelDelegate {
         }
     }
     
+    /// This property represents the Default Transition Time State.
+    ///
+    /// Setting the value will publish a Generic Default Transition Time Set Unacknowleged
+    /// message if publication was set for the model.
+    ///
+    /// Initially, the value is "unknown time".
     var defaultTransitionTime: TransitionTime = TransitionTime() {
         didSet {
             publish(using: MeshNetworkManager.instance)

--- a/Example/Source/Mesh Network/GenericState.swift
+++ b/Example/Source/Mesh Network/GenericState.swift
@@ -81,11 +81,12 @@ struct GenericState<T: Equatable> {
     }
     
     init(transitionFrom state: GenericState<T>, to targetValue: T,
-         delay: TimeInterval, duration: TimeInterval,
+         delay: TimeInterval, duration: TimeInterval?,
          storedWithScene: Bool = false) {
         self.animation = nil
         self.storedWithScene = storedWithScene
-        guard delay > 0 || duration > 0 else {
+        guard let duration = duration,
+              delay > 0 || duration > 0 else {
             self.value = targetValue
             self.transition = nil
             return
@@ -101,11 +102,12 @@ struct GenericState<T: Equatable> {
     }
     
     init(continueTransitionFrom state: GenericState<T>, to targetValue: T,
-         delay: TimeInterval, duration: TimeInterval,
+         delay: TimeInterval, duration: TimeInterval?,
          storedWithScene: Bool = false) {
         self.animation = nil
         self.storedWithScene = storedWithScene
-        guard delay > 0 || duration > 0 else {
+        guard let duration = duration,
+              delay > 0 || duration > 0 else {
             self.value = targetValue
             self.transition = nil
             return
@@ -131,11 +133,12 @@ struct GenericState<T: Equatable> {
 extension GenericState where T: BinaryInteger {
     
     init(transitionFrom state: GenericState<T>, to targetValue: T,
-         delay: TimeInterval, duration: TimeInterval,
+         delay: TimeInterval, duration: TimeInterval?,
          storedWithScene: Bool = false) {
         self.animation = nil
         self.storedWithScene = storedWithScene
-        guard delay > 0 || duration > 0 else {
+        guard let duration = duration,
+              delay > 0 || duration > 0 else {
             self.value = targetValue
             self.transition = nil
             return
@@ -151,11 +154,12 @@ extension GenericState where T: BinaryInteger {
     }
     
     init(continueTransitionFrom state: GenericState<T>, to targetValue: T,
-         delay: TimeInterval, duration: TimeInterval,
+         delay: TimeInterval, duration: TimeInterval?,
          storedWithScene: Bool = false) {
         self.animation = nil
         self.storedWithScene = storedWithScene
-        guard delay > 0 || duration > 0 else {
+        guard let duration = duration,
+              delay > 0 || duration > 0 else {
             self.value = targetValue
             self.transition = nil
             return
@@ -177,12 +181,13 @@ extension GenericState where T: BinaryInteger {
     }
     
     init(animateFrom state: GenericState<T>, to targetValue: T,
-         delay: TimeInterval, duration: TimeInterval,
+         delay: TimeInterval, duration: TimeInterval?,
          storedWithScene: Bool = false) {
         self.value = state.value
         self.transition = nil
         self.storedWithScene = storedWithScene
-        guard state.value != targetValue, duration > 0 else {
+        guard let duration = duration,
+              state.value != targetValue, duration > 0 else {
             self.animation = nil
             return
         }

--- a/Example/Source/Mesh Network/SceneServerDelegate.swift
+++ b/Example/Source/Mesh Network/SceneServerDelegate.swift
@@ -161,7 +161,7 @@ class SceneServerDelegate: SceneServerModelDelegate {
             if transitionTime.isImmediate {
                 currentScene = request.scene
             } else {
-                let complete = Date(timeIntervalSinceNow: transitionTime.interval + TimeInterval(delay) * 0.005)
+                let complete = Date(timeIntervalSinceNow: transitionTime.interval! + TimeInterval(delay) * 0.005)
                 targetScene = (scene: request.scene, complete: complete)
                 currentScene = .invalidScene
             }
@@ -234,7 +234,7 @@ class SceneServerDelegate: SceneServerModelDelegate {
             if transitionTime.isImmediate {
                 currentScene = request.scene
             } else {
-                let complete = Date(timeIntervalSinceNow: transitionTime.interval + TimeInterval(delay) * 0.005)
+                let complete = Date(timeIntervalSinceNow: transitionTime.interval! + TimeInterval(delay) * 0.005)
                 targetScene = (scene: request.scene, complete: complete)
                 currentScene = .invalidScene
             }

--- a/Example/Source/View Controllers/Network/Configuration/Model/GenericLevelViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/GenericLevelViewCell.swift
@@ -140,8 +140,8 @@ class GenericLevelViewCell: ModelViewCell {
             currentStatusLabel.text = "\(Int(level))%"
             if let targetLevel = status.targetLevel, let remainingTime = status.remainingTime {
                 let level = floorf(0.1 + (Float(targetLevel) + 32768.0) / 655.35)
-                if remainingTime.isKnown {
-                    targetStatusLabel.text = "\(Int(level))% in \(remainingTime.interval) sec"
+                if let interval = remainingTime.interval {
+                    targetStatusLabel.text = "\(Int(level))% in \(interval) sec"
                 } else {
                     targetStatusLabel.text = "\(Int(level))% in unknown time"
                 }

--- a/Example/Source/View Controllers/Network/Configuration/Model/GenericOnOffViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/GenericOnOffViewCell.swift
@@ -105,8 +105,8 @@ class GenericOnOffViewCell: ModelViewCell {
         case let status as GenericOnOffStatus:
             currentStatusLabel.text = status.isOn ? "ON" : "OFF"
             if let targetStatus = status.targetState, let remainingTime = status.remainingTime {
-                if remainingTime.isKnown {
-                    targetStatusLabel.text = "\(targetStatus ? "ON" : "OFF") in \(remainingTime.interval) sec"
+                if let interval = remainingTime.interval {
+                    targetStatusLabel.text = "\(targetStatus ? "ON" : "OFF") in \(interval) sec"
                 } else {
                     targetStatusLabel.text = "\(targetStatus ? "ON" : "OFF") in unknown time"
                 }

--- a/nRFMeshProvision/Classes/Mesh Model/Publish.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Publish.swift
@@ -58,7 +58,8 @@ public struct Publish: Codable {
         public let count: UInt8
         /// The interval (in milliseconds) between retransmissions (50...1600 with step 50).
         public let interval: UInt16
-        /// Retransmission steps, from 0 to 31. Use `interval` to get the interval in ms.
+        /// Retransmission steps, from 0 to 31. Use ``Publish/Retransmit-swift.struct/interval``
+        /// to get the interval in ms.
         public var steps: UInt8 {
             return UInt8((interval / 50) - 1)
         }

--- a/nRFMeshProvision/Classes/Mesh Model/StepResolution.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/StepResolution.swift
@@ -30,7 +30,8 @@
 
 import Foundation
 
-/// The Step Resolution field enumerates the resolution of the Number of Steps field,
+/// The Step Resolution field enumerates the resolution of the Number of Steps field
+/// in ``TransitionTime`` or ``Publish/Period-swift.struct``.
 public enum StepResolution: UInt8 {
     /// The Step Resolution is 100 milliseconds.
     case hundredsOfMilliseconds = 0b00

--- a/nRFMeshProvision/Classes/Mesh Model/TransitionTime.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/TransitionTime.swift
@@ -43,11 +43,21 @@ public struct TransitionTime {
     public let stepResolution: StepResolution
     
     /// The transition time in milliseconds.
-    public var milliseconds: Int {
+    ///
+    /// `nil` value represents an unknown time.
+    public var milliseconds: Int? {
+        guard steps != 0x3F else {
+            return nil
+        }
         return stepResolution.toMilliseconds(steps: steps & 0x3F)
     }
     /// The transition time as `TimeInterval` in seconds.
-    public var interval: TimeInterval {
+    ///
+    /// `nil` value represents an unknown time.
+    public var interval: TimeInterval? {
+        guard let milliseconds = milliseconds else {
+            return nil
+        }
         return TimeInterval(milliseconds) / 1000.0
     }
     

--- a/nRFMeshProvision/Classes/Mesh Model/TransitionTime.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/TransitionTime.swift
@@ -113,7 +113,7 @@ public extension TransitionTime {
     /// Unknown transition time.
     ///
     /// This can not be used as default transition time.
-    static let unknown = TransitionTime(steps: 0x3F, stepResolution: .tensOfMinutes)
+    static let unknown = TransitionTime()
     
     /// Returns whether the transition time is known.
     var isKnown: Bool {

--- a/nRFMeshProvision/Classes/Mesh Model/TransitionTime.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/TransitionTime.swift
@@ -30,6 +30,11 @@
 
 import Foundation
 
+/// This stucture represents a time needed to transition from one state to another,
+/// for example dimming a light.
+///
+/// Internally, it uses steps and step resolution. Thanks to that only some time
+/// intervals are possible. Use ``TransitionTime/interval`` to get exact time
 public struct TransitionTime {
     /// Transition Number of Steps, 6-bit value.
     ///
@@ -71,6 +76,8 @@ public struct TransitionTime {
     /// Only values of 0x00 through 0x3E shall be used to specify the value
     /// of the Transition Number of Steps field.
     ///
+    /// - note: Use ``TransitionTime/init()`` to create a Transition Time
+    ///         representing an unknow time.
     /// - parameter steps: Transition Number of Steps, valid values are in
     ///                    range 0...62. Value 63 means that the value is
     ///                    unknown and the state cannot be set to this value.
@@ -87,6 +94,12 @@ public struct TransitionTime {
     }
     
     /// Creates the Transition Time object for the `TimeInterval`.
+    ///
+    /// - note: Mind, that the transition time will be converted to steps
+    ///         and step resolution using rounding. Check implementation
+    ///         for details.
+    ///
+    /// - parameter interval: The transiton time in seconds.
     public init(_ interval: TimeInterval) {
         switch interval {
         case let interval where interval <= 0:


### PR DESCRIPTION
This PR slightly changes the API of `TransitionTime`. The `milliseconds` and `interval` fields can now return `nil` if the value is "unknown" *(steps = 0x3F).