### PR TITLE
Support for Mesh 1.1 (Part 3: Models) - continuation

### DIFF
--- a/nRFMeshProvision/Mesh API/Model+Keys.swift
+++ b/nRFMeshProvision/Mesh API/Model+Keys.swift
@@ -54,10 +54,7 @@ public extension Model {
     ///
     /// Models that do not support App Key binding use Device Key on access layer security.
     var supportsApplicationKeyBinding: Bool {
-        if isConfigurationServer || isConfigurationClient {
-            return false
-        }
-        return true
+        return !requiresDeviceKey
     }
     
 }

--- a/nRFMeshProvision/Mesh API/Models.swift
+++ b/nRFMeshProvision/Mesh API/Models.swift
@@ -65,6 +65,25 @@ public extension Model {
         case .configurationClientModelId: return false
         case .healthServerModelId: return true
         case .healthClientModelId: return true
+        // Configuration models added in Mesh Protocol 1.1
+        case .remoteProvisioningServerModelId: return false
+        case .remoteProvisioningClientModelId: return false
+        case .directedForwardingConfigurationServerModelId: return false
+        case .directedForwardingConfigurationClientModelId: return false
+        case .bridgeConfigurationServerModelId: return false
+        case .bridgeConfigurationClientModelId: return false
+        case .privateBeaconServerModelId: return false
+        case .privateBeaconClientModelId: return false
+        case .onDemandPrivateProxyServerModelId: return false
+        case .onDemandPrivateProxyClientModelId: return false
+        case .sarConfigurationServerModelId: return false
+        case .sarConfigurationClientModelId: return false
+        case .opcodesAggregatorServerModelId: return false
+        case .opcodesAggregatorClientModelId: return false
+        case .largeCompositionDataServerModelId: return false
+        case .largeCompositionDataClientModelId: return false
+        case .solicitationPduRplConfigurationServerModelId: return false
+        case .solicitationPduRplConfigurationClientModelId: return false
         // Generic
         case .genericOnOffServerModelId: return true
         case .genericOnOffClientModelId: return true
@@ -140,6 +159,25 @@ public extension Model {
         case .configurationClientModelId: return false
         case .healthServerModelId: return true
         case .healthClientModelId: return true
+        // Configuration models added in Mesh Protocol 1.1
+        case .remoteProvisioningServerModelId: return false
+        case .remoteProvisioningClientModelId: return false
+        case .directedForwardingConfigurationServerModelId: return false
+        case .directedForwardingConfigurationClientModelId: return false
+        case .bridgeConfigurationServerModelId: return false
+        case .bridgeConfigurationClientModelId: return false
+        case .privateBeaconServerModelId: return false
+        case .privateBeaconClientModelId: return false
+        case .onDemandPrivateProxyServerModelId: return false
+        case .onDemandPrivateProxyClientModelId: return false
+        case .sarConfigurationServerModelId: return false
+        case .sarConfigurationClientModelId: return false
+        case .opcodesAggregatorServerModelId: return false
+        case .opcodesAggregatorClientModelId: return false
+        case .largeCompositionDataServerModelId: return false
+        case .largeCompositionDataClientModelId: return false
+        case .solicitationPduRplConfigurationServerModelId: return false
+        case .solicitationPduRplConfigurationClientModelId: return false
         // Generic
         case .genericOnOffServerModelId: return true
         case .genericOnOffClientModelId: return true

--- a/nRFMeshProvision/Mesh Model/Model.swift
+++ b/nRFMeshProvision/Mesh Model/Model.swift
@@ -225,7 +225,7 @@ internal extension Model {
     var isBridgeConfigurationServer: Bool { return modelId == UInt32(UInt16.bridgeConfigurationServerModelId) }
     var isBridgeConfigurationClient: Bool { return modelId == UInt32(UInt16.bridgeConfigurationClientModelId) }
     var isPrivateBeaconServer: Bool { return modelId == UInt32(UInt16.privateBeaconServerModelId) }
-    var isPrivateBeaconClient: Bool { return modelId == UInt32(UInt16.privateBeaconServerModelId) }
+    var isPrivateBeaconClient: Bool { return modelId == UInt32(UInt16.privateBeaconClientModelId) }
     var isOnDemandPrivateProxyServer: Bool { return modelId == UInt32(UInt16.onDemandPrivateProxyServerModelId) }
     var isOnDemandPrivateProxyClient: Bool { return modelId == UInt32(UInt16.onDemandPrivateProxyClientModelId) }
     var isSarConfigurationServer: Bool { return modelId == UInt32(UInt16.sarConfigurationServerModelId) }


### PR DESCRIPTION
This PR continues #468 by adding new models to `supportsModelPublication` and `supportsModelSubscriptions`.
It also fixes `supportsApplicationKeyBinding`.