### PR TITLE
API improvement: contains methods added

### DIFF
--- a/nRFMeshProvision/Mesh API/MeshNetwork+Nodes.swift
+++ b/nRFMeshProvision/Mesh API/MeshNetwork+Nodes.swift
@@ -32,6 +32,23 @@ import Foundation
 
 public extension MeshNetwork {
     
+    /// Returns whether the given Node is in the mesh network.
+    ///
+    /// - parameter node: The Node to look for.
+    /// - returns: `True` if the Node was found, `false` otherwise.
+    func contains(node: Node) -> Bool {
+        return nodes.contains(node)
+    }
+    
+    /// Returns whether the Node with given UUID is in the
+    /// mesh network.
+    ///
+    /// - parameter uuid: The Node's UUID to look for.
+    /// - returns: `True` if the Node was found, `false` otherwise.
+    func contains(nodeWithUuid uuid: UUID) -> Bool {
+        return node(withUuid: uuid) != nil
+    }
+    
     /// Returns Provisioner's Node object, if such exist and the Provisioner
     /// is in the mesh network; `nil` otherwise.
     ///
@@ -43,7 +60,7 @@ public extension MeshNetwork {
     /// - parameter provisioner: The provisioner which node is to be returned.
     /// - returns: The Provisioner's node object, or `nil`.
     func node(for provisioner: Provisioner) -> Node? {
-        guard hasProvisioner(provisioner) else {
+        guard contains(provisioner: provisioner) else {
             return nil
         }
         return node(withUuid: provisioner.uuid)

--- a/nRFMeshProvision/Mesh API/MeshNetwork+Provisioner.swift
+++ b/nRFMeshProvision/Mesh API/MeshNetwork+Provisioner.swift
@@ -32,6 +32,23 @@ import Foundation
 
 public extension MeshNetwork {
     
+    /// Returns whether the Provisioner is in the mesh network.
+    ///
+    /// - parameter provisioner: The Provisioner to look for.
+    /// - returns: `True` if the Provisioner was found, `false` otherwise.
+    func contains(provisioner: Provisioner) -> Bool {
+        return provisioners.contains(provisioner)
+    }
+    
+    /// Returns whether the Provisioner with given UUID is in the
+    /// mesh network.
+    ///
+    /// - parameter uuid: The Provisioner's UUID to look for.
+    /// - returns: `True` if the Provisioner was found, `false` otherwise.
+    func contains(provisionerWithUuid uuid: UUID) -> Bool {
+        return provisioners.contains { $0.uuid == uuid }
+    }
+    
     /// Returns the local Provisioner, or `nil` if the mesh network
     /// does not have any.
     ///
@@ -52,7 +69,7 @@ public extension MeshNetwork {
     /// - parameter provisioner: The Provisioner to be used for provisioning.
     /// - throws: An error if adding the Provisioner failed.
     func setLocalProvisioner(_ provisioner: Provisioner) throws {
-        if !hasProvisioner(provisioner) {
+        if !contains(provisioner: provisioner) {
             try add(provisioner: provisioner)
         }
         
@@ -158,7 +175,7 @@ public extension MeshNetwork {
         }
         
         // Is it already added?
-        guard !hasProvisioner(provisioner) else {
+        guard !contains(provisioner: provisioner) else {
             return
         }
         
@@ -361,7 +378,7 @@ public extension MeshNetwork {
     ///           or is already used by some other Node in the mesh network.
     func assign(unicastAddress address: Address, for provisioner: Provisioner) throws {
         // Is the Provisioner in the network?
-        guard hasProvisioner(provisioner) else {
+        guard contains(provisioner: provisioner) else {
             throw MeshNetworkError.provisionerNotInNetwork
         }
         

--- a/nRFMeshProvision/Mesh API/Node+Provisioner.swift
+++ b/nRFMeshProvision/Mesh API/Node+Provisioner.swift
@@ -40,7 +40,7 @@ public extension Node {
     /// Returns whether the Node belongs to one of the Provisioners
     /// of the mesh network.
     var isProvisioner: Bool {
-        return meshNetwork?.hasProvisioner(with: uuid) ?? false
+        return meshNetwork?.contains(provisionerWithUuid: uuid) ?? false
     }
     
     /// Returns whether the Node belongs to the main Provisioner.

--- a/nRFMeshProvision/Mesh Model/MeshNetwork.swift
+++ b/nRFMeshProvision/Mesh Model/MeshNetwork.swift
@@ -422,23 +422,6 @@ public class MeshNetwork: Codable {
 
 extension MeshNetwork {
     
-    /// Returns whether the Provisioner is in the mesh network.
-    ///
-    /// - parameter provisioner: The Provisioner to look for.
-    /// - returns: `True` if the Provisioner was found, `false` otherwise.
-    func hasProvisioner(_ provisioner: Provisioner) -> Bool {
-        return provisioners.contains(provisioner)
-    }
-    
-    /// Returns whether the Provisioner with given UUID is in the
-    /// mesh network.
-    ///
-    /// - parameter uuid: The Provisioner's UUID to look for.
-    /// - returns: `True` if the Provisioner was found, `false` otherwise.
-    func hasProvisioner(with uuid: UUID) -> Bool {
-        return provisioners.contains { $0.uuid == uuid }
-    }
-    
     /// Removes the Provisioner's Node from the mesh network.
     ///
     /// - parameter provisioner: Provisioner, which Node should be removed.

--- a/nRFMeshProvision/MeshNetworkManager.swift
+++ b/nRFMeshProvision/MeshNetworkManager.swift
@@ -304,8 +304,8 @@ public extension MeshNetworkManager {
             print("Error: Mesh Network not created")
             throw MeshNetworkError.noNetwork
         }
-        guard meshNetwork.node(withUuid: unprovisionedDevice.uuid) == nil &&
-              !meshNetwork.provisioners.contains(where: { $0.uuid == unprovisionedDevice.uuid }) else {
+        guard !meshNetwork.contains(nodeWithUuid: unprovisionedDevice.uuid) &&
+              !meshNetwork.contains(provisionerWithUuid: unprovisionedDevice.uuid) else {
             throw MeshNetworkError.nodeAlreadyExist
         }
         return ProvisioningManager(for: unprovisionedDevice, over: bearer, in: meshNetwork)


### PR DESCRIPTION
4 new methods added to `MeshNetwork`:
- `contains(node: Node)`
- `contains(nodeWithUuid: UUID)`
- `contains(provisioner: Provisioner)`
- `contains(provisionerWithUuid: UUID)`