### PR TITLE
Fixed updating Relay Count slider value

### DIFF
--- a/Example/Source/View Controllers/Network/Configuration/Model/ConfigurationServerViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/ConfigurationServerViewCell.swift
@@ -110,7 +110,7 @@ class ConfigurationServerViewCell: ModelViewCell {
                 relayIntervalSlider.value = Float(relay.steps)
                 relayIntervalSlider.isEnabled = true
                 relayIntervalDidChange(relayIntervalSlider)
-                relayCountSlider.value = Float(relay.count)
+                relayCountSlider.value = Float(relay.count - 1)
                 relayCountDidChange(relayCountSlider)
             } else if delegate.isRefreshing {
                 relayCountLabel.text = "Not supported"


### PR DESCRIPTION
This PR fixes how the Relay Count slider is updated in Configuration Server screen.
It used to show the count increased by 1. Clicking *Set Relay* button in a loop was increasing the Relay count state.