### PR TITLE
Update incorrect member vars in Crypto and SchedulerMessages

### DIFF
--- a/Example/Source/View Controllers/Network/Configuration/NodeAddAppKeyViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeAddAppKeyViewController.swift
@@ -128,7 +128,7 @@ private extension NodeAddAppKeyViewController {
     
     /// Adds the given Application Key to the target Node.
     ///
-    /// - parameter networkKey: The Application Key to be added.
+    /// - parameter applicationKey: The Application Key to be added.
     func addKey(_ applicationKey: ApplicationKey) {
         guard let node = node else {
             return

--- a/Example/Tests/SchedulerMessages.swift
+++ b/Example/Tests/SchedulerMessages.swift
@@ -42,7 +42,7 @@ class SchedulerMessages: XCTestCase {
     }
 
     func testSchedulerEntryMarshalling() throws {
-        let data = SchedulerRegistryEntry.marshal(index: 3, entry: SchedulerRegistryEntry(year: SchedulerYear.specific(year: 35), month: SchedulerMonth.any(of: [Month.April]), day: SchedulerDay.specific(day: 12), hour: SchedulerHour.specific(hour: 5), minute: SchedulerMinute.every15(), second: SchedulerSecond.random(), dayOfWeek: SchedulerDayOfWeek.any(of: [WeekDay.Saturday]), action: SchedulerAction.SceneRecall, transitionTime: TransitionTime.init(steps: 5, stepResolution: StepResolution.seconds), sceneNumber: 10))
+        let data = SchedulerRegistryEntry.marshal(index: 3, entry: SchedulerRegistryEntry(year: SchedulerYear.specific(year: 35), month: SchedulerMonth.any(of: [Month.April]), day: SchedulerDay.specific(day: 12), hour: SchedulerHour.specific(hour: 5), minute: SchedulerMinute.every15(), second: SchedulerSecond.random(), dayOfWeek: SchedulerDayOfWeek.any(of: [WeekDay.Saturday]), action: SchedulerAction.sceneRecall, transitionTime: TransitionTime.init(steps: 5, stepResolution: StepResolution.seconds), sceneNumber: 10))
         
         XCTAssertEqual(data, Data([51, 66, 0, 86, 250, 31, 36, 69, 10, 0]))
     }
@@ -59,7 +59,7 @@ class SchedulerMessages: XCTestCase {
         XCTAssertEqual(entry.entry.minute.value, SchedulerMinute.every15().value)
         XCTAssertEqual(entry.entry.second.value, SchedulerSecond.random().value)
         XCTAssertEqual(entry.entry.dayOfWeek.value, WeekDay.Saturday.rawValue)
-        XCTAssertEqual(entry.entry.action, SchedulerAction.SceneRecall)
+        XCTAssertEqual(entry.entry.action, SchedulerAction.sceneRecall)
         XCTAssertEqual(entry.entry.transitionTime.stepResolution, StepResolution.seconds)
         XCTAssertEqual(entry.entry.transitionTime.steps, 5)
         XCTAssertEqual(entry.entry.sceneNumber, 10)

--- a/nRFMeshProvision/Classes/Crypto/Crypto.swift
+++ b/nRFMeshProvision/Classes/Crypto/Crypto.swift
@@ -458,7 +458,7 @@ private extension Crypto {
     /// - returns: The 128-bit authentication code (MAC).
     static func calculateHMAC_SHA256(_ data: Data, andKey key: Data) -> Data {
         do {
-            let array = try HMAC(key: key.bytes, variant: .sha2(.sha256)).authenticate(data.bytes)
+            let array = try HMAC(key: key.bytes, variant: .sha256).authenticate(data.bytes)
             return Data(array)
         } catch {
             fatalError("Failed to calculate HMAC-SHA-256: \(error)")


### PR DESCRIPTION
Makes a couple small changes to ensure that the build IOS-nRF-Mesh-Library builds without error. Also updated a docstring to reflect the actual parameter name.