### PR TITLE
API improvements for Key Refresh Procedure

### DIFF
--- a/nRFMeshProvision/Mesh API/MeshNetwork+Keys.swift
+++ b/nRFMeshProvision/Mesh API/MeshNetwork+Keys.swift
@@ -72,13 +72,10 @@ public extension MeshNetwork {
     ///           or the assigned Key Index is out of range.
     @discardableResult
     func add(applicationKey: Data, withIndex index: KeyIndex? = nil, name: String) throws -> ApplicationKey {
-        guard applicationKey.count == 16 else {
-            throw MeshNetworkError.invalidKey
-        }
         guard let defaultNetworkKey = networkKeys.first else {
             throw MeshNetworkError.noNetworkKey
         }
-        guard let nextIndex = index ?? nextAvailableApplicationKeyIndex, nextIndex.isValidKeyIndex else {
+        guard let nextIndex = index ?? nextAvailableApplicationKeyIndex else {
             throw MeshNetworkError.keyIndexOutOfRange
         }
         let key = try ApplicationKey(name: name, index: nextIndex,
@@ -146,10 +143,7 @@ public extension MeshNetwork {
     /// - seeAlso: ``MeshNetwork/nextAvailableNetworkKeyIndex``
     @discardableResult
     func add(networkKey: Data, withIndex index: KeyIndex? = nil, name: String) throws -> NetworkKey {
-        guard networkKey.count == 16 else {
-            throw MeshNetworkError.invalidKey
-        }
-        guard let nextIndex = index ?? nextAvailableNetworkKeyIndex, nextIndex.isValidKeyIndex else {
+        guard let nextIndex = index ?? nextAvailableNetworkKeyIndex else {
             throw MeshNetworkError.keyIndexOutOfRange
         }
         let key = try NetworkKey(name: name, index: nextIndex, key: networkKey)

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyAdd.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyAdd.swift
@@ -30,6 +30,15 @@
 
 import Foundation
 
+/// A `ConfigAppKeyAdd` is an acknowledged message used to add an ``ApplicationKey``
+/// to the AppKey List on a Node and bind it to the ``NetworkKey`` identified by
+/// ``NetworkKey/index``.
+///
+/// The added Application Key can be used by the Node only as a pair with the specified
+/// Network Key.
+///
+/// The Application Key is used to authenticate and decrypt messages it receives,
+/// as well as authenticate and encrypt messages it sends.
 public struct ConfigAppKeyAdd: AcknowledgedConfigMessage, ConfigNetAndAppKeyMessage {
     public static let opCode: UInt32 = 0x00
     public static let responseType: StaticMeshMessage.Type = ConfigAppKeyStatus.self
@@ -43,6 +52,13 @@ public struct ConfigAppKeyAdd: AcknowledgedConfigMessage, ConfigNetAndAppKeyMess
     /// The 128-bit Application Key data.
     public let key: Data
     
+    /// Creates a ``ConfigAppKeyAdd`` message.
+    ///
+    /// Use ``MeshNetwork/add(applicationKey:withIndex:name:)`` to create a new
+    /// ``ApplicationKey`` and bind it to selected ``NetworkKey`` using
+    /// ``ApplicationKey/bind(to:)``.
+    ///
+    /// - parameter applicationKey: The Application Key to be added.
     public init(applicationKey: ApplicationKey) {
         self.applicationKeyIndex = applicationKey.index
         self.networkKeyIndex = applicationKey.boundNetworkKey.index

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyDelete.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyDelete.swift
@@ -30,6 +30,16 @@
 
 import Foundation
 
+/// A `ConfigAppKeyDelete` is an acknowledged message used to delete an ``ApplicationKey``
+/// from the AppKey List on a Node.
+///
+/// To remove the key from the local Node you may use ``MeshNetwork/remove(applicationKey:force:)``.
+///
+/// - warning: It is not guaranteed, that the target Node will remove the key from its
+///            AppKey List. To make sure the Node gets excluded, use ``ConfigAppKeyUpdate``
+///            to update the value of the key and skip the Node when distributing the new
+///            value. After the Key Refresh Procedure is complete, the target Node will
+///            effectively be excluded from the mesh network.
 public struct ConfigAppKeyDelete: AcknowledgedConfigMessage, ConfigNetAndAppKeyMessage {
     public static let opCode: UInt32 = 0x8000
     public static let responseType: StaticMeshMessage.Type = ConfigAppKeyStatus.self
@@ -41,6 +51,9 @@ public struct ConfigAppKeyDelete: AcknowledgedConfigMessage, ConfigNetAndAppKeyM
     public let networkKeyIndex: KeyIndex
     public let applicationKeyIndex: KeyIndex
     
+    /// Creates a ``ConfigAppKeyDelete`` message.
+    ///
+    /// - Parameter applicationKey: The Application Key to be removed.
     public init(applicationKey: ApplicationKey) {
         self.applicationKeyIndex = applicationKey.index
         self.networkKeyIndex = applicationKey.boundNetworkKey.index

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyGet.swift
@@ -30,6 +30,10 @@
 
 import Foundation
 
+/// A `ConfigAppKeyGet` is an acknowledged message used to report all ``ApplicationKey``s
+/// known to the Node that are bound to the given ``NetworkKey``.
+///
+/// The response to this message is a ``ConfigNetKeyList`` message.
 public struct ConfigAppKeyGet: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8001
     public static let responseType: StaticMeshMessage.Type = ConfigAppKeyList.self
@@ -40,6 +44,9 @@ public struct ConfigAppKeyGet: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     
     public let networkKeyIndex: KeyIndex
     
+    /// Creates a ``ConfigAppKeyGet`` message.
+    ///
+    /// - parameter networkKey: The Network Key for which Application Keys are requested.
     public init(networkKey: NetworkKey) {
         self.networkKeyIndex = networkKey.index
     }

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyList.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyList.swift
@@ -30,6 +30,8 @@
 
 import Foundation
 
+/// A `ConfigAppKeyList` is an unacknowledged message reporting all ``ApplicationKey``s
+/// bound to requested ``NetworkKey`` that are known to the Node.
 public struct ConfigAppKeyList: ConfigStatusMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8002
     
@@ -43,12 +45,22 @@ public struct ConfigAppKeyList: ConfigStatusMessage, ConfigNetKeyMessage {
     /// Application Key Indexes bound to the Network Key known to the Node.
     public let applicationKeyIndexes: [KeyIndex]
     
+    /// Creates a ``ConfigAppKeyList`` message.
+    ///
+    /// - parameters:
+    ///   - request: The request, for which this message is to be sent.
+    ///   - applicationKeys: The list of Application Keys.
     public init(responseTo request: ConfigAppKeyGet, with applicationKeys: [ApplicationKey]) {
         self.networkKeyIndex = request.networkKeyIndex
         self.applicationKeyIndexes = applicationKeys.map { return $0.index }
         self.status = .success
     }
     
+    /// Creates a ``ConfigAppKeyList`` message in case the request has failed.
+    ///
+    /// - parameters:
+    ///   - request: The request, for which this message is to be sent.
+    ///   - status: The response status.
     public init(responseTo request: ConfigAppKeyGet, with status: ConfigMessageStatus) {
         self.networkKeyIndex = request.networkKeyIndex
         self.applicationKeyIndexes = []

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyStatus.swift
@@ -30,6 +30,10 @@
 
 import Foundation
 
+/// A `ConfigAppKeyStatus` is an unacknowledged message used to report a status for
+/// the requesting message, based on the ``NetworkKey/index`` identifying the
+/// ``NetworkKey`` on the NetKey List and on the ``ApplicationKey/index`` identifying
+/// the ``ApplicationKey`` on the AppKey List.
 public struct ConfigAppKeyStatus: ConfigNetAndAppKeyMessage, ConfigStatusMessage {
     public static let opCode: UInt32 = 0x8003  
     
@@ -41,12 +45,20 @@ public struct ConfigAppKeyStatus: ConfigNetAndAppKeyMessage, ConfigStatusMessage
     public let applicationKeyIndex: KeyIndex
     public let status: ConfigMessageStatus
     
+    /// Creates a ``ConfigAppKeyStatus`` message confirming the request.
+    ///
+    /// - parameter applicationKey: The Application Key to confirm.
     public init(confirm applicationKey: ApplicationKey) {
         self.applicationKeyIndex = applicationKey.index
         self.networkKeyIndex = applicationKey.boundNetworkKey.index
         self.status = .success
     }
     
+    /// Creates a ``ConfigAppKeyStatus`` message in case of a failure.
+    ///
+    /// - parameters:
+    ///   - request: The request, for which this message is to be sent.
+    ///   - status: The response status.
     public init(responseTo request: ConfigNetAndAppKeyMessage, with status: ConfigMessageStatus) {
         self.applicationKeyIndex = request.applicationKeyIndex
         self.networkKeyIndex = request.networkKeyIndex

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyUpdate.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyUpdate.swift
@@ -30,6 +30,15 @@
 
 import Foundation
 
+/// A `ConfigAppKeyUpdate` is an acknowledged message used to update an ``ApplicationKey``
+/// value on the AppKey List on a Node.
+///
+/// This message initiates a Key Refresh Procedure. The message can be sent to
+/// remote nodes which are not scheduled for exclusion (see ``Node/isExcluded``).
+///
+/// To update the key on the local Node use  ``MeshNetworkManager/sendToLocalNode(_:)``.
+///
+/// To transition to the next phases of the Key Refresh Procedure use ``ConfigKeyRefreshPhaseSet``.
 public struct ConfigAppKeyUpdate: AcknowledgedConfigMessage, ConfigNetAndAppKeyMessage {
     public static let opCode: UInt32 = 0x01
     public static let responseType: StaticMeshMessage.Type = ConfigAppKeyStatus.self

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyUpdate.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyUpdate.swift
@@ -52,10 +52,15 @@ public struct ConfigAppKeyUpdate: AcknowledgedConfigMessage, ConfigNetAndAppKeyM
     /// The 128-bit Application Key data.
     public let key: Data
     
-    public init(applicationKey: ApplicationKey) {
+    /// Creates a ``ConfigAppKeyUpdate`` message.
+    /// 
+    /// - parameters:
+    ///   - applicationKey: The Application Key to be updated.
+    ///   - newKey: The new value of the key. The key must be 128-bit long.
+    public init(applicationKey: ApplicationKey, with newKey: Data) throws {
         self.applicationKeyIndex = applicationKey.index
         self.networkKeyIndex = applicationKey.boundNetworkKey.index
-        self.key = applicationKey.key
+        self.key = newKey
     }
     
     public init?(parameters: Data) {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyAdd.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyAdd.swift
@@ -30,6 +30,11 @@
 
 import Foundation
 
+/// A `ConfigNetKeyAdd` is an acknowledged message used to add an ``NetworkKey``
+/// to the NetKey List on a Node.
+///
+/// The Network Key is used to authenticate and decrypt messages it receives,
+/// as well as authenticate and encrypt messages it sends.
 public struct ConfigNetKeyAdd: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8040
     public static let responseType: StaticMeshMessage.Type = ConfigNetKeyStatus.self
@@ -42,6 +47,11 @@ public struct ConfigNetKeyAdd: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     /// The 128-bit Application Key data.
     public let key: Data
     
+    /// Creates a ``ConfigNetKeyAdd`` message.
+    ///
+    /// Use ``MeshNetwork/add(networkKey:withIndex:name:)`` to create a new ``NetworkKey``.
+    ///
+    /// - parameter networkKey: The new Network Key.
     public init(networkKey: NetworkKey) {
         self.networkKeyIndex = networkKey.index
         self.key = networkKey.key

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyDelete.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyDelete.swift
@@ -30,6 +30,16 @@
 
 import Foundation
 
+/// A `ConfigNetKeyDelete` is an acknowledged message used to delete an ``NetworkKey``
+/// from the NetKey List on a Node.
+///
+/// To remove the key from the local Node you may use ``MeshNetwork/remove(networkKey:force:)``.
+///
+/// - warning: It is not guaranteed, that the target Node will remove the key from its
+///            NetKey List. To make sure the Node gets excluded, use ``ConfigNetKeyUpdate``
+///            to update the value of the key and skip the Node when distributing the new
+///            value. After the Key Refresh Procedure is complete, the target Node will
+///            effectively be excluded from the mesh network.
 public struct ConfigNetKeyDelete: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8041
     public static let responseType: StaticMeshMessage.Type = ConfigNetKeyStatus.self
@@ -40,6 +50,9 @@ public struct ConfigNetKeyDelete: AcknowledgedConfigMessage, ConfigNetKeyMessage
     
     public let networkKeyIndex: KeyIndex
     
+    /// Creates a ``ConfigNetKeyDelete`` message.
+    ///
+    /// - Parameter networkKey: The Network Key to be removed.
     public init(networkKey: NetworkKey) {
         self.networkKeyIndex = networkKey.index
     }

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyGet.swift
@@ -30,6 +30,10 @@
 
 import Foundation
 
+/// A `ConfigNetKeyGet` is an acknowledged message used to report all ``NetworkKey``s
+/// known to the Node.
+///
+/// The response to this message is a ``ConfigNetKeyList`` message.
 public struct ConfigNetKeyGet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8042
     public static let responseType: StaticMeshMessage.Type = ConfigNetKeyList.self
@@ -38,6 +42,7 @@ public struct ConfigNetKeyGet: AcknowledgedConfigMessage {
         return nil
     }
     
+    /// Creates a ``ConfigNetKeyGet`` message.
     public init() {
         // Empty
     }

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyList.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyList.swift
@@ -30,6 +30,8 @@
 
 import Foundation
 
+/// A `ConfigNetKeyList` is an unacknowledged message reporting all ``NetworkKey``s
+/// known to the Node.
 public struct ConfigNetKeyList: ConfigMessage {
     public static let opCode: UInt32 = 0x8043
     
@@ -40,6 +42,10 @@ public struct ConfigNetKeyList: ConfigMessage {
     /// Network Key Indexes known to the Node.
     public let networkKeyIndexes: [KeyIndex]
     
+    /// Creates a ``ConfigNetKeyList`` message.
+    ///
+    /// - parameter networkKeys: The list of Network Keys bound to the requested
+    ///                          ``ApplicationKey`` that are known to the Node.
     public init(networkKeys: [NetworkKey]) {
         self.networkKeyIndexes = networkKeys.map { return $0.index }
     }

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyStatus.swift
@@ -30,6 +30,8 @@
 
 import Foundation
 
+/// A `ConfigNetKeyStatus` is an unacknowledged message used to report the status of
+/// the operation on the NetKey List.
 public struct ConfigNetKeyStatus: ConfigNetKeyMessage, ConfigStatusMessage {
     public static let opCode: UInt32 = 0x8044
     
@@ -40,11 +42,19 @@ public struct ConfigNetKeyStatus: ConfigNetKeyMessage, ConfigStatusMessage {
     public let networkKeyIndex: KeyIndex
     public let status: ConfigMessageStatus
     
+    /// Creates a ``ConfigNetKeyStatus`` message confirming the request.
+    ///
+    /// - parameter networkKey: The Network Key to confirm.
     public init(confirm networkKey: NetworkKey) {
         self.networkKeyIndex = networkKey.index
         self.status = .success
     }
     
+    /// Creates a ``ConfigNetKeyStatus`` message in case of a failure.
+    ///
+    /// - parameters:
+    ///   - request: The request, for which this message is to be sent.
+    ///   - status: The response status.
     public init(responseTo request: ConfigNetKeyMessage, with status: ConfigMessageStatus) {
         self.networkKeyIndex = request.networkKeyIndex
         self.status = status

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyUpdate.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyUpdate.swift
@@ -51,9 +51,17 @@ public struct ConfigNetKeyUpdate: AcknowledgedConfigMessage, ConfigNetKeyMessage
     /// The 128-bit Application Key data.
     public let key: Data
     
-    public init(networkKey: NetworkKey) {
+    /// Creates a ``ConfigNetKeyUpdate`` message.
+    ///
+    /// - parameters:
+    ///   - networkKey: The Network Key to be updated.
+    ///   - newKey: The new value of the key. The key must be 128-bit long.
+    public init(networkKey: NetworkKey, with newKey: Data) throws {
+        guard newKey.count == 16 else {
+            throw MeshNetworkError.invalidKey
+        }
         self.networkKeyIndex = networkKey.index
-        self.key = networkKey.key
+        self.key = newKey
     }
     
     public init?(parameters: Data) {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyUpdate.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyUpdate.swift
@@ -30,6 +30,15 @@
 
 import Foundation
 
+/// A `ConfigNetKeyUpdate` is an acknowledged message used to update a ``NetworkKey`` on
+/// a Node.
+///
+/// This message initiates a Key Refresh Procedure. The message can be sent to
+/// remote nodes which are not scheduled for exclusion (see ``Node/isExcluded``).
+///
+/// To update the key on the local Node use  ``MeshNetworkManager/sendToLocalNode(_:)``.
+///
+/// To transition to the next phases of the Key Refresh Procedure use ``ConfigKeyRefreshPhaseSet``.
 public struct ConfigNetKeyUpdate: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8045
     public static let responseType: StaticMeshMessage.Type = ConfigNetKeyStatus.self

--- a/nRFMeshProvision/Mesh Model/ApplicationKey.swift
+++ b/nRFMeshProvision/Mesh Model/ApplicationKey.swift
@@ -81,6 +81,9 @@ public class ApplicationKey: Key, Codable {
     internal var oldAid: UInt8?
     
     internal init(name: String, index: KeyIndex, key: Data, boundTo networkKey: NetworkKey) throws {
+        guard key.count == 16 else {
+            throw MeshNetworkError.invalidKey
+        }
         guard index.isValidKeyIndex else {
             throw MeshNetworkError.keyIndexOutOfRange
         }

--- a/nRFMeshProvision/Mesh Model/NetworkKey.swift
+++ b/nRFMeshProvision/Mesh Model/NetworkKey.swift
@@ -102,8 +102,9 @@ public class NetworkKey: Key, Codable {
             regenerateKeyDerivatives()
         }
     }
-    /// The old Network Key is present when the phase property has a non-zero
-    /// value, such as when a Key Refresh procedure is in progress.
+    /// The old Network Key is present when the phase property has a different
+    /// value than ``KeyRefreshPhase/normalOperation``, such as when a Key Refresh
+    /// procedure is in progress.
     public internal(set) var oldKey: Data? {
         didSet {
             if oldKey == nil {

--- a/nRFMeshProvision/Mesh Model/NetworkKey.swift
+++ b/nRFMeshProvision/Mesh Model/NetworkKey.swift
@@ -142,6 +142,9 @@ public class NetworkKey: Key, Codable {
     }
     
     internal init(name: String, index: KeyIndex, key: Data) throws {
+        guard key.count == 16 else {
+            throw MeshNetworkError.invalidKey
+        }
         guard index.isValidKeyIndex else {
             throw MeshNetworkError.keyIndexOutOfRange
         }


### PR DESCRIPTION
This PR fixes #477.

The API of `ConfigNetKeyUpdate` and `ConfigAppKeyUpdate` was change to allow passing the new key value.

Use the 2 messages to initiate Key Refresh Procedure on a node. The messages can also be sent to the local node.

This PR also adds of documentation for `Config[Type]Key[Action]` messages.