### PR TITLE
Switching GATT connection to newly provisioned node

### DIFF
--- a/Example/Source/Utils/UIViewController+Alert.swift
+++ b/Example/Source/Utils/UIViewController+Alert.swift
@@ -98,6 +98,22 @@ extension UIViewController {
     }
     
     /// Displays an alert dialog with given title and message.
+    ///
+    /// - parameters:
+    ///   - title:      The alert title.
+    ///   - message:    The message below the title.
+    ///   - actions:    Alert actions.
+    func presentAlert(title: String?, message: String?,
+                      options actions: [UIAlertAction]) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            actions.forEach { alert.addAction($0) }
+            self.present(alert, animated: true)
+        }
+    }
+    
+    /// Displays an alert dialog with given title and message.
     /// The alert dialog will contain two Text Fields allowing to
     /// specify a Range.
     ///

--- a/Example/Source/View Controllers/Proxy/Cells/DisconnectCell.swift
+++ b/Example/Source/View Controllers/Proxy/Cells/DisconnectCell.swift
@@ -36,6 +36,6 @@ class DisconnectCell: UITableViewCell {
     @IBOutlet weak var disconnectButton: UIButton!
     
     @IBAction func disconnectDidTapped(_ sender: UIButton) {
-        MeshNetworkManager.bearer.disconnectCurrent()
+        MeshNetworkManager.bearer.disconnect()
     }
 }


### PR DESCRIPTION
In some situations it is useful to connect to a newly provisioned node using GATT Proxy instead of relying on transporting messages over ADV Bearer. This is especially true for Low Power Nodes (LPN), which need to establish friendship before they can exchange messages. However, they may be open for GATT connections.

This PR adds a feature allowing to switch the GATT connection to a newly provisioned node. When the phone was connected to another GATT Proxy at the time of provisioning, a new dialog will be displayed allowing to disconnect it and connect to the new node.

> **Note**
> This will only work if the node doesn't change MAC address when switching to Mesh Proxy service. 

![Screen Shot 2023-06-01 at 12 48 23](https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/assets/6576580/77641cf9-2842-404d-a8a4-8d3b2283b5b9)
