### PR TITLE
Ignoring message failures when not applicable

### DIFF
--- a/Example/Source/View Controllers/Control/ControlViewCell.swift
+++ b/Example/Source/View Controllers/Control/ControlViewCell.swift
@@ -184,14 +184,12 @@ extension ControlViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager, didSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address) {
-        done()
+        // Ignore.
     }
     
     func meshNetworkManager(_ manager: MeshNetworkManager, failedToSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address, error: Error) {
-        done {
-            self.presentAlert(title: "Error", message: error.localizedDescription)
-        }
+        // Ignore.
     }
 }
 

--- a/Example/Source/View Controllers/Network/Configuration/ModelBindAppKeyViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/ModelBindAppKeyViewController.swift
@@ -183,6 +183,10 @@ extension ModelBindAppKeyViewController: MeshNetworkDelegate {
                             failedToSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address,
                             error: Error) {
+        // Ignore messages sent from model publication.
+        guard message is ConfigMessage else {
+            return
+        }
         done {
             self.presentAlert(title: "Error", message: error.localizedDescription)
         }

--- a/Example/Source/View Controllers/Network/Configuration/ModelViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/ModelViewController.swift
@@ -939,18 +939,14 @@ extension ModelViewController: MeshNetworkDelegate {
             navigationController?.popToRootViewController(animated: true)
             return
         }
-        
-        switch message {
-        case is ConfigMessage:
-            // Ignore.
-            break
-            
-        default:
-            let isMore = modelViewCell?.meshNetworkManager(manager, didSendMessage: message,
-                                                           from: localElement, to: destination) ?? false
-            if !isMore {
-                done()
-            }
+        // Ignore messages sent from model publication.
+        guard message is ConfigMessage else {
+            return
+        }
+        let isMore = modelViewCell?.meshNetworkManager(manager, didSendMessage: message,
+                                                       from: localElement, to: destination) ?? false
+        if !isMore {
+            done()
         }
     }
     
@@ -958,6 +954,10 @@ extension ModelViewController: MeshNetworkDelegate {
                             failedToSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address,
                             error: Error) {
+        // Ignore messages sent from model publication.
+        guard message is ConfigMessage else {
+            return
+        }
         done {
             self.presentAlert(title: "Error", message: error.localizedDescription)
             self.refreshControl?.endRefreshing()

--- a/Example/Source/View Controllers/Network/Configuration/NodeAddAppKeyViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeAddAppKeyViewController.swift
@@ -189,6 +189,10 @@ extension NodeAddAppKeyViewController: MeshNetworkDelegate {
                             failedToSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address,
                             error: Error) {
+        // Ignore messages sent using model publication.
+        guard message is ConfigMessage else {
+            return
+        }
         done {
             self.presentAlert(title: "Error", message: error.localizedDescription)
         }

--- a/Example/Source/View Controllers/Network/Configuration/NodeAddNetworkKeyViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeAddNetworkKeyViewController.swift
@@ -186,6 +186,10 @@ extension NodeAddNetworkKeyViewController: MeshNetworkDelegate {
                             failedToSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address,
                             error: Error) {
+        // Ignore messages sent using model publication.
+        guard message is ConfigNetKeyAdd else {
+            return
+        }
         done {
             self.presentAlert(title: "Error", message: error.localizedDescription)
         }

--- a/Example/Source/View Controllers/Network/Configuration/NodeAppKeysViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeAppKeysViewController.swift
@@ -247,6 +247,10 @@ extension NodeAppKeysViewController: MeshNetworkDelegate {
                             failedToSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address,
                             error: Error) {
+        // Ignore messages sent using model publication.
+        guard message is ConfigMessage else {
+            return
+        }
         done {
             self.presentAlert(title: "Error", message: error.localizedDescription)
             self.refreshControl?.endRefreshing()

--- a/Example/Source/View Controllers/Network/Configuration/NodeNetworkKeysViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeNetworkKeysViewController.swift
@@ -235,6 +235,10 @@ extension NodeNetworkKeysViewController: MeshNetworkDelegate {
                             failedToSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address,
                             error: Error) {
+        // Ignore messages sent using model publication.
+        guard message is ConfigMessage else {
+            return
+        }
         done {
             self.presentAlert(title: "Error", message: error.localizedDescription)
             self.refreshControl?.endRefreshing()

--- a/Example/Source/View Controllers/Network/Configuration/NodeScenesViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeScenesViewController.swift
@@ -537,6 +537,14 @@ extension NodeScenesViewController: MeshNetworkDelegate {
                             failedToSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address,
                             error: Error) {
+        // Ignore messages sent using model publication.
+        guard message is ConfigMessage ||
+              message is SceneRecall ||
+              message is SceneGet ||
+              message is SceneRegisterGet ||
+              message is SceneDelete else {
+            return
+        }
         done {
             self.presentAlert(title: "Error", message: error.localizedDescription)
             self.refreshControl?.endRefreshing()

--- a/Example/Source/View Controllers/Network/Configuration/NodeStoreSceneViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeStoreSceneViewController.swift
@@ -228,6 +228,10 @@ extension NodeStoreSceneViewController: MeshNetworkDelegate {
                             failedToSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address,
                             error: Error) {
+        // Ignore messages sent using model publication.
+        guard message is SceneStore else {
+            return
+        }
         done {
             self.presentAlert(title: "Error", message: error.localizedDescription)
         }

--- a/Example/Source/View Controllers/Network/Configuration/NodeViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeViewController.swift
@@ -163,6 +163,11 @@ class NodeViewController: ProgressViewController {
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: indexPath.cellIdentifier, for: indexPath)
+        if #available(iOS 13.0, *) {
+            cell.textLabel?.textColor = .label
+        } else {
+            cell.textLabel?.textColor = .darkText
+        }
         
         if indexPath.isName {
             cell.textLabel?.text = indexPath.title
@@ -251,11 +256,6 @@ class NodeViewController: ProgressViewController {
             if node.isCompositionDataReceived {
                 let element = node.elements[indexPath.row]
                 cell.textLabel?.text = element.name ?? "Element \(element.index + 1)"
-                if #available(iOS 13.0, *) {
-                    cell.textLabel?.textColor = .label
-                } else {
-                    cell.textLabel?.textColor = .darkText
-                }
                 cell.detailTextLabel?.text = "\(element.models.count) models"
                 cell.accessoryType = .disclosureIndicator
                 cell.selectionStyle = .default
@@ -533,6 +533,10 @@ extension NodeViewController: MeshNetworkDelegate {
                             failedToSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address,
                             error: Error) {
+        // Ignore messages sent using model publication.
+        guard message is ConfigMessage else {
+            return
+        }
         done {
             self.presentAlert(title: "Error", message: error.localizedDescription)
             self.refreshControl?.endRefreshing()

--- a/Example/Source/View Controllers/Network/Configuration/SetHeartbeatPublicationViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/SetHeartbeatPublicationViewController.swift
@@ -321,6 +321,10 @@ extension SetHeartbeatPublicationViewController: MeshNetworkDelegate {
                             failedToSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address,
                             error: Error) {
+        // Ignore messages sent from model publication.
+        guard message is ConfigMessage else {
+            return
+        }
         done {
             self.presentAlert(title: "Error", message: error.localizedDescription)
         }

--- a/Example/Source/View Controllers/Network/Configuration/SetHeartbeatSubscriptionViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/SetHeartbeatSubscriptionViewController.swift
@@ -299,6 +299,10 @@ extension SetHeartbeatSubscriptionViewController: MeshNetworkDelegate {
                             failedToSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address,
                             error: Error) {
+        // Ignore messages sent from model publication.
+        guard message is ConfigMessage else {
+            return
+        }
         done {
             self.presentAlert(title: "Error", message: error.localizedDescription)
         }

--- a/Example/Source/View Controllers/Network/Configuration/SetPublicationViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/SetPublicationViewController.swift
@@ -420,6 +420,10 @@ extension SetPublicationViewController: MeshNetworkDelegate {
                             failedToSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address,
                             error: Error) {
+        // Ignore messages sent from model publication.
+        guard message is ConfigMessage else {
+            return
+        }
         done {
             self.presentAlert(title: "Error", message: error.localizedDescription)
         }

--- a/Example/Source/View Controllers/Network/Configuration/SubscribeViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/SubscribeViewController.swift
@@ -227,6 +227,10 @@ extension SubscribeViewController: MeshNetworkDelegate {
                             failedToSendMessage message: MeshMessage,
                             from localElement: Element, to destination: Address,
                             error: Error) {
+        // Ignore messages sent from model publication.
+        guard message is ConfigMessage else {
+            return
+        }
         done {
             self.presentAlert(title: "Error", message: error.localizedDescription)
         }


### PR DESCRIPTION
### Before

Each screen, from which it was possible to send a message, was listening to message failures.
Whenever a message failed to be sent, a popup with an error was displayed.

However, this also happened when the bearer was closed and there was no action from the user. For example, when the local node was configured to publish periodically, the error message was shown each time.

### After

The error message is only displayed for messages initiated by the user.