### PR TITLE
Bugfix: Accepting SNB from a Node that does not know the Primary Network Key

### DIFF
--- a/nRFMeshProvision/Layers/Network Layer/NetworkLayer.swift
+++ b/nRFMeshProvision/Layers/Network Layer/NetworkLayer.swift
@@ -273,10 +273,11 @@ private extension NetworkLayer {
         // beacon on a secondary subnet, it will disregard it.
         if let _ = meshNetwork.networkKeys.primaryKey, networkKey.isSecondary {
             logger?.w(.network, "Discarding beacon for secondary network (key index: \(networkKey.index))")
-            // However, if we're connected to a Proxy Node that doesn't know the Primary Network Key,
-            // we should store it and notify the app that a new connection was made.
+            
+            // If we've connected to a Proxy Node that doesn't know the Primary Network
+            // we should still notify the user about a new Proxy.
             if proxyNetworkKey == nil {
-                updateProxyFilter(usingNetworkKey: networkKey, afterIvIndexChanged: false)
+                updateProxyFilter(usingNetworkKey: networkKey)
             }
             return
         }
@@ -362,22 +363,19 @@ private extension NetworkLayer {
         // that has not yet transitioned to the one local Node has. Such IV Index
         // is still valid, at least for some time.
         
-        updateProxyFilter(usingNetworkKey: networkKey,
-                          afterIvIndexChanged: lastIVIndex != meshNetwork.ivIndex)
+        updateProxyFilter(usingNetworkKey: networkKey)
     }
     
     /// Updates the information about the Network Key known to the current Proxy Server.
+    ///
     /// The Network Key is required to send Proxy Configuration Messages that can be
     /// decoded by the connected Proxy.
     ///
-    /// This method also initiates the Proxy Filter with local Provisioner's Unicast Address
-    /// and the `Address.allNodes` group address if a new connection has been found.
+    /// For new Proxy connections this method also initiates the Proxy Filter with
+    /// preset ``ProxyFilter/initialState``.
     ///
-    /// - parameters:
-    ///   - networkKey: The Network Key known to the connected Proxy.
-    ///   - ivIndexChanged: True, if IV Index has changed, false otherwise.
-    func updateProxyFilter(usingNetworkKey networkKey: NetworkKey,
-                           afterIvIndexChanged ivIndexChanged: Bool) {
+    /// - parameter networkKey: The Network Key known to the connected Proxy.
+    func updateProxyFilter(usingNetworkKey networkKey: NetworkKey) {
         let justConnected = proxyNetworkKey == nil
         
         // Keep the primary Network Key or the most recently received one from the connected
@@ -385,7 +383,7 @@ private extension NetworkLayer {
         // are sent encrypted with a key known to this Node.
         proxyNetworkKey = networkKey
         
-        if justConnected || !ivIndexChanged {
+        if justConnected {
             networkManager.manager.proxyFilter.newProxyDidConnect()
         }
     }


### PR DESCRIPTION
The Bluetooth Mesh Profile 1.0.1 spec says: 

3.9.3.1:
> A Secure Network beacon may be sent for each subnet that a node is a member of to identify the subnet and inform about IV Index updates and Key Refresh procedures.

3.10.5:
> If this node is a member of a primary subnet and receives a Secure Network beacon or a Mesh Private beacon on a secondary subnet with an IV Index greater than the last known IV Index of the primary subnet, the Secure Network beacon or the Mesh Private beacon shall be ignored.

A Node may be provisioned with a secondary Network Key. In that case, a connected GATT client would only receive a Secure Network beacon (SNB) for just that secondary network.

Before the change, the SNB was discarded (correctly), but the app wasn't notified about a new Proxy connection. The Proxy Filter wasn't set.
After the change, if the `proxyNetworkKey` is `nil` (so there was no proxy connection before), the beacon is still discarded, but the app gets a notification and can set up the Proxy Filter.
