### PR TITLE
Bugfix: Fixed `ConfigModelSubscriptionVirtualAddressAdd`

### DIFF
--- a/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionVirtualAddressAdd.swift
+++ b/nRFMeshProvision/Classes/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionVirtualAddressAdd.swift
@@ -65,7 +65,7 @@ public struct ConfigModelSubscriptionVirtualAddressAdd: AcknowledgedConfigMessag
     }
     
     public init?(parameters: Data) {
-        guard parameters.count == 20 || parameters.count == 24 else {
+        guard parameters.count == 20 || parameters.count == 22 else {
             return nil
         }
         elementAddress = parameters.read(fromOffset: 0)


### PR DESCRIPTION
This PR fixes a bug in `ConfigModelSubscriptionVirtualAddressAdd`. When the model was a vendor model, the message could not be created from `Data`.