### PR TITLE
Parsing sensor values fixed

### DIFF
--- a/nRFMeshProvision/Mesh Messages/DeviceProperty.swift
+++ b/nRFMeshProvision/Mesh Messages/DeviceProperty.swift
@@ -1296,7 +1296,7 @@ extension DevicePropertyCharacteristic: CustomDebugStringConvertible {
         // Decimal:
         case .pressure(let pressure):
             let float = NSDecimalNumber(decimal: pressure).floatValue
-            return String(format: "%.1f°C", max(0, min(Float(UInt32.max / 10), float)))
+            return String(format: "%.1f hPa", max(0, min(Float(UInt32.max / 10), float)))
             
         // Decimal?:
         case .percentage8(let percent):


### PR DESCRIPTION
This PR fixes #507.

Additionally, it fixes rounding errors when converting them to String. For example, Illuminance value 167772.13 (0xFFFFFFD) was parsed as 167772.12 as it was converted to float and represented as 167772.125 in between.