### PR TITLE
Bugfix: Crash when configuring a node with no primary key

### DIFF
--- a/Example/Source/View Controllers/Network/Configuration/Automation/Binding/SelectKeysViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Automation/Binding/SelectKeysViewController.swift
@@ -126,7 +126,7 @@ class SelectKeysViewController: UITableViewController {
                 return cell
             } else {
                 let cell = tableView.dequeueReusableCell(withIdentifier: "action", for: indexPath)
-                cell.detailTextLabel?.text = "Bound to \(node.networkKeys.primaryKey!.name)"
+                cell.detailTextLabel?.text = "Bound to \(node.networkKeys.first!.name)"
                 return cell
             }
         }


### PR DESCRIPTION
This PR fixes a crash when trying to configure a node which doesn't know the primary network key, just a secondary one.