### PR TITLE
Showing related (base and extending) models

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1018,6 +1018,7 @@
 		EE85A051003338DEEFC47D56271705C3 /* MeshNetwork+Scenes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MeshNetwork+Scenes.swift"; sourceTree = "<group>"; };
 		EE97BE77EA799B9150105B1D58257380 /* SceneRegisterGet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneRegisterGet.swift; sourceTree = "<group>"; };
 		F00BDBCD0D3166FDBFF9DA168EC7EE71 /* ConfigKeyRefreshPhaseSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigKeyRefreshPhaseSet.swift; sourceTree = "<group>"; };
+		F085C9FE29CC748100C2DF89 /* Unique.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Unique.swift; sourceTree = "<group>"; };
 		F0C3660A28D8FF910017F22E /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
 		F141ABC372814AD7C3B42351BCC012F0 /* Data.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		F1B92E125B44E1EBDBC14DC54EC22AF5 /* NetworkLayer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkLayer.swift; sourceTree = "<group>"; };

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -472,6 +472,7 @@
 		EDC9CE9A4C3F5931540CFD4D58598481 /* String Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692D1EC047A1DE0CF09A65F37F570AA4 /* String Conversion.swift */; };
 		EE2E8C944B6BC296F7697C50DDF2669E /* Provisioner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC37D4B2AC79FD72299452C85669A2D /* Provisioner.swift */; };
 		EFEC7D3012E608336D9BD3563DFCEFE9 /* ConfigRelayStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0EBFE12B307EBE72B9B69D6D55F7CC /* ConfigRelayStatus.swift */; };
+		F085C9FF29CC748100C2DF89 /* Unique.swift in Sources */ = {isa = PBXBuildFile; fileRef = F085C9FE29CC748100C2DF89 /* Unique.swift */; };
 		F0C3660B28D8FF910017F22E /* Documentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = F0C3660A28D8FF910017F22E /* Documentation.docc */; };
 		F0FD71263E69F31C310C2594A8402E86 /* ConfigModelAppStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D31946D8C70F98A3B12CCC0F147376C /* ConfigModelAppStatus.swift */; };
 		F3469F1B9BE6D193EA4A4C5D9E52F10D /* MeshConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7142EB111A7480EB29540FBF16494D /* MeshConstants.swift */; };
@@ -1890,6 +1891,7 @@
 			isa = PBXGroup;
 			children = (
 				E4E77EBBA8A0B719CCD42C6A401CC8FF /* ClosedRange.swift */,
+				F085C9FE29CC748100C2DF89 /* Unique.swift */,
 				F141ABC372814AD7C3B42351BCC012F0 /* Data.swift */,
 				DB94A37AAAC21871A5BF2DFE75F01E64 /* Data+Hex.swift */,
 				3F25FDE6F08DB17150FE99E03B63E5EC /* Data+Keys.swift */,
@@ -2356,6 +2358,7 @@
 				6C8331341F87B3DF78B6FA1D658559A7 /* GenericOnPowerUpSetUnacknowledged.swift in Sources */,
 				6E831781ABE7247F7F2C18E72F981F37 /* GenericOnPowerUpStatus.swift in Sources */,
 				56FDB25A923E91295EF015CB90553653 /* GenericPowerDefaultSet.swift in Sources */,
+				F085C9FF29CC748100C2DF89 /* Unique.swift in Sources */,
 				85F2019A0117BF1F546496F6CBAC2E3B /* GenericPowerDefaultSetUnacknowledged.swift in Sources */,
 				B540DD4A8ECFAAA3C01623E493FCAD6C /* GenericPowerDefaultStatus.swift in Sources */,
 				7D0A3D875B01A1D62672F7097023077A /* GenericPowerDefautGet.swift in Sources */,

--- a/Example/Source/UI/Base.lproj/Subscribe.storyboard
+++ b/Example/Source/UI/Base.lproj/Subscribe.storyboard
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="qEN-zs-Gdv">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Subscribe-->
+        <scene sceneID="FHI-sr-Ai4">
+            <objects>
+                <tableViewController id="qj8-rY-EMa" customClass="SubscribeViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="ZCH-U2-rnQ">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="group" textLabel="qGJ-q6-tac" imageView="2uI-i4-AHX" style="IBUITableViewCellStyleDefault" id="9xQ-3Q-vvq">
+                                <rect key="frame" x="0.0" y="38" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="9xQ-3Q-vvq" id="33E-IW-2hh">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qGJ-q6-tac">
+                                            <rect key="frame" x="59" y="0.0" width="335" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="ic_group_24pt" id="2uI-i4-AHX">
+                                            <rect key="frame" x="20" y="9.5" width="24" height="24"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </imageView>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="action" textLabel="IHh-sT-StB" style="IBUITableViewCellStyleDefault" id="Dcg-1z-usk">
+                                <rect key="frame" x="0.0" y="81.5" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Dcg-1z-usk" id="Fjf-KM-mdd">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Add Group" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="IHh-sT-StB">
+                                            <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="qj8-rY-EMa" id="KYK-RQ-Ydf"/>
+                            <outlet property="delegate" destination="qj8-rY-EMa" id="8nZ-jV-TvI"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Subscribe" id="ZNa-lX-txK">
+                        <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="BlV-Vl-QfJ">
+                            <connections>
+                                <action selector="cancelTapped:" destination="qj8-rY-EMa" id="bHq-Gv-qMB"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" systemItem="done" id="yqm-Ux-NkK">
+                            <connections>
+                                <action selector="doneTapped:" destination="qj8-rY-EMa" id="7zI-cI-vCa"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="doneButton" destination="yqm-Ux-NkK" id="blp-AZ-FR9"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ik0-CZ-c76" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5934" y="-2563"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="T7d-wd-neH">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="qEN-zs-Gdv" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="0Pz-HX-4Y1">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="108"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="tintColor" red="0.0" green="0.66274509800000003" blue="0.80784313730000001" alpha="1" colorSpace="calibratedRGB"/>
+                        <textAttributes key="titleTextAttributes">
+                            <color key="textColor" red="0.0" green="0.66274509800000003" blue="0.80784313730000001" alpha="1" colorSpace="calibratedRGB"/>
+                        </textAttributes>
+                        <textAttributes key="largeTitleTextAttributes">
+                            <color key="textColor" red="0.0" green="0.66274509800000003" blue="0.80784313730000001" alpha="1" colorSpace="calibratedRGB"/>
+                        </textAttributes>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="qj8-rY-EMa" kind="relationship" relationship="rootViewController" id="f7b-t0-tS3"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="5IB-ng-44o" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4991" y="-2564"/>
+        </scene>
+    </scenes>
+    <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+    <resources>
+        <image name="ic_group_24pt" width="24" height="24"/>
+    </resources>
+</document>

--- a/Example/Source/UI/Base.lproj/Subscribe~.storyboard
+++ b/Example/Source/UI/Base.lproj/Subscribe~.storyboard
@@ -449,12 +449,12 @@
             <objects>
                 <tableViewController id="veF-nS-gn0" customClass="ModelViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="huL-bC-LUM">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="752"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="normal" textLabel="3p5-Ls-7HB" detailTextLabel="WZp-yu-SUw" style="IBUITableViewCellStyleValue1" id="iMu-ff-fDV">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="normal" textLabel="3p5-Ls-7HB" detailTextLabel="WZp-yu-SUw" style="IBUITableViewCellStyleValue1" id="iMu-ff-fDV">
+                                <rect key="frame" x="0.0" y="38" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="iMu-ff-fDV" id="Txb-p3-m6q">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -478,7 +478,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="key" textLabel="Ivw-Zk-1Ri" detailTextLabel="J04-h7-HNa" imageView="SVn-ht-AO0" style="IBUITableViewCellStyleSubtitle" id="otu-JZ-HV0">
-                                <rect key="frame" x="0.0" y="99" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="81.5" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="otu-JZ-HV0" id="NgI-An-9RZ">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -506,7 +506,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="destination" rowHeight="123" id="Spq-Ja-fLm" customClass="PublicationCell" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="154.5" width="414" height="123"/>
+                                <rect key="frame" x="0.0" y="137" width="414" height="123"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Spq-Ja-fLm" id="kqG-5g-2cX">
                                     <rect key="frame" x="0.0" y="0.0" width="383.5" height="123"/>
@@ -586,7 +586,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="heartbeatPublication" rowHeight="123" id="099-xq-uYk" customClass="HeartbeatPublicationCell" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="277.5" width="414" height="123"/>
+                                <rect key="frame" x="0.0" y="260" width="414" height="123"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="099-xq-uYk" id="LS7-zd-726">
                                     <rect key="frame" x="0.0" y="0.0" width="383.5" height="123"/>
@@ -659,7 +659,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="group" textLabel="1oJ-fF-jyJ" detailTextLabel="Ezb-Bc-f95" imageView="hHF-iP-OqZ" style="IBUITableViewCellStyleSubtitle" id="ZHd-AD-r5e">
-                                <rect key="frame" x="0.0" y="400.5" width="414" height="55.5"/>
+                                <rect key="frame" x="0.0" y="383" width="414" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZHd-AD-r5e" id="erD-pz-EdV">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="55.5"/>
@@ -687,7 +687,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="value" id="ewv-CT-3vO" customClass="SensorValueCell" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="456" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="438.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ewv-CT-3vO" id="kUc-HY-AEY">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -725,7 +725,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="heartbeatSubscription" rowHeight="117" id="7eN-W8-bl6" customClass="HeartbeatSubscriptionCell" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="499.5" width="414" height="117"/>
+                                <rect key="frame" x="0.0" y="482" width="414" height="117"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="7eN-W8-bl6" id="Sv5-p2-DUR">
                                     <rect key="frame" x="0.0" y="0.0" width="383.5" height="117"/>
@@ -797,7 +797,7 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="action" textLabel="Wih-3i-ZYO" style="IBUITableViewCellStyleDefault" id="Coq-iZ-Cul">
-                                <rect key="frame" x="0.0" y="616.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="599" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Coq-iZ-Cul" id="A6y-Hp-Rsk">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -814,7 +814,7 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="rightAction" id="Q6u-8W-cen" customClass="RightActionCell" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="660" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="642.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Q6u-8W-cen" id="tVO-gC-OXg">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -842,21 +842,21 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="switch" id="ukA-iV-k75" customClass="SwitchCell" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="703.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="686" width="414" height="43"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ukA-iV-k75" id="q0I-rL-LSs">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P1w-ws-FGk">
-                                            <rect key="frame" x="345" y="6.5" width="51" height="31"/>
+                                            <rect key="frame" x="345" y="6" width="51" height="31"/>
                                             <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                             <connections>
                                                 <action selector="switchDidChange:" destination="ukA-iV-k75" eventType="valueChanged" id="PJe-b6-sbf"/>
                                             </connections>
                                         </switch>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pqx-lg-qPZ">
-                                            <rect key="frame" x="20" y="11" width="33" height="21.5"/>
+                                            <rect key="frame" x="20" y="11" width="33" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -886,10 +886,9 @@
                     <connections>
                         <segue destination="gj6-4N-egc" kind="presentation" identifier="bind" id="wef-vj-jmc"/>
                         <segue destination="QcC-OJ-A1T" kind="presentation" identifier="publish" id="lgy-G5-iSO"/>
-                        <segue destination="NR1-PM-pYj" kind="presentation" identifier="subscribe" id="nXr-vx-Zp4"/>
+                        <segue destination="qEN-zs-Gdv" kind="presentation" identifier="subscribe" id="nXr-vx-Zp4"/>
                         <segue destination="tgQ-Xv-xEj" kind="presentation" identifier="heartbeatPublication" id="yv6-5C-nxN"/>
                         <segue destination="VIe-pF-jd2" kind="presentation" identifier="heartbeatSubscription" id="NNM-0Y-mx6"/>
-                        <segue destination="bJQ-aJ-Li6" kind="show" identifier="related" id="p59-pA-hy7"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ue8-ug-zxs" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1933,6 +1932,79 @@
             </objects>
             <point key="canvasLocation" x="5934" y="-3369"/>
         </scene>
+        <!--Subscribe-->
+        <scene sceneID="FHI-sr-Ai4">
+            <objects>
+                <tableViewController id="qj8-rY-EMa" customClass="SubscribeViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="ZCH-U2-rnQ">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="group" textLabel="qGJ-q6-tac" imageView="2uI-i4-AHX" style="IBUITableViewCellStyleDefault" id="9xQ-3Q-vvq">
+                                <rect key="frame" x="0.0" y="38" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="9xQ-3Q-vvq" id="33E-IW-2hh">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qGJ-q6-tac">
+                                            <rect key="frame" x="59" y="0.0" width="335" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="ic_group_24pt" id="2uI-i4-AHX">
+                                            <rect key="frame" x="20" y="9.5" width="24" height="24"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </imageView>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="action" textLabel="IHh-sT-StB" style="IBUITableViewCellStyleDefault" id="Dcg-1z-usk">
+                                <rect key="frame" x="0.0" y="81.5" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Dcg-1z-usk" id="Fjf-KM-mdd">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Add Group" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="IHh-sT-StB">
+                                            <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <color key="textColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="qj8-rY-EMa" id="KYK-RQ-Ydf"/>
+                            <outlet property="delegate" destination="qj8-rY-EMa" id="8nZ-jV-TvI"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Subscribe" id="ZNa-lX-txK">
+                        <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="BlV-Vl-QfJ">
+                            <connections>
+                                <action selector="cancelTapped:" destination="qj8-rY-EMa" id="bHq-Gv-qMB"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" systemItem="done" id="yqm-Ux-NkK">
+                            <connections>
+                                <action selector="doneTapped:" destination="qj8-rY-EMa" id="7zI-cI-vCa"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="doneButton" destination="yqm-Ux-NkK" id="blp-AZ-FR9"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ik0-CZ-c76" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5934" y="-2563"/>
+        </scene>
         <!--Navigation Controller-->
         <scene sceneID="Plj-og-MKj">
             <objects>
@@ -1966,13 +2038,38 @@
             </objects>
             <point key="canvasLocation" x="4272" y="-2472"/>
         </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="T7d-wd-neH">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="qEN-zs-Gdv" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="0Pz-HX-4Y1">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="108"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <color key="tintColor" red="0.0" green="0.66274509800000003" blue="0.80784313730000001" alpha="1" colorSpace="calibratedRGB"/>
+                        <textAttributes key="titleTextAttributes">
+                            <color key="textColor" red="0.0" green="0.66274509800000003" blue="0.80784313730000001" alpha="1" colorSpace="calibratedRGB"/>
+                        </textAttributes>
+                        <textAttributes key="largeTitleTextAttributes">
+                            <color key="textColor" red="0.0" green="0.66274509800000003" blue="0.80784313730000001" alpha="1" colorSpace="calibratedRGB"/>
+                        </textAttributes>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="qj8-rY-EMa" kind="relationship" relationship="rootViewController" id="f7b-t0-tS3"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="5IB-ng-44o" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4991" y="-2564"/>
+        </scene>
         <!--SetHeartbeatPublication-->
         <scene sceneID="St8-M8-80k">
             <objects>
                 <viewControllerPlaceholder storyboardName="SetHeartbeatPublication" id="tgQ-Xv-xEj" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ka4-yk-okS" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3535" y="-2472"/>
+            <point key="canvasLocation" x="3783" y="-2472"/>
         </scene>
         <!--SetHeartbeatSubscription-->
         <scene sceneID="3rf-Iq-Pa7">
@@ -1980,7 +2077,7 @@
                 <viewControllerPlaceholder storyboardName="SetHeartbeatSubscription" id="VIe-pF-jd2" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="JeS-9d-LRx" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3853" y="-2472"/>
+            <point key="canvasLocation" x="4024" y="-2405"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="agc-ec-U0v">
@@ -2167,82 +2264,8 @@
             </objects>
             <point key="canvasLocation" x="4016" y="586"/>
         </scene>
-        <!--Related Models-->
-        <scene sceneID="tRT-UW-1ny">
-            <objects>
-                <tableViewController id="bJQ-aJ-Li6" customClass="RelatedModelsViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="xDS-oc-jOV">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="empty" textLabel="X5S-YF-ACX" style="IBUITableViewCellStyleDefault" id="YnI-t2-Tgh">
-                                <rect key="frame" x="0.0" y="55.5" width="414" height="43.5"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="YnI-t2-Tgh" id="AmS-es-2F3">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="X5S-YF-ACX">
-                                            <rect key="frame" x="20" y="0.0" width="374" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <color key="textColor" systemColor="secondaryLabelColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="model" textLabel="Cxr-AX-hTO" detailTextLabel="hSi-uU-YZM" style="IBUITableViewCellStyleSubtitle" id="qsf-9i-tdd">
-                                <rect key="frame" x="0.0" y="99" width="414" height="55.5"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qsf-9i-tdd" id="BkA-OA-I5v">
-                                    <rect key="frame" x="0.0" y="0.0" width="383.5" height="55.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Cxr-AX-hTO">
-                                            <rect key="frame" x="20" y="10" width="33" height="20.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hSi-uU-YZM">
-                                            <rect key="frame" x="20" y="31.5" width="44" height="14.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                            <color key="textColor" systemColor="secondaryLabelColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="bJQ-aJ-Li6" id="B0b-ep-hdT"/>
-                            <outlet property="delegate" destination="bJQ-aJ-Li6" id="zSb-Gz-L6M"/>
-                        </connections>
-                    </tableView>
-                    <navigationItem key="navigationItem" title="Related Models" id="42e-Je-3i5"/>
-                    <connections>
-                        <segue destination="veF-nS-gn0" kind="show" identifier="details" id="mtt-Te-nBR"/>
-                    </connections>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="07r-z3-GsC" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="5030" y="-2651"/>
-        </scene>
-        <!--Subscribe-->
-        <scene sceneID="vlQ-gk-pzd">
-            <objects>
-                <viewControllerPlaceholder storyboardName="Subscribe" id="NR1-PM-pYj" sceneMemberID="viewController"/>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="jgc-qq-IRl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="4088" y="-2405"/>
-        </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="mtt-Te-nBR"/>
         <segue reference="ThO-5P-90Y"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>

--- a/Example/Source/View Controllers/Network/Configuration/RelatedModelsViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/RelatedModelsViewController.swift
@@ -1,0 +1,193 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import UIKit
+import nRFMeshProvision
+
+class RelatedModelsViewController: UITableViewController {
+    
+    // MARK: - Properties
+    
+    var model: Model!
+    
+    private var sections: [(title: String, models: [Model], emptyText: String?)] = []
+    
+    // MARK: - View Controller
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let directBaseModels = model.directBaseModels
+        let directExtendingModels = model.directExtendingModels
+        
+        // Add Direct Base Models section.
+        let directBaseModelsOnTheSameElement = directBaseModels
+            .filter { $0.parentElement == model.parentElement }
+        let directBaseModelsOnOtherElements = directBaseModels
+            .filter { $0.parentElement != model.parentElement }
+        if !directBaseModelsOnOtherElements.isEmpty || directBaseModelsOnOtherElements.isEmpty {
+            sections.append((
+                title: "Base Models",
+                models: directBaseModelsOnTheSameElement,
+                emptyText: "This model is a root model."
+            ))
+        }
+        
+        // Add Direct Base Models from other Elements.
+        let directBaseModelsPerElement = directBaseModelsOnOtherElements.groupedByElement
+        directBaseModelsPerElement.forEach { element, models in
+            sections.append((
+                title: "Base Models on \(element.name ?? "Element \(element.index + 1)")",
+                models: models,
+                emptyText: nil
+            ))
+        }
+        
+        // Add Direct Extending Models section.
+        let directExtendingModelsOnTheSameElement = directExtendingModels
+            .filter { $0.parentElement == model.parentElement }
+        sections.append((
+            title: "Extending Models",
+            models: directExtendingModelsOnTheSameElement,
+            emptyText: "This model is not extend by other Models."
+        ))
+        
+        // Add Direct Base Models from other Elements.
+        let directExtendingModelsOnOtherElements = directExtendingModels
+            .filter { $0.parentElement != model.parentElement }
+        let directExtendingModelsPerElement = directExtendingModelsOnOtherElements.groupedByElement
+        directExtendingModelsPerElement.forEach { element, models in
+            sections.append((
+                title: "Extending Models on \(element.name ?? "Element \(element.index + 1)")",
+                models: models,
+                emptyText: nil
+            ))
+        }
+        
+        // Other other Related Models per Element.
+        let relatedModels = model.relatedModels
+            .filter { !directBaseModels.contains($0) && !directExtendingModels.contains($0) }
+        let relatedModelsPerElement = relatedModels.groupedByElement
+        relatedModelsPerElement.forEach { element, models in
+            sections.append((
+                title: "Related Models on \(element.name ?? "Element \(element.index + 1)")",
+                models: models,
+                emptyText: nil
+            ))
+        }
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return sections.count
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return max(1, sections[section].models.count)
+    }
+    
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return sections[section].title
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let section = sections[indexPath.section]
+        guard !section.models.isEmpty else {
+            let cell = tableView.dequeueReusableCell(withIdentifier: "empty", for: indexPath)
+            cell.textLabel?.text = section.emptyText
+            return cell
+        }
+        
+        let cell = tableView.dequeueReusableCell(withIdentifier: "model", for: indexPath)
+        let model = section.models[indexPath.row]
+        if model.isBluetoothSIGAssigned {
+            cell.textLabel?.text = model.name ?? "Unknown Model ID: \(model.modelIdentifier.asString())"
+            cell.detailTextLabel?.text = "Bluetooth SIG"
+        } else {
+            cell.textLabel?.text = "Vendor Model ID: \(model.modelIdentifier.asString())"
+            if let companyId = model.companyIdentifier {
+                if let companyName = CompanyIdentifier.name(for: companyId) {
+                    cell.detailTextLabel?.text = companyName
+                } else {
+                    cell.detailTextLabel?.text = "Unknown Company ID (\(companyId.asString()))"
+                }
+            } else {
+                cell.detailTextLabel?.text = "Unknown Company ID"
+            }
+        }
+        return cell
+    }
+    
+    override func tableView(_ tableView: UITableView, shouldHighlightRowAt indexPath: IndexPath) -> Bool {
+        return !sections[indexPath.section].models.isEmpty
+    }
+    
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        
+        performSegue(withIdentifier: "details", sender: indexPath)
+    }
+
+    
+    // MARK: - Navigation
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "details" {
+            let indexPath = sender as! IndexPath
+            let model = sections[indexPath.section].models[indexPath.row]
+            let destination = segue.destination as! ModelViewController
+            destination.model = model
+        }
+    }
+
+}
+
+private extension Array where Element == Model {
+    
+    var groupedByElement: [MeshElement: [Model]] {
+        var map: [MeshElement: [Model]] = [:]
+        
+        forEach { model in
+            if let element = model.parentElement {
+                if map[element] == nil {
+                    map[element] = [model]
+                } else {
+                    map[element]?.append(model)
+                }
+            }
+        }
+        
+        return map
+    }
+    
+}
+
+

--- a/Example/Tests/Addresses.swift
+++ b/Example/Tests/Addresses.swift
@@ -32,27 +32,12 @@ import XCTest
 @testable import nRFMeshProvision
 
 class Addresses: XCTestCase {
-
-    override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
+    
     func testVirtualAddress() {
         let virtualLabel = UUID(uuidString: "0073e7e4-d8b9-440f-af84-15df4c56c0e1")!
         let address = MeshAddress(virtualLabel)
         
         XCTAssertEqual(address.address, 0xB529)
-    }
-
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
     }
 
 }

--- a/Example/Tests/Models.swift
+++ b/Example/Tests/Models.swift
@@ -131,7 +131,7 @@ class Models: XCTestCase {
         let lightLCServer = node.elements[3].model(withSigModelId: .lightLCServerModelId)
         XCTAssertNotNil(lightLCServer)
         
-        let extendedModels = lightLCServer!.extendedModels
+        let extendedModels = lightLCServer!.baseModels
         XCTAssertEqual(extendedModels.count, 5)
         
         let extendingModels = lightLCServer!.extendingModels
@@ -143,7 +143,7 @@ class Models: XCTestCase {
             .model(withSigModelId: .lightLightnessServerModelId)
         XCTAssertNotNil(lightLightnessServer)
         
-        let extendedModels = lightLightnessServer!.extendedModels
+        let extendedModels = lightLightnessServer!.baseModels
         XCTAssertEqual(extendedModels.count, 3)
         
         let extendingModels = lightLightnessServer!.extendingModels

--- a/Example/Tests/Models.swift
+++ b/Example/Tests/Models.swift
@@ -1,0 +1,154 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import XCTest
+@testable import nRFMeshProvision
+
+class Models: XCTestCase {
+    var node: Node!
+    
+    override func setUp() {
+        node = Node(name: "Test Node", unicastAddress: 0x0001, elements: 0)
+        node.add(elements: [
+            Element(models: [
+                // Base models
+                Model(sigModelId: .configurationServerModelId),
+                Model(sigModelId: .healthServerModelId),
+                Model(sigModelId: .genericLevelServerModelId),
+                Model(sigModelId: .genericOnOffServerModelId),
+                Model(sigModelId: .genericDefaultTransitionTimeServerModelId),
+                // Extends Generic OnOff Server model:
+                Model(sigModelId: .genericPowerOnOffServerModelId),
+                // Extends Generic Power OnOff Server model:
+                Model(sigModelId: .genericPowerOnOffSetupServerModelId),
+                // Extends Generic Power OnOff Server and Generic Level Server models:
+                Model(sigModelId: .lightLightnessServerModelId),
+                // Extends Light Lightness Server model:
+                Model(sigModelId: .lightLightnessSetupServerModelId),
+            ]),
+            Element(models: [
+                // Base model:
+                Model(sigModelId: .genericOnOffServerModelId),
+                // Extends Generic OnOff Server on this Element
+                // and Light Lightness Server on Element 0:
+                Model(sigModelId: .lightLCServerModelId),
+                // Extends Light LC Server model:
+                Model(sigModelId: .lightLCSetupServerModelId),
+            ]),
+            Element(models: [
+                // Base models
+                Model(sigModelId: .genericLevelServerModelId),
+                Model(sigModelId: .genericOnOffServerModelId),
+                Model(sigModelId: .genericDefaultTransitionTimeServerModelId),
+                // Extends Generic OnOff Server model:
+                Model(sigModelId: .genericPowerOnOffServerModelId),
+                // Extends Generic Power OnOff Server model:
+                Model(sigModelId: .genericPowerOnOffSetupServerModelId),
+                // Extends Generic Power OnOff Server and Generic Level Server models:
+                Model(sigModelId: .lightLightnessServerModelId),
+                // Extends Light Lightness Server model:
+                Model(sigModelId: .lightLightnessSetupServerModelId),
+            ]),
+            Element(models: [
+                // Base model:
+                Model(sigModelId: .genericOnOffServerModelId),
+                // Extends Generic OnOff Server on this Element
+                // and Light Lightness Server on Element 0:
+                Model(sigModelId: .lightLCServerModelId),
+                // Extends Light LC Server model:
+                Model(sigModelId: .lightLCSetupServerModelId),
+            ])
+        ])
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+    
+    func testConfigServerModel() throws {
+        let configServerModel = node.elements[0].model(withSigModelId: .configurationServerModelId)
+        XCTAssertNotNil(configServerModel)
+        
+        let otherModels = node.elements
+            .flatMap { $0.models }
+            .filter { $0.modelIdentifier != .configurationServerModelId }
+        
+        XCTAssertFalse(otherModels.contains { $0.extendsDirectly(configServerModel!) })
+        XCTAssertFalse(otherModels.contains { configServerModel!.extendsDirectly($0) })
+        XCTAssertFalse(otherModels.contains { $0.extends(configServerModel!) })
+        XCTAssertFalse(otherModels.contains { configServerModel!.extends($0) })
+    }
+    
+    func testGenericPowerOnOffServerModelId() throws {
+        let powerOnOffSetupServer = node.elements[0].model(withSigModelId: .genericPowerOnOffSetupServerModelId)
+        XCTAssertNotNil(powerOnOffSetupServer)
+        
+        let otherModels = node.elements
+            .flatMap { $0.models }
+            .filter { $0.modelIdentifier != .genericPowerOnOffSetupServerModelId }
+        
+        // Generic Power OnOff Setup Server model extends:
+        // - Generic Power OnOff Server model
+        // - Default Transition Time Server model
+        let directBaseModels = otherModels
+            .filter { powerOnOffSetupServer!.extendsDirectly($0) }
+        XCTAssertEqual(directBaseModels.count, 2)
+        // Additionally, Power OnOff Server model extends:
+        // - Generic OnOff Server
+        let baseModels = otherModels
+            .filter { powerOnOffSetupServer!.extends($0) }
+        XCTAssertEqual(baseModels.count, 3)
+    }
+    
+    func testLightLCServer() throws {
+        let lightLCServer = node.elements[3].model(withSigModelId: .lightLCServerModelId)
+        XCTAssertNotNil(lightLCServer)
+        
+        let extendedModels = lightLCServer!.extendedModels
+        XCTAssertEqual(extendedModels.count, 5)
+        
+        let extendingModels = lightLCServer!.extendingModels
+        XCTAssertEqual(extendingModels.count, 1)
+    }
+    
+    func testLightLightnessServer() throws {
+        let lightLightnessServer = node.elements[0]
+            .model(withSigModelId: .lightLightnessServerModelId)
+        XCTAssertNotNil(lightLightnessServer)
+        
+        let extendedModels = lightLightnessServer!.extendedModels
+        XCTAssertEqual(extendedModels.count, 3)
+        
+        let extendingModels = lightLightnessServer!.extendingModels
+        XCTAssertEqual(extendingModels.count, 3)
+    }
+    
+}
+

--- a/Example/nRF Mesh.xcodeproj/project.pbxproj
+++ b/Example/nRF Mesh.xcodeproj/project.pbxproj
@@ -163,6 +163,8 @@
 		A7B526A7277B210000F5C60D /* GenericPowerOnOffSetupViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B526A5277B210000F5C60D /* GenericPowerOnOffSetupViewCell.swift */; };
 		A7B526A8277B210000F5C60D /* GenericPowerOnOffSetup.xib in Resources */ = {isa = PBXBuildFile; fileRef = A7B526A6277B210000F5C60D /* GenericPowerOnOffSetup.xib */; };
 		F085C9FD29CB26B000C2DF89 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = F085C9FC29CB26B000C2DF89 /* Models.swift */; };
+		F085CA0229D1E0B900C2DF89 /* Subscribe.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F085CA0029D1E0B900C2DF89 /* Subscribe.storyboard */; };
+		F085CA0429D1E2B000C2DF89 /* RelatedModelsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F085CA0329D1E2B000C2DF89 /* RelatedModelsViewController.swift */; };
 		F0A79242F997F08105E46FF6 /* Pods_nRF_Mesh_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DAC1677AA94583D28A5867E /* Pods_nRF_Mesh_Tests.framework */; };
 /* End PBXBuildFile section */
 
@@ -351,6 +353,8 @@
 		E7CB7DCE18F6E38D2240310F /* nRFMeshProvision.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = nRFMeshProvision.podspec; path = ../nRFMeshProvision.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		EA733BBB45B56B4142103F0F /* Pods-nRFMeshProvision_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-nRFMeshProvision_Example.debug.xcconfig"; path = "Target Support Files/Pods-nRFMeshProvision_Example/Pods-nRFMeshProvision_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		F085C9FC29CB26B000C2DF89 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
+		F085CA0129D1E0B900C2DF89 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Subscribe.storyboard; sourceTree = "<group>"; };
+		F085CA0329D1E2B000C2DF89 /* RelatedModelsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelatedModelsViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -452,6 +456,7 @@
 				523F778B22CCEA900030EA6A /* SetPublication.storyboard */,
 				52A8EA8924E6A371004C14C7 /* SetHeartbeatPublication.storyboard */,
 				52A8EA9024ED35F4004C14C7 /* SetHeartbeatSubscription.storyboard */,
+				F085CA0029D1E0B900C2DF89 /* Subscribe.storyboard */,
 				52CD0A562330BDE500A9A181 /* Groups.storyboard */,
 				52CD0A592330BF4800A9A181 /* Proxy.storyboard */,
 				5283524E227887970097B949 /* Settings.storyboard */,
@@ -673,6 +678,7 @@
 				52B7FD6C2525B40300308673 /* NodeSceneRecallViewController.swift */,
 				5292F8A4250237A600EA0F2A /* NodeStoreSceneViewController.swift */,
 				523F777822CB57190030EA6A /* ModelViewController.swift */,
+				F085CA0329D1E2B000C2DF89 /* RelatedModelsViewController.swift */,
 				523F777A22CB86A00030EA6A /* ModelBindAppKeyViewController.swift */,
 				523F778622CCDE250030EA6A /* SetPublicationViewController.swift */,
 				523F779622CE2BF60030EA6A /* SetPublicationDestinationsViewController.swift */,
@@ -930,6 +936,7 @@
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
 				A7B526A8277B210000F5C60D /* GenericPowerOnOffSetup.xib in Resources */,
 				52A9C1C62313D7D80036792A /* GenericLevel.xib in Resources */,
+				F085CA0229D1E0B900C2DF89 /* Subscribe.storyboard in Resources */,
 				5231404E230AC4680074325A /* VendorModel.xib in Resources */,
 				5231403C22FDA8670074325A /* ConfigurationServer.xib in Resources */,
 				521599DB25E9306300F602FA /* CHANGELOG.md in Resources */,
@@ -1042,6 +1049,7 @@
 				52E54CE12344974B00478F05 /* GenericLevelClientDelegate.swift in Sources */,
 				5292F8A9250654C600EA0F2A /* SceneSetupServerGroupCell.swift in Sources */,
 				5283528022806C280097B949 /* ProvisioningViewController.swift in Sources */,
+				F085CA0429D1E2B000C2DF89 /* RelatedModelsViewController.swift in Sources */,
 				52CD0A602330D71900A9A181 /* AddAddressViewController.swift in Sources */,
 				52835269227B2BAE0097B949 /* ScannerTableViewController.swift in Sources */,
 				528352BC2285B6150097B949 /* OobSelector.swift in Sources */,
@@ -1266,6 +1274,14 @@
 				607FACDA1AFB9204008FA782 /* Base */,
 			);
 			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		F085CA0029D1E0B900C2DF89 /* Subscribe.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F085CA0129D1E0B900C2DF89 /* Base */,
+			);
+			name = Subscribe.storyboard;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/Example/nRF Mesh.xcodeproj/project.pbxproj
+++ b/Example/nRF Mesh.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		A7A59BD92773218C0045A8ED /* GenericPowerOnOffClientDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7A59BD82773218C0045A8ED /* GenericPowerOnOffClientDelegate.swift */; };
 		A7B526A7277B210000F5C60D /* GenericPowerOnOffSetupViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B526A5277B210000F5C60D /* GenericPowerOnOffSetupViewCell.swift */; };
 		A7B526A8277B210000F5C60D /* GenericPowerOnOffSetup.xib in Resources */ = {isa = PBXBuildFile; fileRef = A7B526A6277B210000F5C60D /* GenericPowerOnOffSetup.xib */; };
+		F085C9FD29CB26B000C2DF89 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = F085C9FC29CB26B000C2DF89 /* Models.swift */; };
 		F0A79242F997F08105E46FF6 /* Pods_nRF_Mesh_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DAC1677AA94583D28A5867E /* Pods_nRF_Mesh_Tests.framework */; };
 /* End PBXBuildFile section */
 
@@ -349,6 +350,7 @@
 		C775BBAAAC42952ED786BABF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		E7CB7DCE18F6E38D2240310F /* nRFMeshProvision.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = nRFMeshProvision.podspec; path = ../nRFMeshProvision.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		EA733BBB45B56B4142103F0F /* Pods-nRFMeshProvision_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-nRFMeshProvision_Example.debug.xcconfig"; path = "Target Support Files/Pods-nRFMeshProvision_Example/Pods-nRFMeshProvision_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		F085C9FC29CB26B000C2DF89 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -784,6 +786,7 @@
 				528352B32284139F0097B949 /* ProxyProtocol.swift */,
 				52B492DA25C8A32E0096E75D /* KeyRefreshProcedure.swift */,
 				52B7F67C229829F200B0A42F /* Addresses.swift */,
+				F085C9FC29CB26B000C2DF89 /* Models.swift */,
 				52DF5D92229C009200C297C1 /* NetworkPdus.swift */,
 				5294DAD922B109810041370E /* Pdus.swift */,
 				52F6AD6B22B78F3000F0D7DF /* CompositionData.swift */,
@@ -1170,6 +1173,7 @@
 				529B75AD22491770008F1CE7 /* AddressRanges.swift in Sources */,
 				529B764122521075008F1CE7 /* ManagingProvisioners.swift in Sources */,
 				529B75AB2248E276008F1CE7 /* SceneRanges.swift in Sources */,
+				F085C9FD29CB26B000C2DF89 /* Models.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/nRFMeshProvision/Classes/Mesh API/Model+Keys.swift
+++ b/nRFMeshProvision/Classes/Mesh API/Model+Keys.swift
@@ -38,7 +38,7 @@ public extension Model {
     /// to this Model, possibly bound by other Provisioner.
     var boundApplicationKeys: [ApplicationKey] {
         return parentElement?.parentNode?.applicationKeys
-            .filter({ bind.contains($0.index) }) ?? []
+            .filter { bind.contains($0.index) } ?? []
     }
     
     /// Whether the given Application Key is bound to this Model.
@@ -48,6 +48,16 @@ public extension Model {
     ///            otherwise `false`.
     func isBoundTo(_ applicationKey: ApplicationKey) -> Bool {
         return bind.contains(applicationKey.index)
+    }
+    
+    /// Whether the model supports App Key binding.
+    ///
+    /// Models that do not support App Key binding use Device Key on access layer security.
+    var supportsApplicationKeyBinding: Bool {
+        if isConfigurationServer || isConfigurationClient {
+            return false
+        }
+        return true
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh API/Models.swift
+++ b/nRFMeshProvision/Classes/Mesh API/Models.swift
@@ -263,7 +263,20 @@ public extension Model {
     ///
     /// The list does not include the Model on which it is being called.
     var relatedModels: [Model] {
-        return extendedModels + extendingModels
+        // Find all Models that extend this one.
+        let extendingModels = extendingModels
+        // If there are no such, just return Models that this Model extend.
+        if extendingModels.isEmpty {
+            return extendedModels
+        }
+        // Otherwise, for all such Models
+        return extendingModels
+            // create a list of extended Models,
+            .flatMap { [$0] + $0.extendedModels }
+            // make it unique.
+            .uniqued()
+            // and remove the Node in question.
+            .filter { $0 != self }
     }
     
     /// Returns whether that Model extends the given ``Model`` directly or indirectly.

--- a/nRFMeshProvision/Classes/Mesh API/Models.swift
+++ b/nRFMeshProvision/Classes/Mesh API/Models.swift
@@ -61,67 +61,66 @@ public extension Model {
         }
         switch modelIdentifier {
         // Foundation
-        case 0x0000: return false // Configuration Server
-        case 0x0001: return false // Configuration Client
-        case 0x0002: return true  // Health Server
-        case 0x0003: return true  // Health Client
+        case .configurationServerModelId: return false
+        case .configurationClientModelId: return false
+        case .healthServerModelId: return true
+        case .healthClientModelId: return true
         // Generic
-        case 0x1000: return true  // Generic OnOff Server
-        case 0x1001: return true  // Generic OnOff Client
-        case 0x1002: return true  // Generic Level Server
-        case 0x1003: return true  // Generic Level Client
-        case 0x1004: return true  // Generic Default Transition Time Server
-        case 0x1005: return true  // Generic Default Transition Time Client
-        case 0x1006: return true  // Generic Power OnOff Server
-        case 0x1007: return false // Generic Power OnOff Setup Server = only subsc
-        case 0x1008: return true  // Generic Power OnOff Client
-        case 0x1009: return true  // Generic Power Level Server
-        case 0x100A: return false // Generic Power Level Setup Server
-        case 0x100B: return true  // Generic Power Level Client
-        case 0x100C: return true  // Generic Battery Server
-        case 0x100D: return true  // Generic Battery Client
-        case 0x100E: return true  // Generic Location Server
-        case 0x100F: return false // Generic Location Setup Server
-        case 0x1010: return true  // Generic Location Client
-        case 0x1011: return true  // Generic Admin Property Server
-        case 0x1012: return true  // Generic Manufacturer Property Server
-        case 0x1013: return true  // Generic User Property Server
-        case 0x1014: return true  // Generic Client Property Server
-        case 0x1015: return true  // Generic Property Client
+        case .genericOnOffServerModelId: return true
+        case .genericOnOffClientModelId: return true
+        case .genericLevelServerModelId: return true
+        case .genericLevelClientModelId: return true
+        case .genericDefaultTransitionTimeServerModelId: return true
+        case .genericDefaultTransitionTimeClientModelId: return true
+        case .genericPowerOnOffServerModelId: return true
+        case .genericPowerOnOffSetupServerModelId: return false
+        case .genericPowerOnOffClientModelId: return true
+        case .genericPowerLevelServerModelId: return true
+        case .genericPowerLevelSetupServerModelId: return false
+        case .genericPowerLevelClientModelId: return true
+        case .genericBatteryServerModelId: return true
+        case .genericBatteryClientModelId: return true
+        case .genericLocationServerModelId: return true
+        case .genericLocationSetupServerModelId: return false
+        case .genericLocationClientModelId: return true
+        case .genericAdminPropertyServerModelId: return true
+        case .genericManufacturerPropertyServerModelId: return true
+        case .genericUserPropertyServerModelId: return true
+        case .genericClientPropertyServerModelId: return true
+        case .genericPropertyClientModelId: return true
         // Sensors
-        case 0x1100: return true  // Sensor Server
-        case 0x1101: return true  // Sensor Setup Server
-        case 0x1102: return true  // Sensor Client
+        case .sensorServerModelId: return true
+        case .sensorSetupServerModelId: return true
+        case .sensorClientModelId: return true
         // Time and Scenes
-        case 0x1200: return true  // Time Server
-        case 0x1201: return false // Time Setup Server
-        case 0x1202: return true  // Time Client
-        case 0x1203: return true  // Scene Server
-        case 0x1204: return false // Scene Setup Server
-        case 0x1205: return true  // Scene Client
-        case 0x1206: return true  // Scheduler Server
-        case 0x1207: return false // Scheduler Setup Server
-        case 0x1208: return true  // Scheduler Client
+        case .timeServerModelId: return true
+        case .timeSetupServerModelId: return false
+        case .timeClientModelId: return true
+        case .sceneServerModelId: return true
+        case .sceneSetupServerModelId: return false
+        case .sceneClientModelId: return true
+        case .schedulerServerModelId: return true
+        case .schedulerSetupServerModelId: return false
+        case .schedulerClientModelId: return true
         // Lighting
-        case 0x1300: return true  // Light Lightness Server
-        case 0x1301: return false // Light Lightness Setup Server
-        case 0x1302: return true  // Light Lightness Client
-        case 0x1303: return true  // Light CTL Server
-        case 0x1304: return false // Light CTL Setup Server
-        case 0x1305: return true  // Light CTL Client
-        case 0x1306: return true  // Light CTL Temperature Server
-        case 0x1307: return true  // Light HSL Server
-        case 0x1308: return false // Light HSL Setup Server
-        case 0x1309: return true  // Light HSL Client
-        case 0x130A: return true  // Light HSL Hue Server
-        case 0x130B: return true  // Light HSL Saturation Server
-        case 0x130C: return true  // Light xyL Server
-        case 0x130D: return false // Light xyL Setup Server
-        case 0x130E: return true  // Light xyL Client
-        case 0x130F: return true  // Light LC Server
-        case 0x1310: return true  // Light LC Setup Server
-        case 0x1311: return true  // Light LC Client
-            
+        case .lightLightnessServerModelId: return true
+        case .lightLightnessSetupServerModelId: return false
+        case .lightLightnessClientModelId: return true
+        case .lightCTLServerModelId: return true
+        case .lightCTLSetupServerModelId: return false
+        case .lightCTLClientModelId: return true
+        case .lightCTLTemperatureServerModelId: return true
+        case .lightHSLServerModelId: return true
+        case .lightHSLSetupServerModelId: return false
+        case .lightHSLClientModelId: return true
+        case .lightHSLHueServerModelId: return true
+        case .lightHSLSaturationServerModelId: return true
+        case .lightXyLServerModelId: return true
+        case .lightXyLSetupServerModelId: return false
+        case .lightXyLClientModelId: return true
+        case .lightLCServerModelId: return true
+        case .lightLCSetupServerModelId: return true
+        case .lightLCClientModelId: return true
         default: return nil
         }
     }
@@ -137,69 +136,343 @@ public extension Model {
         }
         switch modelIdentifier {
         // Foundation
-        case 0x0000: return false // Configuration Server
-        case 0x0001: return false // Configuration Client
-        case 0x0002: return true  // Health Server
-        case 0x0003: return true  // Health Client
+        case .configurationServerModelId: return false
+        case .configurationClientModelId: return false
+        case .healthServerModelId: return true
+        case .healthClientModelId: return true
         // Generic
-        case 0x1000: return true  // Generic OnOff Server
-        case 0x1001: return true  // Generic OnOff Client
-        case 0x1002: return true  // Generic Level Server
-        case 0x1003: return true  // Generic Level Client
-        case 0x1004: return true  // Generic Default Transition Time Server
-        case 0x1005: return true  // Generic Default Transition Time Client
-        case 0x1006: return true  // Generic Power OnOff Server
-        case 0x1007: return true  // Generic Power OnOff Setup Server
-        case 0x1008: return true  // Generic Power OnOff Client
-        case 0x1009: return true  // Generic Power Level Server
-        case 0x100A: return true  // Generic Power Level Setup Server
-        case 0x100B: return true  // Generic Power Level Client
-        case 0x100C: return true  // Generic Battery Server
-        case 0x100D: return true  // Generic Battery Client
-        case 0x100E: return true  // Generic Location Server
-        case 0x100F: return true  // Generic Location Setup Server
-        case 0x1010: return true  // Generic Location Client
-        case 0x1011: return true  // Generic Admin Property Server
-        case 0x1012: return true  // Generic Manufacturer Property Server
-        case 0x1013: return true  // Generic User Property Server
-        case 0x1014: return true  // Generic Client Property Server
-        case 0x1015: return true  // Generic Property Client
+        case .genericOnOffServerModelId: return true
+        case .genericOnOffClientModelId: return true
+        case .genericLevelServerModelId: return true
+        case .genericLevelClientModelId: return true
+        case .genericDefaultTransitionTimeServerModelId: return true
+        case .genericDefaultTransitionTimeClientModelId: return true
+        case .genericPowerOnOffServerModelId: return true
+        case .genericPowerOnOffSetupServerModelId: return true
+        case .genericPowerOnOffClientModelId: return true
+        case .genericPowerLevelServerModelId: return true
+        case .genericPowerLevelSetupServerModelId: return true
+        case .genericPowerLevelClientModelId: return true
+        case .genericBatteryServerModelId: return true
+        case .genericBatteryClientModelId: return true
+        case .genericLocationServerModelId: return true
+        case .genericLocationSetupServerModelId: return true
+        case .genericLocationClientModelId: return true
+        case .genericAdminPropertyServerModelId: return true
+        case .genericManufacturerPropertyServerModelId: return true
+        case .genericUserPropertyServerModelId: return true
+        case .genericClientPropertyServerModelId: return true
+        case .genericPropertyClientModelId: return true
         // Sensors
-        case 0x1100: return true  // Sensor Server
-        case 0x1101: return true  // Sensor Setup Server
-        case 0x1102: return true  // Sensor Client
+        case .sensorServerModelId: return true
+        case .sensorSetupServerModelId: return true
+        case .sensorClientModelId: return true
         // Time and Scenes
-        case 0x1200: return true  // Time Server
-        case 0x1201: return false // Time Setup Server
-        case 0x1202: return true  // Time Client
-        case 0x1203: return true  // Scene Server
-        case 0x1204: return true  // Scene Setup Server
-        case 0x1205: return true  // Scene Client
-        case 0x1206: return true  // Scheduler Server
-        case 0x1207: return true  // Scheduler Setup Server
-        case 0x1208: return true  // Scheduler Client
+        case .timeServerModelId: return true
+        case .timeSetupServerModelId: return false
+        case .timeClientModelId: return true
+        case .sceneServerModelId: return true
+        case .sceneSetupServerModelId: return true
+        case .sceneClientModelId: return true
+        case .schedulerServerModelId: return true
+        case .schedulerSetupServerModelId: return true
+        case .schedulerClientModelId: return true
         // Lighting
-        case 0x1300: return true  // Light Lightness Server
-        case 0x1301: return true  // Light Lightness Setup Server
-        case 0x1302: return true  // Light Lightness Client
-        case 0x1303: return true  // Light CTL Server
-        case 0x1304: return true  // Light CTL Setup Server
-        case 0x1305: return true  // Light CTL Client
-        case 0x1306: return true  // Light CTL Temperature Server
-        case 0x1307: return true  // Light HSL Server
-        case 0x1308: return true  // Light HSL Setup Server
-        case 0x1309: return true  // Light HSL Client
-        case 0x130A: return true  // Light HSL Hue Server
-        case 0x130B: return true  // Light HSL Saturation Server
-        case 0x130C: return true  // Light xyL Server
-        case 0x130D: return true  // Light xyL Setup Server
-        case 0x130E: return true  // Light xyL Client
-        case 0x130F: return true  // Light LC Server
-        case 0x1310: return true  // Light LC Setup Server
-        case 0x1311: return true  // Light LC Client
-            
+        case .lightLightnessServerModelId: return true
+        case .lightLightnessSetupServerModelId: return true
+        case .lightLightnessClientModelId: return true
+        case .lightCTLServerModelId: return true
+        case .lightCTLSetupServerModelId: return true
+        case .lightCTLClientModelId: return true
+        case .lightCTLTemperatureServerModelId: return true
+        case .lightHSLServerModelId: return true
+        case .lightHSLSetupServerModelId: return true
+        case .lightHSLClientModelId: return true
+        case .lightHSLHueServerModelId: return true
+        case .lightHSLSaturationServerModelId: return true
+        case .lightXyLServerModelId: return true
+        case .lightXyLSetupServerModelId: return true
+        case .lightXyLClientModelId: return true
+        case .lightLCServerModelId: return true
+        case .lightLCSetupServerModelId: return true
+        case .lightLCClientModelId: return true
         default: return nil
         }
     }
     
+    /// A list of ``Model``s extended by this Model.
+    ///
+    /// The *Extend* relationship is explained in Mesh Profile 1.0.1, chapter 2.3.6.
+    ///
+    /// - note: Models that operate on bound states share a single instance of a Subscription List per Element.
+    var extendedModels: [Model] {
+        // The Model must be on an Element on a Node.
+        guard let parentElement = parentElement,
+              let node = parentElement.parentNode else {
+            return []
+        }
+        // Get all direct base models of this Model.
+        let directBaseModels = node.elements
+            // Look only on that and previous Elements.
+            // Models can't extend Models on Elements with higher index.
+            .filter { $0.index <= parentElement.index }
+            // Sort in reverse order so that unifying the list will
+            // remove those on Elements with lowest indexes.
+            .sorted { $0.index > $1.index }
+            // Get a list of all models.
+            .flatMap { $0.models }
+            // Remove duplicates.
+            .uniqued()
+            // Get all direct base models of this Model.
+            .filter { extendsDirectly($0) }
+        // Return the direct base Models and all models that they extend.
+        return directBaseModels + directBaseModels.flatMap { $0.extendedModels }
+    }
+    
+    /// A list of ``Model``s extending this Model.
+    ///
+    /// The *Extend* relationship is explained in Mesh Profile 1.0.1, chapter 2.3.6.
+    ///
+    /// - note: Models that operate on bound states share a single instance of a Subscription List per Element.
+    var extendingModels: [Model] {
+        // The Model must be on an Element on a Node.
+        guard let parentElement = parentElement,
+              let node = parentElement.parentNode else {
+            return []
+        }
+        // Get all direct base models of this Model.
+        let directlyExtendingModels = node.elements
+            // Look only on that and next Elements.
+            // Models can't be exgtended by other Models on Elements with lower index.
+            .filter { $0.index >= parentElement.index }
+            // Get a list of all models.
+            .flatMap { $0.models }
+            // Remove duplicates.
+            .uniqued()
+            // Get all direct base models of this Model.
+            .filter { $0.extendsDirectly(self) }
+        // Return the direct base Models and all models that they are extending.
+        return directlyExtendingModels + directlyExtendingModels.flatMap { $0.extendingModels }
+    }
+    
+    /// Returns all ``Model`` instances that are in a hierarchy of *Extend* relationship with this Model.
+    ///
+    /// The list includes Models that extend the one and those are extended by it, directly or indirectly.
+    ///
+    /// The *Extend* relationship is explained in Mesh Profile 1.0.1, chapter 2.3.6.
+    ///
+    /// The list does not include the Model on which it is being called.
+    var relatedModels: [Model] {
+        return extendedModels + extendingModels
+    }
+    
+    /// Returns whether that Model extends the given ``Model`` directly or indirectly.
+    ///
+    /// If a Model A extends B, which extends C, this method will return `true` if checked with A and C.
+    /// Base Models may be on the same Element or on an Element with a lower index.
+    ///
+    /// The *Extend* relationship is explained in Mesh Profile 1.0.1, chapter 2.3.6.
+    ///
+    /// - note: Models that operate on bound states share a single instance of a Subscription List per Element.
+    ///
+    /// - note: Model extension is only defined for SIG Models. Currently it is not possible to
+    ///         get relationships between Vendor Models, and for those this method returns `false`.
+    ///
+    /// - parameter model: A Model to be checked.
+    /// - returns: `True` if the given Model is a direct or indirect *base* Model of that one,
+    ///            `false` otherwise.
+    func extends(_ model: Model) -> Bool {
+        // The Models must be on the same Node.
+        guard let parentElement = parentElement,
+              let otherParentElement = model.parentElement,
+              let node = parentElement.parentNode,
+              let otherNode = otherParentElement.parentNode,
+              node === otherNode else {
+            return false
+        }
+        return extendedModels.contains(model)
+    }
+    
+    /// Returns whether that Model directly extends the given ``Model``.
+    ///
+    /// This method only checks direct Extend relationship, not hierarchical. If a Model A extends B,
+    /// which extends C, this method will return `false` if checked with A and C. Base Models
+    /// may be on the same Element or on an Element with a lower index.
+    ///
+    /// The *Extend* relationship is explained in Mesh Profile 1.0.1, chapter 2.3.6.
+    ///
+    /// - note: Models in Extend relationship share their Subscription List if they are on the same Element.
+    ///
+    /// - note: Model extension is only defined for SIG Models. Currently it is not possible to
+    ///         get relationships between Vendor Models, and for those this method returns `false`.
+    ///
+    /// - parameter model: A Model to be checked.
+    /// - returns: `True` if the given Model is a *base* Model of that one,
+    ///            `false` otherwise.
+    func extendsDirectly(_ model: Model) -> Bool {
+        // The Models must be on the same Node.
+        guard let parentElement = parentElement,
+              let otherParentElement = model.parentElement,
+              let node = parentElement.parentNode,
+              let otherNode = otherParentElement.parentNode,
+              node === otherNode else {
+            return false
+        }
+        // Model can't extend itself or any other instance of the same model.
+        if modelIdentifier == model.modelIdentifier {
+            return false
+        }
+        // Currently, it is not possible to get relationships between Vendor models.
+        if !isBluetoothSIGAssigned || !model.isBluetoothSIGAssigned {
+            return false
+        }
+        // Check Models on the same Element.
+        if model.parentElement == parentElement {
+            switch modelIdentifier {
+            // Generics
+            case .genericPowerOnOffServerModelId:
+                return model.modelIdentifier == .genericOnOffServerModelId
+            case .genericPowerOnOffSetupServerModelId:
+                return model.modelIdentifier == .genericPowerOnOffServerModelId ||
+                       model.modelIdentifier == .genericDefaultTransitionTimeServerModelId
+            case .genericPowerLevelServerModelId:
+                return model.modelIdentifier == .genericPowerOnOffServerModelId ||
+                       model.modelIdentifier == .genericLevelServerModelId
+            case .genericPowerLevelSetupServerModelId:
+                return model.modelIdentifier == .genericPowerLevelServerModelId ||
+                       model.modelIdentifier == .genericPowerOnOffSetupServerModelId
+            case .genericLocationSetupServerModelId:
+                return model.modelIdentifier == .genericLocationServerModelId
+            case .genericAdminPropertyServerModelId, .genericManufacturerPropertyServerModelId:
+                return model.modelIdentifier == .genericUserPropertyServerModelId
+            // Sensors
+            case .sensorSetupServerModelId:
+                return model.modelIdentifier == .sensorServerModelId
+            // Time and Scenes
+            case .timeSetupServerModelId:
+                return model.modelIdentifier == .timeServerModelId
+            case .sceneSetupServerModelId:
+                return model.modelIdentifier == .sceneServerModelId ||
+                       model.modelIdentifier == .genericDefaultTransitionTimeServerModelId
+            case .schedulerSetupServerModelId:
+                return model.modelIdentifier == .schedulerServerModelId
+            // Lighting
+            case .lightLightnessServerModelId:
+                return model.modelIdentifier == .genericPowerOnOffServerModelId ||
+                       model.modelIdentifier == .genericLevelServerModelId
+            case .lightLightnessSetupServerModelId:
+                return model.modelIdentifier == .lightLightnessServerModelId ||
+                       model.modelIdentifier == .genericPowerOnOffSetupServerModelId
+            case .lightCTLServerModelId,
+                 .lightHSLServerModelId,
+                 .lightXyLServerModelId:
+                return model.modelIdentifier == .lightLightnessServerModelId
+            case .lightCTLTemperatureServerModelId,
+                 .lightHSLHueServerModelId,
+                 .lightHSLSaturationServerModelId:
+                return model.modelIdentifier == .genericLevelServerModelId
+            case .lightCTLSetupServerModelId:
+                return model.modelIdentifier == .lightCTLServerModelId ||
+                       model.modelIdentifier == .lightLightnessSetupServerModelId
+            case .lightHSLSetupServerModelId:
+                return model.modelIdentifier == .lightHSLServerModelId ||
+                       model.modelIdentifier == .lightLightnessSetupServerModelId
+            case .lightXyLSetupServerModelId:
+                return model.modelIdentifier == .lightXyLServerModelId ||
+                       model.modelIdentifier == .lightLightnessSetupServerModelId
+            case .lightLCServerModelId:
+                // It also extends a Light Lightness Server on another Element.
+                return model.modelIdentifier == .genericOnOffServerModelId
+            case .lightLCSetupServerModelId:
+                return model.modelIdentifier == .lightLCServerModelId
+            default:
+                return false
+            }
+        } else {
+            // Some features are split into 2 Elements.
+            switch modelIdentifier {
+            case .lightLCServerModelId:
+                // Light LC Server Model extends a Light Lightness Server
+                // Model that cannot be on the same Element.
+                // Search for a Model on an Element with lower Index.
+                let modelWithLightLigthnessServer = node.elements
+                    // Filter to Elements with lower Index number.
+                    .filter { $0.index < parentElement.index }
+                    // Reverse the ordering to look for a first Element with LLS model.
+                    .sorted { $0.index > $1.index }
+                    // Find an Element with Light Lightness Server model.
+                    .first { $0.contains(modelWithSigModelId: .lightLightnessServerModelId) }?
+                    // And return that model.
+                    .model(withSigModelId: .lightLightnessServerModelId)
+                return model === modelWithLightLigthnessServer
+            default:
+                return false
+            }
+        }
+    }
+    
+}
+
+public extension UInt16 {
+    // Foundation
+    static let configurationServerModelId: UInt16 = 0x0000
+    static let configurationClientModelId: UInt16 = 0x0001
+    static let healthServerModelId: UInt16 = 0x0002
+    static let healthClientModelId: UInt16 = 0x0003
+    // Generic
+    static let genericOnOffServerModelId: UInt16 = 0x1000
+    static let genericOnOffClientModelId: UInt16 = 0x1001
+    static let genericLevelServerModelId: UInt16 = 0x1002
+    static let genericLevelClientModelId: UInt16 = 0x1003
+    static let genericDefaultTransitionTimeServerModelId: UInt16 = 0x1004
+    static let genericDefaultTransitionTimeClientModelId: UInt16 = 0x1005
+    static let genericPowerOnOffServerModelId: UInt16 = 0x1006
+    static let genericPowerOnOffSetupServerModelId: UInt16 = 0x1007
+    static let genericPowerOnOffClientModelId: UInt16 = 0x1008
+    static let genericPowerLevelServerModelId: UInt16 = 0x1009
+    static let genericPowerLevelSetupServerModelId: UInt16 = 0x100A
+    static let genericPowerLevelClientModelId: UInt16 = 0x100B
+    static let genericBatteryServerModelId: UInt16 = 0x100C
+    static let genericBatteryClientModelId: UInt16 = 0x100D
+    static let genericLocationServerModelId: UInt16 = 0x100E
+    static let genericLocationSetupServerModelId: UInt16 = 0x100F
+    static let genericLocationClientModelId: UInt16 = 0x1010
+    static let genericAdminPropertyServerModelId: UInt16 = 0x1011
+    static let genericManufacturerPropertyServerModelId: UInt16 = 0x1012
+    static let genericUserPropertyServerModelId: UInt16 = 0x1013
+    static let genericClientPropertyServerModelId: UInt16 = 0x1014
+    static let genericPropertyClientModelId: UInt16 = 0x1015
+    // Sensors
+    static let sensorServerModelId: UInt16 = 0x1100
+    static let sensorSetupServerModelId: UInt16 = 0x1101
+    static let sensorClientModelId: UInt16 = 0x1102
+    // Time and Scenes
+    static let timeServerModelId: UInt16 = 0x1200
+    static let timeSetupServerModelId: UInt16 = 0x1201
+    static let timeClientModelId: UInt16 = 0x1202
+    static let sceneServerModelId: UInt16 = 0x1203
+    static let sceneSetupServerModelId: UInt16 = 0x1204
+    static let sceneClientModelId: UInt16 = 0x1205
+    static let schedulerServerModelId: UInt16 = 0x1206
+    static let schedulerSetupServerModelId: UInt16 = 0x1207
+    static let schedulerClientModelId: UInt16 = 0x1208
+    // Lighting
+    static let lightLightnessServerModelId: UInt16 = 0x1300
+    static let lightLightnessSetupServerModelId: UInt16 = 0x1301
+    static let lightLightnessClientModelId: UInt16 = 0x1302
+    static let lightCTLServerModelId: UInt16 = 0x1303
+    static let lightCTLSetupServerModelId: UInt16 = 0x1304
+    static let lightCTLClientModelId: UInt16 = 0x1305
+    static let lightCTLTemperatureServerModelId: UInt16 = 0x1306
+    static let lightHSLServerModelId: UInt16 = 0x1307
+    static let lightHSLSetupServerModelId: UInt16 = 0x1308
+    static let lightHSLClientModelId: UInt16 = 0x1309
+    static let lightHSLHueServerModelId: UInt16 = 0x130A
+    static let lightHSLSaturationServerModelId: UInt16 = 0x130B
+    static let lightXyLServerModelId: UInt16 = 0x130C
+    static let lightXyLSetupServerModelId: UInt16 = 0x130D
+    static let lightXyLClientModelId: UInt16 = 0x130E
+    static let lightLCServerModelId: UInt16 = 0x130F
+    static let lightLCSetupServerModelId: UInt16 = 0x1310
+    static let lightLCClientModelId: UInt16 = 0x1311
 }

--- a/nRFMeshProvision/Classes/Mesh API/Models.swift
+++ b/nRFMeshProvision/Classes/Mesh API/Models.swift
@@ -50,4 +50,156 @@ public extension Model {
         return subscriptions.contains { $0.address == address }
     }
     
+    /// Whether the Model supports model publication defined in Section 4.2.3 in
+    /// Bluetooth Mesh Profile 1.0.1 specification.
+    ///
+    /// - returns: `true` if the model supports model publication, `false` ir it doesn't
+    ///            or `nil` if unknown.
+    var supportsModelPublication: Bool? {
+        if !isBluetoothSIGAssigned {
+            return nil
+        }
+        switch modelIdentifier {
+        // Foundation
+        case 0x0000: return false // Configuration Server
+        case 0x0001: return false // Configuration Client
+        case 0x0002: return true  // Health Server
+        case 0x0003: return true  // Health Client
+        // Generic
+        case 0x1000: return true  // Generic OnOff Server
+        case 0x1001: return true  // Generic OnOff Client
+        case 0x1002: return true  // Generic Level Server
+        case 0x1003: return true  // Generic Level Client
+        case 0x1004: return true  // Generic Default Transition Time Server
+        case 0x1005: return true  // Generic Default Transition Time Client
+        case 0x1006: return true  // Generic Power OnOff Server
+        case 0x1007: return false // Generic Power OnOff Setup Server = only subsc
+        case 0x1008: return true  // Generic Power OnOff Client
+        case 0x1009: return true  // Generic Power Level Server
+        case 0x100A: return false // Generic Power Level Setup Server
+        case 0x100B: return true  // Generic Power Level Client
+        case 0x100C: return true  // Generic Battery Server
+        case 0x100D: return true  // Generic Battery Client
+        case 0x100E: return true  // Generic Location Server
+        case 0x100F: return false // Generic Location Setup Server
+        case 0x1010: return true  // Generic Location Client
+        case 0x1011: return true  // Generic Admin Property Server
+        case 0x1012: return true  // Generic Manufacturer Property Server
+        case 0x1013: return true  // Generic User Property Server
+        case 0x1014: return true  // Generic Client Property Server
+        case 0x1015: return true  // Generic Property Client
+        // Sensors
+        case 0x1100: return true  // Sensor Server
+        case 0x1101: return true  // Sensor Setup Server
+        case 0x1102: return true  // Sensor Client
+        // Time and Scenes
+        case 0x1200: return true  // Time Server
+        case 0x1201: return false // Time Setup Server
+        case 0x1202: return true  // Time Client
+        case 0x1203: return true  // Scene Server
+        case 0x1204: return false // Scene Setup Server
+        case 0x1205: return true  // Scene Client
+        case 0x1206: return true  // Scheduler Server
+        case 0x1207: return false // Scheduler Setup Server
+        case 0x1208: return true  // Scheduler Client
+        // Lighting
+        case 0x1300: return true  // Light Lightness Server
+        case 0x1301: return false // Light Lightness Setup Server
+        case 0x1302: return true  // Light Lightness Client
+        case 0x1303: return true  // Light CTL Server
+        case 0x1304: return false // Light CTL Setup Server
+        case 0x1305: return true  // Light CTL Client
+        case 0x1306: return true  // Light CTL Temperature Server
+        case 0x1307: return true  // Light HSL Server
+        case 0x1308: return false // Light HSL Setup Server
+        case 0x1309: return true  // Light HSL Client
+        case 0x130A: return true  // Light HSL Hue Server
+        case 0x130B: return true  // Light HSL Saturation Server
+        case 0x130C: return true  // Light xyL Server
+        case 0x130D: return false // Light xyL Setup Server
+        case 0x130E: return true  // Light xyL Client
+        case 0x130F: return true  // Light LC Server
+        case 0x1310: return true  // Light LC Setup Server
+        case 0x1311: return true  // Light LC Client
+            
+        default: return nil
+        }
+    }
+    
+    /// Whether the Model supports model subscription defined in Section 4.2.4 in
+    /// Bluetooth Mesh Profile 1.0.1 specification.
+    ///
+    /// - returns: `true` if the model supports model subscription, `false` ir it doesn't
+    ///            or `nil` if unknown.
+    var supportsModelSubscriptions: Bool? {
+        if !isBluetoothSIGAssigned {
+            return nil
+        }
+        switch modelIdentifier {
+        // Foundation
+        case 0x0000: return false // Configuration Server
+        case 0x0001: return false // Configuration Client
+        case 0x0002: return true  // Health Server
+        case 0x0003: return true  // Health Client
+        // Generic
+        case 0x1000: return true  // Generic OnOff Server
+        case 0x1001: return true  // Generic OnOff Client
+        case 0x1002: return true  // Generic Level Server
+        case 0x1003: return true  // Generic Level Client
+        case 0x1004: return true  // Generic Default Transition Time Server
+        case 0x1005: return true  // Generic Default Transition Time Client
+        case 0x1006: return true  // Generic Power OnOff Server
+        case 0x1007: return true  // Generic Power OnOff Setup Server
+        case 0x1008: return true  // Generic Power OnOff Client
+        case 0x1009: return true  // Generic Power Level Server
+        case 0x100A: return true  // Generic Power Level Setup Server
+        case 0x100B: return true  // Generic Power Level Client
+        case 0x100C: return true  // Generic Battery Server
+        case 0x100D: return true  // Generic Battery Client
+        case 0x100E: return true  // Generic Location Server
+        case 0x100F: return true  // Generic Location Setup Server
+        case 0x1010: return true  // Generic Location Client
+        case 0x1011: return true  // Generic Admin Property Server
+        case 0x1012: return true  // Generic Manufacturer Property Server
+        case 0x1013: return true  // Generic User Property Server
+        case 0x1014: return true  // Generic Client Property Server
+        case 0x1015: return true  // Generic Property Client
+        // Sensors
+        case 0x1100: return true  // Sensor Server
+        case 0x1101: return true  // Sensor Setup Server
+        case 0x1102: return true  // Sensor Client
+        // Time and Scenes
+        case 0x1200: return true  // Time Server
+        case 0x1201: return false // Time Setup Server
+        case 0x1202: return true  // Time Client
+        case 0x1203: return true  // Scene Server
+        case 0x1204: return true  // Scene Setup Server
+        case 0x1205: return true  // Scene Client
+        case 0x1206: return true  // Scheduler Server
+        case 0x1207: return true  // Scheduler Setup Server
+        case 0x1208: return true  // Scheduler Client
+        // Lighting
+        case 0x1300: return true  // Light Lightness Server
+        case 0x1301: return true  // Light Lightness Setup Server
+        case 0x1302: return true  // Light Lightness Client
+        case 0x1303: return true  // Light CTL Server
+        case 0x1304: return true  // Light CTL Setup Server
+        case 0x1305: return true  // Light CTL Client
+        case 0x1306: return true  // Light CTL Temperature Server
+        case 0x1307: return true  // Light HSL Server
+        case 0x1308: return true  // Light HSL Setup Server
+        case 0x1309: return true  // Light HSL Client
+        case 0x130A: return true  // Light HSL Hue Server
+        case 0x130B: return true  // Light HSL Saturation Server
+        case 0x130C: return true  // Light xyL Server
+        case 0x130D: return true  // Light xyL Setup Server
+        case 0x130E: return true  // Light xyL Client
+        case 0x130F: return true  // Light LC Server
+        case 0x1310: return true  // Light LC Setup Server
+        case 0x1311: return true  // Light LC Client
+            
+        default: return nil
+        }
+    }
+    
 }

--- a/nRFMeshProvision/Classes/Mesh Model/Element.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Element.swift
@@ -188,7 +188,7 @@ public class Element: Codable {
 
 // MARK: - Operators
 
-extension Element: Equatable {
+extension Element: Equatable, Hashable {
     
     public static func == (lhs: Element, rhs: Element) -> Bool {
         return lhs.parentNode === rhs.parentNode && lhs.index == rhs.index
@@ -196,6 +196,10 @@ extension Element: Equatable {
     
     public static func != (lhs: Element, rhs: Element) -> Bool {
         return lhs.parentNode !== rhs.parentNode || lhs.index != rhs.index
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(unicastAddress)
     }
     
 }

--- a/nRFMeshProvision/Classes/Mesh Model/Model.swift
+++ b/nRFMeshProvision/Classes/Mesh Model/Model.swift
@@ -211,18 +211,6 @@ public class Model: Codable {
     }
 }
 
-internal extension UInt16 {
-    
-    static let configurationServerModelId: UInt16 = 0x0000
-    static let configurationClientModelId: UInt16 = 0x0001
-    static let healthServerModelId: UInt16 = 0x0002
-    static let healthClientModelId: UInt16 = 0x0003
-    static let sceneServerModelId: UInt16 = 0x1203
-    static let sceneSetupServerModelId: UInt16 = 0x1204
-    static let sceneClientModelId: UInt16 = 0x1205
-    
-}
-
 internal extension Model {
     
     var isConfigurationServer: Bool { return modelId == UInt32(UInt16.configurationServerModelId) }
@@ -339,15 +327,31 @@ internal extension Model {
 extension Model: Equatable, Hashable {
     
     public static func == (lhs: Model, rhs: Model) -> Bool {
-        return lhs.modelId == rhs.modelId
+        return lhs.modelId == rhs.modelId && lhs.parentElement == rhs.parentElement
     }
     
     public static func != (lhs: Model, rhs: Model) -> Bool {
-        return lhs.modelId != rhs.modelId
+        return lhs.modelId != rhs.modelId || lhs.parentElement != rhs.parentElement
     }
     
     public func hash(into hasher: inout Hasher) {
         hasher.combine(modelId)
+    }
+    
+}
+
+extension Model: CustomDebugStringConvertible {
+    
+    public var debugDescription: String {
+        guard let parentElement = parentElement else {
+            return "Model not added to a Node"
+        }
+        let element = parentElement.name ?? "Element \(parentElement.index)"
+        if let companyIdentifier = companyIdentifier {
+            return "Vendor Model \(modelIdentifier.hex) by Company \(companyIdentifier.hex) on \(element)"
+        } else {
+            return "Model \(modelIdentifier.hex) on \(element)"
+        }
     }
     
 }

--- a/nRFMeshProvision/Classes/Type Extensions/Unique.swift
+++ b/nRFMeshProvision/Classes/Type Extensions/Unique.swift
@@ -1,0 +1,44 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+internal extension Array where Element: Hashable {
+    
+    func uniqued() -> [Element] {
+        var seen: Set<Element> = []
+        var result: [Element] = []
+        for element in self {
+            if seen.insert(element).inserted {
+                result.append(element)
+            }
+        }
+        return result
+    }
+
+}


### PR DESCRIPTION
This PR adds API to get base and extending Models of a given Model. It also adds a screen in the nRF Mesh app showing them.

Other changes:
1. Network storyboard was split to 3 to save some space.
2. Now `.[modelName]ModelID` constants were added to the library. Before a subset of them was only in nRF Mesh app, not the library.
3. New methods added to `Model` class:
   1. `supportsApplicationKeyBinding`
   2. `supportsModelSubscriptions`
   3. `supportsModelPublication`