### PR TITLE
Breaking: Message callbacks

### DIFF
--- a/Example/Source/Mesh Network/GenericDefaultTransitionTimeClientDelegate.swift
+++ b/Example/Source/Mesh Network/GenericDefaultTransitionTimeClientDelegate.swift
@@ -58,7 +58,7 @@ class GenericDefaultTransitionTimeClientDelegate: ModelDelegate {
     }
     
     init() {
-        let types: [GenericMessage.Type] = [
+        let types: [StaticMeshMessage.Type] = [
             GenericDefaultTransitionTimeStatus.self
         ]
         messageTypes = types.toMap()
@@ -67,18 +67,18 @@ class GenericDefaultTransitionTimeClientDelegate: ModelDelegate {
     // MARK: - Message handlers
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) throws -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) throws -> MeshResponse {
         fatalError("Not possible")
     }
     
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         // The status message may be received here if the Generic Default
         // Transition Time Server model has been configured to publish.
         // Ignore this message.
     }
     
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address) {
         // Ignore.

--- a/Example/Source/Mesh Network/GenericDefaultTransitionTimeServerDelegate.swift
+++ b/Example/Source/Mesh Network/GenericDefaultTransitionTimeServerDelegate.swift
@@ -48,7 +48,7 @@ class GenericDefaultTransitionTimeServerDelegate: ModelDelegate {
     private let defaults: UserDefaults
     
     init(_ meshNetwork: MeshNetwork) {
-        let types: [GenericMessage.Type] = [
+        let types: [StaticMeshMessage.Type] = [
             GenericDefaultTransitionTimeGet.self,
             GenericDefaultTransitionTimeSet.self,
             GenericDefaultTransitionTimeSetUnacknowledged.self
@@ -63,7 +63,7 @@ class GenericDefaultTransitionTimeServerDelegate: ModelDelegate {
     // MARK: - Message handlers
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) throws -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) throws -> MeshResponse {
         switch request {
             
         case let request as GenericDefaultTransitionTimeSet:
@@ -85,7 +85,7 @@ class GenericDefaultTransitionTimeServerDelegate: ModelDelegate {
         return GenericDefaultTransitionTimeStatus(transitionTime: defaultTransitionTime)
     }
     
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         switch message {
             
@@ -103,7 +103,7 @@ class GenericDefaultTransitionTimeServerDelegate: ModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address) {
         // Not possible.

--- a/Example/Source/Mesh Network/GenericLevelClientDelegate.swift
+++ b/Example/Source/Mesh Network/GenericLevelClientDelegate.swift
@@ -53,7 +53,7 @@ class GenericLevelClientDelegate: ModelDelegate {
     }
     
     init() {
-        let types: [GenericMessage.Type] = [
+        let types: [StaticMeshMessage.Type] = [
             GenericLevelStatus.self
         ]
         messageTypes = types.toMap()
@@ -62,17 +62,17 @@ class GenericLevelClientDelegate: ModelDelegate {
     // MARK: - Message handlers
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) -> MeshResponse {
         fatalError("Not possible")
     }
     
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         // The status message may be received here if the Generic Level Server model
         // has been configured to publish. Ignore this message.
     }
     
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address){
         // Ignore.

--- a/Example/Source/Mesh Network/GenericLevelServerDelegate.swift
+++ b/Example/Source/Mesh Network/GenericLevelServerDelegate.swift
@@ -102,7 +102,7 @@ class GenericLevelServerDelegate: StoredWithSceneModelDelegate {
     init(_ meshNetwork: MeshNetwork,
          defaultTransitionTimeServer delegate: GenericDefaultTransitionTimeServerDelegate,
          elementIndex: UInt8) {
-        let types: [GenericMessage.Type] = [
+        let types: [StaticMeshMessage.Type] = [
             GenericLevelGet.self,
             GenericLevelSet.self,
             GenericLevelSetUnacknowledged.self,
@@ -145,7 +145,7 @@ class GenericLevelServerDelegate: StoredWithSceneModelDelegate {
     // MARK: - Message handlers
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) -> MeshResponse {
         switch request {
         case let request as GenericLevelSet:
             // Ignore a repeated request (with the same TID) from the same source
@@ -228,7 +228,7 @@ class GenericLevelServerDelegate: StoredWithSceneModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         switch message {
         case let request as GenericLevelSetUnacknowledged:
@@ -301,7 +301,7 @@ class GenericLevelServerDelegate: StoredWithSceneModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address) {
         // Not possible.

--- a/Example/Source/Mesh Network/GenericOnOffClientDelegate.swift
+++ b/Example/Source/Mesh Network/GenericOnOffClientDelegate.swift
@@ -54,7 +54,7 @@ class GenericOnOffClientDelegate: ModelDelegate {
     }
     
     init() {
-        let types: [GenericMessage.Type] = [
+        let types: [StaticMeshMessage.Type] = [
             GenericOnOffStatus.self
         ]
         messageTypes = types.toMap()
@@ -63,17 +63,17 @@ class GenericOnOffClientDelegate: ModelDelegate {
     // MARK: - Message handlers
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) -> MeshResponse {
         fatalError("Not possible")
     }
     
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         // The status message may be received here if the Generic OnOff Server model
         // has been configured to publish. Ignore this message.
     }
     
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address) {
         // Ignore.

--- a/Example/Source/Mesh Network/GenericOnOffServerDelegate.swift
+++ b/Example/Source/Mesh Network/GenericOnOffServerDelegate.swift
@@ -102,7 +102,7 @@ class GenericOnOffServerDelegate: StoredWithSceneModelDelegate {
     init(_ meshNetwork: MeshNetwork,
          defaultTransitionTimeServer delegate: GenericDefaultTransitionTimeServerDelegate,
          elementIndex: UInt8) {
-        let types: [GenericMessage.Type] = [
+        let types: [StaticMeshMessage.Type] = [
             GenericOnOffGet.self,
             GenericOnOffSet.self,
             GenericOnOffSetUnacknowledged.self
@@ -141,7 +141,7 @@ class GenericOnOffServerDelegate: StoredWithSceneModelDelegate {
     // MARK: - Message handlers
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) -> MeshResponse {
         switch request {
         case let request as GenericOnOffSet:
             // Ignore a repeated request (with the same TID) from the same source
@@ -179,7 +179,7 @@ class GenericOnOffServerDelegate: StoredWithSceneModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         switch message {
         case let request as GenericOnOffSetUnacknowledged:
@@ -207,7 +207,7 @@ class GenericOnOffServerDelegate: StoredWithSceneModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address) {
         // Not possible.

--- a/Example/Source/Mesh Network/GenericPowerOnOffClientDelegate.swift
+++ b/Example/Source/Mesh Network/GenericPowerOnOffClientDelegate.swift
@@ -53,7 +53,7 @@ class GenericPowerOnOffClientDelegate: ModelDelegate {
     }
     
     init() {
-        let types: [GenericMessage.Type] = [
+        let types: [StaticMeshMessage.Type] = [
             GenericOnPowerUpStatus.self
         ]
         messageTypes = types.toMap()
@@ -62,17 +62,17 @@ class GenericPowerOnOffClientDelegate: ModelDelegate {
     // MARK: - Message handlers
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) -> MeshResponse {
         fatalError("Message not supported: \(request)")
     }
     
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         // The status message may be received here if the Generic Power OnOff Server model
         // has been configured to publish. Ignore this message.
     }
     
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address) {
         // Ignore.

--- a/Example/Source/Mesh Network/SceneServerDelegate.swift
+++ b/Example/Source/Mesh Network/SceneServerDelegate.swift
@@ -88,7 +88,7 @@ class SceneServerDelegate: SceneServerModelDelegate {
     
     init(_ meshNetwork: MeshNetwork,
          defaultTransitionTimeServer delegate: GenericDefaultTransitionTimeServerDelegate) {
-        let types: [GenericMessage.Type] = [
+        let types: [StaticMeshMessage.Type] = [
             SceneGet.self,
             SceneRegisterGet.self,
             SceneRecall.self,
@@ -112,7 +112,7 @@ class SceneServerDelegate: SceneServerModelDelegate {
     // MARK: - Message handlers
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) throws -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) throws -> MeshResponse {
         switch request {
         case is SceneRegisterGet:
             // When a Scene Server receives a Scene Register Get message, it shall respond
@@ -190,7 +190,7 @@ class SceneServerDelegate: SceneServerModelDelegate {
         return SceneStatus(report: currentScene)
     }
     
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         switch message {
         case let request as SceneRecallUnacknowledged:
@@ -254,7 +254,7 @@ class SceneServerDelegate: SceneServerModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage, from source: Address) {
         // Not possible.
     }

--- a/Example/Source/Mesh Network/SceneSetupServerDelegate.swift
+++ b/Example/Source/Mesh Network/SceneSetupServerDelegate.swift
@@ -43,7 +43,7 @@ class SceneSetupServerDelegate: ModelDelegate {
     let publicationMessageComposer: MessageComposer? = nil
     
     init(server delegate: SceneServerDelegate) {
-        let types: [GenericMessage.Type] = [
+        let types: [StaticMeshMessage.Type] = [
             SceneStore.self,
             SceneStoreUnacknowledged.self,
             SceneDelete.self,
@@ -56,7 +56,7 @@ class SceneSetupServerDelegate: ModelDelegate {
     // MARK: - Message handlers
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) throws -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) throws -> MeshResponse {
         switch request {
         case let request as SceneStore:
             // Little validation.
@@ -103,7 +103,7 @@ class SceneSetupServerDelegate: ModelDelegate {
         return SceneRegisterStatus(report: currentScene, and: storedScenes)
     }
     
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         switch message {
         case let request as SceneStoreUnacknowledged:
@@ -144,7 +144,7 @@ class SceneSetupServerDelegate: ModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address) {
         // Not possible.

--- a/Example/Source/Mesh Network/SensorClientDelegate.swift
+++ b/Example/Source/Mesh Network/SensorClientDelegate.swift
@@ -39,7 +39,7 @@ class SensorClientDelegate: ModelDelegate {
     let publicationMessageComposer: MessageComposer? = nil
     
     init() {
-        let types: [SensorMessage.Type] = [
+        let types: [StaticMeshMessage.Type] = [
             SensorDescriptorStatus.self,
             SensorCadenceStatus.self,
             SensorSettingsStatus.self,
@@ -52,7 +52,7 @@ class SensorClientDelegate: ModelDelegate {
     }
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) throws -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) throws -> MeshResponse {
         switch request {
             // No acknowledged message supported by this Model.
         default:
@@ -60,12 +60,12 @@ class SensorClientDelegate: ModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         handle(message, sentFrom: source)
     }
     
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address) {
         handle(response, sentFrom: source)

--- a/Example/Source/Mesh Network/Simple OnOff/Messages/SimpleOnOffGet.swift
+++ b/Example/Source/Mesh Network/Simple OnOff/Messages/SimpleOnOffGet.swift
@@ -38,7 +38,7 @@ struct SimpleOnOffGet: AcknowledgedStaticVendorMessage {
     // 0x00-5900 - Nordic Semiconductor ASA company ID (in Little Endian) as defined here:
     //             https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/
     static let opCode: UInt32 = 0xC25900
-    static let responseType: StaticMeshMessage.Type = SimpleOnOffStatus.self
+    static let responseType: StaticMeshResponse.Type = SimpleOnOffStatus.self
     
     var parameters: Data? {
         return Data()

--- a/Example/Source/Mesh Network/Simple OnOff/Messages/SimpleOnOffSet.swift
+++ b/Example/Source/Mesh Network/Simple OnOff/Messages/SimpleOnOffSet.swift
@@ -38,7 +38,7 @@ struct SimpleOnOffSet: AcknowledgedStaticVendorMessage {
     // 0x00-5900 - Nordic Semiconductor ASA company ID (in Little Endian) as defined here:
     //             https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/
     static let opCode: UInt32 = 0xC15900
-    static let responseType: StaticMeshMessage.Type = SimpleOnOffStatus.self
+    static let responseType: StaticMeshResponse.Type = SimpleOnOffStatus.self
     
     var parameters: Data? {
         return Data([isOn ? 0x01 : 0x00])

--- a/Example/Source/Mesh Network/Simple OnOff/Messages/SimpleOnOffStatus.swift
+++ b/Example/Source/Mesh Network/Simple OnOff/Messages/SimpleOnOffStatus.swift
@@ -31,7 +31,7 @@
 import Foundation
 import nRFMeshProvision
 
-struct SimpleOnOffStatus: StaticVendorMessage {
+struct SimpleOnOffStatus: StaticVendorResponse {
     // The Op Code consists of:
     // 0xC0-0000 - Vendor Op Code bitmask
     // 0x04-0000 - The Op Code defined by...

--- a/Example/Source/Mesh Network/Simple OnOff/SimpleOnOffClientDelegate.swift
+++ b/Example/Source/Mesh Network/Simple OnOff/SimpleOnOffClientDelegate.swift
@@ -78,14 +78,14 @@ class SimpleOnOffClientDelegate: ModelDelegate {
     
     func model(_ model: Model,
                didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) -> MeshResponse {
         // This method will never be called for this Model, as the single message
         // type it supports (defines in `messageTypes`) is unacknowledged.
         fatalError("What has just happened?")
     }
     
     func model(_ model: Model,
-               didReceiveUnacknowledgedMessage message: MeshMessage,
+               didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         // A Simple OnOff Server may send status messages that do not reply
         // to any acknowledged messages, for example may publish the state
@@ -109,7 +109,7 @@ class SimpleOnOffClientDelegate: ModelDelegate {
     }
     
     func model(_ model: Model,
-               didReceiveResponse response: MeshMessage,
+               didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage, from source: Address) {
         // This message for sure did not change the state.
         let stateNotChanged = request is SimpleOnOffGet

--- a/Example/Source/View Controllers/Network/Configuration/Model/ModelViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/ModelViewCell.swift
@@ -44,7 +44,7 @@ protocol ModelViewCellDelegate: AnyObject {
     ///
     /// - parameter message: The message to be sent.
     /// - parameter description: The message to be displayed for the user.
-    func send(_ message: ConfigMessage, description: String)
+    func send(_ message: AcknowledgedConfigMessage, description: String)
     
     /// Whether the view is being refreshed with Pull-to-Refresh or not.
     var isRefreshing: Bool { get }

--- a/Example/Source/View Controllers/Network/Configuration/ModelViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/ModelViewController.swift
@@ -618,11 +618,18 @@ extension ModelViewController: ModelViewCellDelegate {
         }
         currentMessage = message
         start(description) {
-            return try MeshNetworkManager.instance.send(message, to: model)
+            switch message {
+            case let request as AcknowledgedMeshMessage:
+                return try MeshNetworkManager.instance.send(request, to: model)
+            case let command as UnacknowledgedMeshMessage:
+                return try MeshNetworkManager.instance.send(command, to: model)
+            default:
+                return nil
+            }
         }
     }
     
-    func send(_ message: ConfigMessage, description: String) {
+    func send(_ message: AcknowledgedConfigMessage, description: String) {
         guard let node = model?.parentElement?.parentNode else {
             return
         }
@@ -778,7 +785,7 @@ extension ModelViewController: MeshNetworkDelegate {
                 presentAlert(title: "Error", message: status.message)
             }
             
-        case let list as ConfigModelAppList:
+        case let list as ConfigModelAppList & StatusMessage:
             if list.isSuccess {
                 reloadSections([.appKeyBinding, .publication], with: .automatic)
                 if model.supportsModelSubscriptions ?? true {
@@ -814,7 +821,7 @@ extension ModelViewController: MeshNetworkDelegate {
                 presentAlert(title: "Error", message: status.message)
             }
             
-        case let list as ConfigModelSubscriptionList:
+        case let list as ConfigModelSubscriptionList & StatusMessage:
             if list.isSuccess {
                 reloadSections(.subscriptions, with: .automatic)
                 if model.supportsModelPublication ?? true {

--- a/Example/Source/View Controllers/Network/Configuration/SetHeartbeatPublicationViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/SetHeartbeatPublicationViewController.swift
@@ -248,7 +248,7 @@ private extension SetHeartbeatPublicationViewController {
         let ttl = self.ttl
         
         start("Setting Heartbeat Publication...") { [features] in
-            let message: ConfigMessage =
+            let message: AcknowledgedConfigMessage =
                 ConfigHeartbeatPublicationSet(startSending: countLog,
                                               heartbeatMessagesEvery: periodLog,
                                               secondsTo: destination,

--- a/Example/Source/View Controllers/Network/Configuration/SetHeartbeatSubscriptionViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/SetHeartbeatSubscriptionViewController.swift
@@ -242,7 +242,7 @@ private extension SetHeartbeatSubscriptionViewController {
         let periodLog = self.periodLog
         
         start("Setting Heartbeat Subscription...") {
-            let message: ConfigMessage =
+            let message: AcknowledgedConfigMessage =
                 ConfigHeartbeatSubscriptionSet(startProcessingHeartbeatMessagesFor: periodLog,
                                                secondsSentFrom: sourceAddress,
                                                to: destinationAddress)!

--- a/Example/Source/View Controllers/Network/Configuration/SetPublicationViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/SetPublicationViewController.swift
@@ -338,7 +338,7 @@ private extension SetPublicationViewController {
                               retransmit: Publish.Retransmit(publishRetransmitCount: retransmissionCount,
                                                              intervalSteps: retransmissionIntervalSteps))
         start("Setting Model Publication...") {
-            let message: ConfigMessage =
+            let message: AcknowledgedConfigMessage =
                 ConfigModelPublicationSet(publish, to: model) ??
                 ConfigModelPublicationVirtualAddressSet(publish, to: model)!
             return try MeshNetworkManager.instance.send(message, to: node)

--- a/Example/Source/View Controllers/Network/Configuration/SubscribeViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/SubscribeViewController.swift
@@ -171,7 +171,7 @@ private extension SubscribeViewController {
             return
         }
         start("Subscribing...") {
-            let message: ConfigMessage =
+            let message: AcknowledgedConfigMessage =
                 ConfigModelSubscriptionAdd(group: group, to: model) ??
                 ConfigModelSubscriptionVirtualAddressAdd(group: group, to: model)!
             return try MeshNetworkManager.instance.send(message, to: node)

--- a/nRFMeshProvision/Layers/Access Layer/AccessError.swift
+++ b/nRFMeshProvision/Layers/Access Layer/AccessError.swift
@@ -54,6 +54,9 @@ public enum AccessError: Error {
     /// Error thrown when the Provisioner is trying to delete
     /// the last Network Key from the Node.
     case cannotDelete
+    /// Error thrown when trying to send a message to an address
+    /// for which another message is already being sent.
+    case busy
     /// Thrown, when the acknowledgment has not been received until
     /// the time run out.
     case timeout
@@ -72,6 +75,7 @@ extension AccessError: LocalizedError {
         case .modelNotBoundToAppKey: return NSLocalizedString("No Application Key bound to the given Model.", comment: "access")
         case .noDeviceKey:           return NSLocalizedString("Unknown Device Key", comment: "access")
         case .cannotDelete:          return NSLocalizedString("Cannot delete the last Network Key.", comment: "access")
+        case .busy:                  return NSLocalizedString("Unable to send a message to specified address. Another transfer in progress.", comment: "access")
         case .timeout:               return NSLocalizedString("Request timed out.", comment: "access")
         case .cancelled:             return NSLocalizedString("Message cancelled.", comment: "access")
         }

--- a/nRFMeshProvision/Layers/Access Layer/AccessLayer.swift
+++ b/nRFMeshProvision/Layers/Access Layer/AccessLayer.swift
@@ -251,14 +251,15 @@ internal class AccessLayer {
     ///
     /// - parameters:
     ///   - message:     The Mesh Config Message to send.
+    ///   - element:     The source Element.   
     ///   - destination: The destination address. This must be a Unicast Address.
     ///   - initialTtl:  The initial TTL (Time To Live) value of the message.
     ///                  If `nil`, the default Node TTL will be used.
     ///   - completion:  The completion handler with the response.
-    func send(_ message: AcknowledgedConfigMessage, to destination: Address,
+    func send(_ message: AcknowledgedConfigMessage,
+              from element: Element, to destination: Address,
               withTtl initialTtl: UInt8?) {
-        guard let element = meshNetwork.localProvisioner?.node?.elements.first,
-              let node = meshNetwork.node(withAddress: destination),
+        guard let node = meshNetwork.node(withAddress: destination),
               var networkKey = node.networkKeys.first else {
             return
         }

--- a/nRFMeshProvision/Layers/Access Layer/AccessLayer.swift
+++ b/nRFMeshProvision/Layers/Access Layer/AccessLayer.swift
@@ -256,7 +256,7 @@ internal class AccessLayer {
     ///   - initialTtl:  The initial TTL (Time To Live) value of the message.
     ///                  If `nil`, the default Node TTL will be used.
     ///   - completion:  The completion handler with the response.
-    func send(_ message: AcknowledgedConfigMessage,
+    func send(_ message: ConfigMessage,
               from element: Element, to destination: Address,
               withTtl initialTtl: UInt8?) {
         guard let node = meshNetwork.node(withAddress: destination),

--- a/nRFMeshProvision/Layers/Access Layer/AccessLayer.swift
+++ b/nRFMeshProvision/Layers/Access Layer/AccessLayer.swift
@@ -509,9 +509,9 @@ private extension AccessLayer {
                     }
                 }
             }
-        } else if let primaryElement = localNode.primaryElement {
+        } else {
             // .. otherwise, the Device Key was used.
-            let models = primaryElement.models.filter { $0.supportsDeviceKey }
+            let models = localNode.elements.flatMap { $0.models.filter { $0.supportsDeviceKey } }
             for model in models {
                 // Check, if the delegate is set, and it supports the opcode
                 // specified in the received Access PDU.
@@ -519,7 +519,7 @@ private extension AccessLayer {
                    let message = delegate.decode(accessPdu) {
                     newMessage = message
                     // Is this message targeting the local Node?
-                    if accessPdu.destination.address == primaryElement.unicastAddress {
+                    if localNode.contains(elementWithAddress: accessPdu.destination.address) {
                         logger?.i(.foundationModel, "\(message) received from: \(accessPdu.source.hex)")
                         if let response = delegate.model(model, didReceiveMessage: message,
                                                          sentFrom: accessPdu.source, to: accessPdu.destination,

--- a/nRFMeshProvision/Layers/Foundation Layer/ConfigurationClientHandler.swift
+++ b/nRFMeshProvision/Layers/Foundation Layer/ConfigurationClientHandler.swift
@@ -69,7 +69,7 @@ internal class ConfigurationClientHandler: ModelDelegate {
     }
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) -> MeshResponse {
         switch request {
             
         default:
@@ -77,7 +77,7 @@ internal class ConfigurationClientHandler: ModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         switch message {
             
@@ -87,7 +87,7 @@ internal class ConfigurationClientHandler: ModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address) {
         switch response {
@@ -161,7 +161,7 @@ internal class ConfigurationClientHandler: ModelDelegate {
                 }
             }
                 
-        case let list as ConfigModelAppList:
+        case let list as ConfigModelAppList & StatusMessage:
             if list.isSuccess,
                let node = meshNetwork.node(withAddress: source),
                let element = node.element(withAddress: list.elementAddress),
@@ -249,7 +249,7 @@ internal class ConfigurationClientHandler: ModelDelegate {
                 }
             }
                 
-        case let list as ConfigModelSubscriptionList:
+        case let list as ConfigModelSubscriptionList & StatusMessage:
             if list.isSuccess,
                let node = meshNetwork.node(withAddress: source),
                let element = node.element(withAddress: list.elementAddress),

--- a/nRFMeshProvision/Layers/Foundation Layer/ConfigurationServerHandler.swift
+++ b/nRFMeshProvision/Layers/Foundation Layer/ConfigurationServerHandler.swift
@@ -92,7 +92,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
     }
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) -> MeshResponse {
         let localNode = model.parentElement!.parentNode!
         
         switch request {
@@ -684,7 +684,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         switch message {
             
@@ -693,7 +693,7 @@ internal class ConfigurationServerHandler: ModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address) {
         switch response {

--- a/nRFMeshProvision/Layers/Foundation Layer/PrivateBeaconClientHandler.swift
+++ b/nRFMeshProvision/Layers/Foundation Layer/PrivateBeaconClientHandler.swift
@@ -55,7 +55,7 @@ internal class PrivateBeaconClientHandler: ModelDelegate {
     }
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) -> MeshResponse {
         switch request {
             // No acknowledged message supported by this Model.
         default:
@@ -63,7 +63,7 @@ internal class PrivateBeaconClientHandler: ModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         switch message {
             
@@ -73,7 +73,7 @@ internal class PrivateBeaconClientHandler: ModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address) {
         // Ignore. There are no CDB fields matching these parameters.

--- a/nRFMeshProvision/Layers/Foundation Layer/SceneClientHandler.swift
+++ b/nRFMeshProvision/Layers/Foundation Layer/SceneClientHandler.swift
@@ -39,7 +39,7 @@ internal class SceneClientHandler: ModelDelegate {
     let publicationMessageComposer: MessageComposer? = nil
     
     init(_ meshNetwork: MeshNetwork) {
-        let types: [GenericMessage.Type] = [
+        let types: [StaticMeshMessage.Type] = [
             // A Scene Server shall send the Scene Status message as a response to
             // a Scene Get and Scene Recall message, or as an unsolicited message.
             SceneStatus.self,
@@ -53,7 +53,7 @@ internal class SceneClientHandler: ModelDelegate {
     }
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) -> MeshMessage {
+               from source: Address, sentTo destination: MeshAddress) -> MeshResponse {
         switch request {
             // No acknowledged message supported by this Model.
         default:
@@ -61,12 +61,12 @@ internal class SceneClientHandler: ModelDelegate {
         }
     }
     
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress) {
         handle(message, sentFrom: source)
     }
     
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address) {
         handle(response, sentFrom: source)

--- a/nRFMeshProvision/Layers/NetworkManager.swift
+++ b/nRFMeshProvision/Layers/NetworkManager.swift
@@ -254,11 +254,13 @@ internal class NetworkManager {
     ///
     /// - parameters:
     ///   - configMessage: The message to be sent.
+    ///   - element:       The source Element.
     ///   - destination:   The destination address.
     ///   - initialTtl:    The initial TTL (Time To Live) value of the message.
     ///                    If `nil`, the default Node TTL will be used.
     ///   - completion:    The completion handler with the response.
-    func send(_ configMessage: AcknowledgedConfigMessage, to destination: Address,
+    func send(_ configMessage: AcknowledgedConfigMessage,
+              from element: Element, to destination: Address,
               withTtl initialTtl: UInt8?,
               completion: ((Result<ConfigResponse, Error>) -> ())?) {
          mutex.sync {
@@ -271,7 +273,7 @@ internal class NetworkManager {
                 configResponseCallbacks[destination] = (configMessage.responseOpCode, completion)
             }
         }
-        accessLayer.send(configMessage, to: destination,
+        accessLayer.send(configMessage, from: element, to: destination,
                          withTtl: initialTtl)
     }
     

--- a/nRFMeshProvision/Layers/NetworkManager.swift
+++ b/nRFMeshProvision/Layers/NetworkManager.swift
@@ -216,25 +216,6 @@ internal class NetworkManager {
     }
     
     /// Replies to the received message, which was sent with the given key set,
-    /// with the given message. The message will be sent from the local
-    /// Primary Element.
-    ///
-    /// - parameters:
-    ///   - origin:      The destination address of the message that the reply is for.
-    ///   - message:     The response message to be sent.
-    ///   - destination: The destination address. This must be a Unicast Address.
-    ///   - keySet:      The keySet that should be used to encrypt the message.
-    // TODO: Remove?
-//    func reply(toAcknowledgedMessageSentTo origin: Address, with message: MeshResponse,
-//               to destination: Address, using keySet: KeySet) {
-//        guard let primaryElement = meshNetwork.localProvisioner?.node?.elements.first else {
-//            return
-//        }
-//        accessLayer.reply(toAcknowledgedMessageSentTo: origin, with: message,
-//                          from: primaryElement, to: destination, using: keySet)
-//    }
-    
-    /// Replies to the received message, which was sent with the given key set,
     /// with the given message.
     ///
     /// - parameters:

--- a/nRFMeshProvision/Layers/NetworkManager.swift
+++ b/nRFMeshProvision/Layers/NetworkManager.swift
@@ -109,8 +109,8 @@ internal class NetworkManager {
             publish.ttl :
             localElement.parentNode?.defaultTTL ?? networkParameters.defaultTtl
         // Send the message.
-        send(message, from: localElement, to: publish.publicationAddress,
-             withTtl: ttl, using: applicationKey, completion: nil)
+        accessLayer.send(message, from: localElement, to: publish.publicationAddress,
+                         withTtl: ttl, using: applicationKey, retransmit: false)
         // If retransmission was configured, start the timer that will retransmit.
         // There is no need to retransmit acknowledged messages, as they have their
         // own retransmission mechanism.
@@ -125,8 +125,7 @@ internal class NetworkManager {
                         return
                     }
                     self.accessLayer.send(message, from: localElement, to: publish.publicationAddress,
-                                          withTtl: ttl, using: applicationKey, retransmit: true,
-                                          completion: nil)
+                                          withTtl: ttl, using: applicationKey, retransmit: true)
                     count -= 1
                     if count == 0 {
                         timer.invalidate()
@@ -160,7 +159,7 @@ internal class NetworkManager {
               completion: ((Result<Void, Error>) -> ())?) {
         accessLayer.send(message, from: element, to: destination,
                          withTtl: initialTtl, using: applicationKey,
-                         retransmit: false, completion: completion)
+                         retransmit: false)
     }
     
     /// Encrypts the message with the Application Key and a Network Key
@@ -185,9 +184,9 @@ internal class NetworkManager {
               withTtl initialTtl: UInt8?,
               using applicationKey: ApplicationKey,
               completion: ((Result<MeshResponse, Error>) -> ())?) {
-        accessLayer.send(message, from: element, to: destination,
+        accessLayer.send(message, from: element, to: MeshAddress(destination),
                          withTtl: initialTtl, using: applicationKey,
-                         retransmit: false, completion: completion)
+                         retransmit: false)
     }
     
     /// Encrypts the message with the Device Key and the first Network Key
@@ -212,7 +211,7 @@ internal class NetworkManager {
               withTtl initialTtl: UInt8?,
               completion: ((Result<ConfigResponse, Error>) -> ())?) {
         accessLayer.send(configMessage, to: destination,
-                         withTtl: initialTtl, completion: completion)
+                         withTtl: initialTtl)
     }
     
     /// Replies to the received message, which was sent with the given key set,

--- a/nRFMeshProvision/Layers/NetworkParameters.swift
+++ b/nRFMeshProvision/Layers/NetworkParameters.swift
@@ -32,7 +32,7 @@ import Foundation
 
 /// A set of network parameters that can be applied to the ``MeshNetworkManager``.
 ///
-/// Network parameters configure the transmition and retransmition intervals,
+/// Network parameters configure the transsmition and retranssmition intervals,
 /// acknowledge message timeout, the default Time To Live (TTL) and other.
 ///
 /// Use ``NetworkParameters/default`` or ``NetworkParameters/custom(_:)`` to create

--- a/nRFMeshProvision/Layers/Upper Transport Layer/UpperTransportLayer.swift
+++ b/nRFMeshProvision/Layers/Upper Transport Layer/UpperTransportLayer.swift
@@ -149,7 +149,9 @@ internal class UpperTransportLayer {
                         $0.pdu.destination == handle.destination
                     }
                     .forEach {
-                        networkManager.notifyAbout(error: LowerTransportError.cancelled, duringSendingMessage: $0.pdu.message!, from: element, to: handle.destination)
+                        networkManager.notifyAbout(error: LowerTransportError.cancelled,
+                                                   duringSendingMessage: $0.pdu.message!,
+                                                   from: element, to: handle.destination)
                     }
             }
             // Remove all enqueued messages that match the handler.

--- a/nRFMeshProvision/Mesh Messages/ConfigMessage.swift
+++ b/nRFMeshProvision/Mesh Messages/ConfigMessage.swift
@@ -40,6 +40,18 @@ public protocol ConfigMessage: StaticMeshMessage {
     // No additional fields.
 }
 
+/// A base protocol for unacknowledged Configuration messages.
+///
+/// Unacknowledged configuration messages are sent as replies to acknowledged messages.
+public protocol UnacknowledgedConfigMessage: ConfigMessage, UnacknowledgedMeshMessage {
+    // No additional fields.
+}
+
+/// The base class for response messages.
+public protocol ConfigResponse: StaticMeshResponse, UnacknowledgedConfigMessage {
+    // No additional fields.
+}
+
 /// A base protocol for acknowledged Configuration messages.
 ///
 /// Acknowledged messages will be responded with a status message.
@@ -155,13 +167,13 @@ public protocol ConfigVirtualLabelMessage: ConfigMessage {
 }
 
 /// A base protocol for config messages with list of Application Keys.
-public protocol ConfigModelAppList: ConfigStatusMessage, ConfigModelMessage {
+public protocol ConfigModelAppList: ConfigModelMessage {
     /// Application Key Indexes bound to the Model.
     var applicationKeyIndexes: [KeyIndex] { get }
 }
 
 /// A base protocol for config messages with list of Model subscription addresses.
-public protocol ConfigModelSubscriptionList: ConfigStatusMessage, ConfigModelMessage {
+public protocol ConfigModelSubscriptionList: ConfigModelMessage {
     /// A list of Addresses.
     var addresses: [Address] { get }
 }

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyAdd.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyAdd.swift
@@ -41,7 +41,7 @@ import Foundation
 /// as well as authenticate and encrypt messages it sends.
 public struct ConfigAppKeyAdd: AcknowledgedConfigMessage, ConfigNetAndAppKeyMessage {
     public static let opCode: UInt32 = 0x00
-    public static let responseType: StaticMeshMessage.Type = ConfigAppKeyStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigAppKeyStatus.self
     
     public var parameters: Data? {
         return encodeNetAndAppKeyIndex() + key

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyDelete.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyDelete.swift
@@ -42,7 +42,7 @@ import Foundation
 ///            effectively be excluded from the mesh network.
 public struct ConfigAppKeyDelete: AcknowledgedConfigMessage, ConfigNetAndAppKeyMessage {
     public static let opCode: UInt32 = 0x8000
-    public static let responseType: StaticMeshMessage.Type = ConfigAppKeyStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigAppKeyStatus.self
     
     public var parameters: Data? {
         return encodeNetAndAppKeyIndex()

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyGet.swift
@@ -36,7 +36,7 @@ import Foundation
 /// The response to this message is a ``ConfigNetKeyList`` message.
 public struct ConfigAppKeyGet: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8001
-    public static let responseType: StaticMeshMessage.Type = ConfigAppKeyList.self
+    public static let responseType: StaticMeshResponse.Type = ConfigAppKeyList.self
     
     public var parameters: Data? {
         return encodeNetKeyIndex()

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyList.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyList.swift
@@ -32,7 +32,7 @@ import Foundation
 
 /// A `ConfigAppKeyList` is an unacknowledged message reporting all ``ApplicationKey``s
 /// bound to requested ``NetworkKey`` that are known to the Node.
-public struct ConfigAppKeyList: ConfigStatusMessage, ConfigNetKeyMessage {
+public struct ConfigAppKeyList: ConfigResponse, ConfigStatusMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8002
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyStatus.swift
@@ -34,7 +34,7 @@ import Foundation
 /// the requesting message, based on the ``NetworkKey/index`` identifying the
 /// ``NetworkKey`` on the NetKey List and on the ``ApplicationKey/index`` identifying
 /// the ``ApplicationKey`` on the AppKey List.
-public struct ConfigAppKeyStatus: ConfigNetAndAppKeyMessage, ConfigStatusMessage {
+public struct ConfigAppKeyStatus: ConfigResponse, ConfigStatusMessage, ConfigNetAndAppKeyMessage {
     public static let opCode: UInt32 = 0x8003  
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyUpdate.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigAppKeyUpdate.swift
@@ -41,7 +41,7 @@ import Foundation
 /// To transition to the next phases of the Key Refresh Procedure use ``ConfigKeyRefreshPhaseSet``.
 public struct ConfigAppKeyUpdate: AcknowledgedConfigMessage, ConfigNetAndAppKeyMessage {
     public static let opCode: UInt32 = 0x01
-    public static let responseType: StaticMeshMessage.Type = ConfigAppKeyStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigAppKeyStatus.self
     
     public var parameters: Data? {
         return encodeNetAndAppKeyIndex() + key

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigBeaconGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigBeaconGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigBeaconGet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8009
-    public static let responseType: StaticMeshMessage.Type = ConfigBeaconStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigBeaconStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigBeaconSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigBeaconSet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigBeaconSet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x800A
-    public static let responseType: StaticMeshMessage.Type = ConfigBeaconStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigBeaconStatus.self
     
     public var parameters: Data? {
         return Data([state ? 0x01 : 0x00])

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigBeaconStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigBeaconStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigBeaconStatus: ConfigMessage {
+public struct ConfigBeaconStatus: ConfigResponse {
     public static let opCode: UInt32 = 0x800B
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigCompositionDataGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigCompositionDataGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigCompositionDataGet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8008
-    public static let responseType: StaticMeshMessage.Type = ConfigCompositionDataStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigCompositionDataStatus.self
     
     public var parameters: Data? {
         return Data([page])

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigCompositionDataStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigCompositionDataStatus.swift
@@ -37,7 +37,7 @@ public protocol CompositionDataPage {
     var parameters: Data? { get }
 }
 
-public struct ConfigCompositionDataStatus: ConfigMessage {
+public struct ConfigCompositionDataStatus: ConfigResponse {
     public static let opCode: UInt32 = 0x02
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigDefaultTtlGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigDefaultTtlGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigDefaultTtlGet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x800C
-    public static let responseType: StaticMeshMessage.Type = ConfigDefaultTtlStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigDefaultTtlStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigDefaultTtlSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigDefaultTtlSet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigDefaultTtlSet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x800D
-    public static let responseType: StaticMeshMessage.Type = ConfigDefaultTtlStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigDefaultTtlStatus.self
     
     public var parameters: Data? {
         return Data([ttl])

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigDefaultTtlStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigDefaultTtlStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigDefaultTtlStatus: ConfigMessage {
+public struct ConfigDefaultTtlStatus: ConfigResponse {
     public static let opCode: UInt32 = 0x800E
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigFriendGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigFriendGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigFriendGet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x800F
-    public static let responseType: StaticMeshMessage.Type = ConfigFriendStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigFriendStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigFriendSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigFriendSet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigFriendSet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8010
-    public static let responseType: StaticMeshMessage.Type = ConfigFriendStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigFriendStatus.self
     
     public var parameters: Data? {
         return Data([state.rawValue])

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigFriendStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigFriendStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigFriendStatus: ConfigMessage {
+public struct ConfigFriendStatus: ConfigResponse {
     public static let opCode: UInt32 = 0x8011
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigGATTProxyGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigGATTProxyGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigGATTProxyGet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8012
-    public static let responseType: StaticMeshMessage.Type = ConfigGATTProxyStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigGATTProxyStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigGATTProxySet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigGATTProxySet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigGATTProxySet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8013
-    public static let responseType: StaticMeshMessage.Type = ConfigGATTProxyStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigGATTProxyStatus.self
     
     public var parameters: Data? {
         return Data([state.rawValue])

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigGATTProxyStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigGATTProxyStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigGATTProxyStatus: ConfigMessage {
+public struct ConfigGATTProxyStatus: ConfigResponse {
     public static let opCode: UInt32 = 0x8014
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigHeartbeatPublicationGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigHeartbeatPublicationGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigHeartbeatPublicationGet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8038
-    public static let responseType: StaticMeshMessage.Type = ConfigHeartbeatPublicationStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigHeartbeatPublicationStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigHeartbeatPublicationSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigHeartbeatPublicationSet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigHeartbeatPublicationSet: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8039
-    public static let responseType: StaticMeshMessage.Type = ConfigHeartbeatPublicationStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigHeartbeatPublicationStatus.self
     
     public var parameters: Data? {
         var data = Data() + destination

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigHeartbeatPublicationStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigHeartbeatPublicationStatus.swift
@@ -30,8 +30,7 @@
 
 import Foundation
 
-public struct ConfigHeartbeatPublicationStatus: ConfigMessage, ConfigStatusMessage, ConfigNetKeyMessage {
-    
+public struct ConfigHeartbeatPublicationStatus: ConfigResponse, ConfigStatusMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x06
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigHeartbeatSubscriptionGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigHeartbeatSubscriptionGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigHeartbeatSubscriptionGet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x803A
-    public static let responseType: StaticMeshMessage.Type = ConfigHeartbeatSubscriptionStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigHeartbeatSubscriptionStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigHeartbeatSubscriptionSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigHeartbeatSubscriptionSet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigHeartbeatSubscriptionSet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x803B
-    public static let responseType: StaticMeshMessage.Type = ConfigHeartbeatSubscriptionStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigHeartbeatSubscriptionStatus.self
     
     public var parameters: Data? {
         var data = Data() + source + destination

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigHeartbeatSubscriptionStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigHeartbeatSubscriptionStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigHeartbeatSubscriptionStatus: ConfigMessage, ConfigStatusMessage {
+public struct ConfigHeartbeatSubscriptionStatus: ConfigResponse, ConfigStatusMessage {
     public static let opCode: UInt32 = 0x803C
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigKeyRefreshPhaseGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigKeyRefreshPhaseGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigKeyRefreshPhaseGet: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8015
-    public static let responseType: StaticMeshMessage.Type = ConfigKeyRefreshPhaseStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigKeyRefreshPhaseStatus.self
     
     public var parameters: Data? {
         return encodeNetKeyIndex()

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigKeyRefreshPhaseSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigKeyRefreshPhaseSet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigKeyRefreshPhaseSet: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8016
-    public static let responseType: StaticMeshMessage.Type = ConfigKeyRefreshPhaseStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigKeyRefreshPhaseStatus.self
     
     public var parameters: Data? {
         return encodeNetKeyIndex() + transition.rawValue

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigKeyRefreshPhaseStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigKeyRefreshPhaseStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigKeyRefreshPhaseStatus: ConfigNetKeyMessage, ConfigStatusMessage {
+public struct ConfigKeyRefreshPhaseStatus: ConfigResponse, ConfigStatusMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8017
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigLowPowerNodePollTimeoutGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigLowPowerNodePollTimeoutGet.swift
@@ -39,7 +39,7 @@ import Foundation
 /// feature supported and enabled.
 public struct ConfigLowPowerNodePollTimeoutGet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x802D
-    public static let responseType: StaticMeshMessage.Type = ConfigLowPowerNodePollTimeoutStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigLowPowerNodePollTimeoutStatus.self
     
     public var parameters: Data? {
         return Data() + lpnAddress

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigLowPowerNodePollTimeoutStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigLowPowerNodePollTimeoutStatus.swift
@@ -33,9 +33,8 @@ import Foundation
 /// The Config Low Power Node PollTimeout Status is an unacknowledged message
 /// used to report the current value of the PollTimeout timer of the Low Power
 /// Node within a Friend Node.
-public struct ConfigLowPowerNodePollTimeoutStatus: ConfigMessage {
+public struct ConfigLowPowerNodePollTimeoutStatus: ConfigResponse {
     public static let opCode: UInt32 = 0x802E
-    public static let responseType: StaticMeshMessage.Type = ConfigLowPowerNodePollTimeoutStatus.self
     
     public var parameters: Data? {
         // PollTimeout value is 24-bit value.

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelAppBind.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelAppBind.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigModelAppBind: AcknowledgedConfigMessage, ConfigAppKeyMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x803D
-    public static let responseType: StaticMeshMessage.Type = ConfigModelAppStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigModelAppStatus.self
     
     public var parameters: Data? {
         let data = Data() + elementAddress + applicationKeyIndex

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelAppStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelAppStatus.swift
@@ -29,7 +29,7 @@
 */
 import Foundation
 
-public struct ConfigModelAppStatus: ConfigAppKeyMessage, ConfigAnyModelMessage, ConfigStatusMessage {
+public struct ConfigModelAppStatus: ConfigResponse, ConfigStatusMessage, ConfigAppKeyMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x803E
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelAppUnbind.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelAppUnbind.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigModelAppUnbind: AcknowledgedConfigMessage, ConfigAppKeyMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x803F
-    public static let responseType: StaticMeshMessage.Type = ConfigModelAppStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigModelAppStatus.self
     
     public var parameters: Data? {
         let data = Data() + elementAddress + applicationKeyIndex

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelPublicationGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelPublicationGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigModelPublicationGet: AcknowledgedConfigMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x8018
-    public static let responseType: StaticMeshMessage.Type = ConfigModelPublicationStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigModelPublicationStatus.self
     
     public var parameters: Data? {
         let data = Data() + elementAddress

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelPublicationSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelPublicationSet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigModelPublicationSet: AcknowledgedConfigMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x03
-    public static let responseType: StaticMeshMessage.Type = ConfigModelPublicationStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigModelPublicationStatus.self
     
     public var parameters: Data? {
         var data = Data() + elementAddress + publish.publicationAddress.address

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelPublicationStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelPublicationStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigModelPublicationStatus: ConfigAnyModelMessage, ConfigStatusMessage {
+public struct ConfigModelPublicationStatus: ConfigResponse, ConfigStatusMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x8019
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelPublicationVirtualAddressSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelPublicationVirtualAddressSet.swift
@@ -33,7 +33,7 @@ import CoreBluetooth
 
 public struct ConfigModelPublicationVirtualAddressSet: AcknowledgedConfigMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x801A
-    public static let responseType: StaticMeshMessage.Type = ConfigModelPublicationStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigModelPublicationStatus.self
     
     public var parameters: Data? {
         var data = Data() + elementAddress + publish.publicationAddress.virtualLabel!.data

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionAdd.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionAdd.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigModelSubscriptionAdd: AcknowledgedConfigMessage, ConfigAddressMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x801B
-    public static let responseType: StaticMeshMessage.Type = ConfigModelSubscriptionStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigModelSubscriptionStatus.self
     
     public var parameters: Data? {
         let data = Data() + elementAddress + address

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionDelete.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionDelete.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigModelSubscriptionDelete: AcknowledgedConfigMessage, ConfigAddressMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x801C
-    public static let responseType: StaticMeshMessage.Type = ConfigModelSubscriptionStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigModelSubscriptionStatus.self
     
     public var parameters: Data? {
         let data = Data() + elementAddress + address

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionDeleteAll.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionDeleteAll.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigModelSubscriptionDeleteAll: AcknowledgedConfigMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x801D
-    public static let responseType: StaticMeshMessage.Type = ConfigModelSubscriptionStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigModelSubscriptionStatus.self
     
     public var parameters: Data? {
         let data = Data() + elementAddress

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionOverwrite.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionOverwrite.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigModelSubscriptionOverwrite: AcknowledgedConfigMessage, ConfigAddressMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x801E
-    public static let responseType: StaticMeshMessage.Type = ConfigModelSubscriptionStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigModelSubscriptionStatus.self
     
     public var parameters: Data? {
         let data = Data() + elementAddress + address

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigModelSubscriptionStatus: ConfigStatusMessage, ConfigAddressMessage, ConfigAnyModelMessage {
+public struct ConfigModelSubscriptionStatus: ConfigResponse, ConfigStatusMessage, ConfigAddressMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x801F
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionVirtualAddressAdd.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionVirtualAddressAdd.swift
@@ -31,10 +31,9 @@
 import Foundation
 import CoreBluetooth
 
-public struct ConfigModelSubscriptionVirtualAddressAdd: AcknowledgedConfigMessage,
-    ConfigVirtualLabelMessage, ConfigAnyModelMessage {
+public struct ConfigModelSubscriptionVirtualAddressAdd: AcknowledgedConfigMessage, ConfigVirtualLabelMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x8020
-    public static let responseType: StaticMeshMessage.Type = ConfigModelSubscriptionStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigModelSubscriptionStatus.self
     
     public var parameters: Data? {
         let data = Data() + elementAddress + virtualLabel.data

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionVirtualAddressDelete.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionVirtualAddressDelete.swift
@@ -31,10 +31,9 @@
 import Foundation
 import CoreBluetooth
 
-public struct ConfigModelSubscriptionVirtualAddressDelete: AcknowledgedConfigMessage,
-    ConfigVirtualLabelMessage, ConfigAnyModelMessage {
+public struct ConfigModelSubscriptionVirtualAddressDelete: AcknowledgedConfigMessage, ConfigVirtualLabelMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x8021
-    public static let responseType: StaticMeshMessage.Type = ConfigModelSubscriptionStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigModelSubscriptionStatus.self
     
     public var parameters: Data? {
         let data = Data() + elementAddress + virtualLabel.data

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionVirtualAddressOverwrite.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigModelSubscriptionVirtualAddressOverwrite.swift
@@ -30,10 +30,9 @@
 import Foundation
 import CoreBluetooth
 
-public struct ConfigModelSubscriptionVirtualAddressOverwrite: AcknowledgedConfigMessage,
-    ConfigVirtualLabelMessage, ConfigAnyModelMessage {
+public struct ConfigModelSubscriptionVirtualAddressOverwrite: AcknowledgedConfigMessage, ConfigVirtualLabelMessage, ConfigAnyModelMessage {
     public static let opCode: UInt32 = 0x8022
-    public static let responseType: StaticMeshMessage.Type = ConfigModelSubscriptionStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigModelSubscriptionStatus.self
     
     public var parameters: Data? {
         let data = Data() + elementAddress + virtualLabel.data

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyAdd.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyAdd.swift
@@ -37,7 +37,7 @@ import Foundation
 /// as well as authenticate and encrypt messages it sends.
 public struct ConfigNetKeyAdd: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8040
-    public static let responseType: StaticMeshMessage.Type = ConfigNetKeyStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigNetKeyStatus.self
     
     public var parameters: Data? {
         return encodeNetKeyIndex() + key

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyDelete.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyDelete.swift
@@ -42,7 +42,7 @@ import Foundation
 ///            effectively be excluded from the mesh network.
 public struct ConfigNetKeyDelete: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8041
-    public static let responseType: StaticMeshMessage.Type = ConfigNetKeyStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigNetKeyStatus.self
     
     public var parameters: Data? {
         return encodeNetKeyIndex()

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyGet.swift
@@ -36,7 +36,7 @@ import Foundation
 /// The response to this message is a ``ConfigNetKeyList`` message.
 public struct ConfigNetKeyGet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8042
-    public static let responseType: StaticMeshMessage.Type = ConfigNetKeyList.self
+    public static let responseType: StaticMeshResponse.Type = ConfigNetKeyList.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyList.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyList.swift
@@ -32,7 +32,7 @@ import Foundation
 
 /// A `ConfigNetKeyList` is an unacknowledged message reporting all ``NetworkKey``s
 /// known to the Node.
-public struct ConfigNetKeyList: ConfigMessage {
+public struct ConfigNetKeyList: ConfigResponse {
     public static let opCode: UInt32 = 0x8043
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyStatus.swift
@@ -32,7 +32,7 @@ import Foundation
 
 /// A `ConfigNetKeyStatus` is an unacknowledged message used to report the status of
 /// the operation on the NetKey List.
-public struct ConfigNetKeyStatus: ConfigNetKeyMessage, ConfigStatusMessage {
+public struct ConfigNetKeyStatus: ConfigResponse, ConfigStatusMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8044
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyUpdate.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetKeyUpdate.swift
@@ -41,7 +41,7 @@ import Foundation
 /// To transition to the next phases of the Key Refresh Procedure use ``ConfigKeyRefreshPhaseSet``.
 public struct ConfigNetKeyUpdate: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8045
-    public static let responseType: StaticMeshMessage.Type = ConfigNetKeyStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigNetKeyStatus.self
     
     public var parameters: Data? {
         return encodeNetKeyIndex() + key

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetworkTransmitGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetworkTransmitGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigNetworkTransmitGet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8023
-    public static let responseType: StaticMeshMessage.Type = ConfigNetworkTransmitStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigNetworkTransmitStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetworkTransmitSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetworkTransmitSet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigNetworkTransmitSet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8024
-    public static let responseType: StaticMeshMessage.Type = ConfigNetworkTransmitStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigNetworkTransmitStatus.self
     
     public var parameters: Data? {
         return Data() + ((count & 0x07) | steps << 3)

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetworkTransmitStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNetworkTransmitStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigNetworkTransmitStatus: ConfigMessage {
+public struct ConfigNetworkTransmitStatus: ConfigResponse {
     public static let opCode: UInt32 = 0x8025
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNodeIdentityGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNodeIdentityGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigNodeIdentityGet: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8046
-    public static let responseType: StaticMeshMessage.Type = ConfigNodeIdentityStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigNodeIdentityStatus.self
     
     public var parameters: Data? {
         return encodeNetKeyIndex()

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNodeIdentitySet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNodeIdentitySet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigNodeIdentitySet: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8047
-    public static let responseType: StaticMeshMessage.Type = ConfigNodeIdentityStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigNodeIdentityStatus.self
     
     public var parameters: Data? {
         return encodeNetKeyIndex() + identity.rawValue

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNodeIdentityStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNodeIdentityStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigNodeIdentityStatus: ConfigNetKeyMessage, ConfigStatusMessage {
+public struct ConfigNodeIdentityStatus: ConfigResponse, ConfigStatusMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8048
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNodeReset.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNodeReset.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigNodeReset: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8049
-    public static let responseType: StaticMeshMessage.Type = ConfigNodeResetStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigNodeResetStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNodeResetStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigNodeResetStatus.swift
@@ -29,7 +29,7 @@
 */
 import Foundation
 
-public struct ConfigNodeResetStatus: ConfigMessage {
+public struct ConfigNodeResetStatus: ConfigResponse {
     public static let opCode: UInt32 = 0x804A
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigRelayGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigRelayGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigRelayGet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8026
-    public static let responseType: StaticMeshMessage.Type = ConfigRelayStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigRelayStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigRelaySet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigRelaySet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigRelaySet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8027
-    public static let responseType: StaticMeshMessage.Type = ConfigRelayStatus.self
+    public static let responseType: StaticMeshResponse.Type = ConfigRelayStatus.self
     
     public var parameters: Data? {
         return Data([state.rawValue]) + ((count & 0x07) | steps << 3)

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigRelayStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigRelayStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigRelayStatus: ConfigMessage {
+public struct ConfigRelayStatus: ConfigResponse {
     public static let opCode: UInt32 = 0x8028
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigSIGModelAppGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigSIGModelAppGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigSIGModelAppGet: AcknowledgedConfigMessage, ConfigModelMessage {
     public static let opCode: UInt32 = 0x804B
-    public static let responseType: StaticMeshMessage.Type = ConfigSIGModelAppList.self
+    public static let responseType: StaticMeshResponse.Type = ConfigSIGModelAppList.self
     
     public var parameters: Data? {
         return Data() + elementAddress + modelIdentifier

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigSIGModelAppList.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigSIGModelAppList.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigSIGModelAppList: ConfigModelAppList {
+public struct ConfigSIGModelAppList: ConfigResponse, ConfigStatusMessage, ConfigModelAppList {
     public static let opCode: UInt32 = 0x804C
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigSIGModelSubscriptionGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigSIGModelSubscriptionGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigSIGModelSubscriptionGet: AcknowledgedConfigMessage, ConfigModelMessage {
     public static let opCode: UInt32 = 0x8029
-    public static let responseType: StaticMeshMessage.Type = ConfigSIGModelSubscriptionList.self
+    public static let responseType: StaticMeshResponse.Type = ConfigSIGModelSubscriptionList.self
     
     public var parameters: Data? {
         return Data() + elementAddress + modelIdentifier

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigSIGModelSubscriptionList.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigSIGModelSubscriptionList.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigSIGModelSubscriptionList: ConfigModelSubscriptionList {
+public struct ConfigSIGModelSubscriptionList: ConfigResponse, ConfigStatusMessage, ConfigModelSubscriptionList {
     public static let opCode: UInt32 = 0x802A
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigVendorModelAppGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigVendorModelAppGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigVendorModelAppGet: AcknowledgedConfigMessage, ConfigVendorModelMessage {
     public static let opCode: UInt32 = 0x804D
-    public static let responseType: StaticMeshMessage.Type = ConfigVendorModelAppList.self
+    public static let responseType: StaticMeshResponse.Type = ConfigVendorModelAppList.self
     
     public var parameters: Data? {
         return Data() + elementAddress + companyIdentifier + modelIdentifier

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigVendorModelAppList.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigVendorModelAppList.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigVendorModelAppList: ConfigModelAppList, ConfigVendorModelMessage {
+public struct ConfigVendorModelAppList: ConfigResponse, ConfigStatusMessage, ConfigModelAppList, ConfigVendorModelMessage {
     public static let opCode: UInt32 = 0x804E
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigVendorModelSubscriptionGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigVendorModelSubscriptionGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct ConfigVendorModelSubscriptionGet: AcknowledgedConfigMessage, ConfigVendorModelMessage {
     public static let opCode: UInt32 = 0x802B
-    public static let responseType: StaticMeshMessage.Type = ConfigVendorModelSubscriptionList.self
+    public static let responseType: StaticMeshResponse.Type = ConfigVendorModelSubscriptionList.self
     
     public var parameters: Data? {
         return Data() + elementAddress + companyIdentifier + modelIdentifier

--- a/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigVendorModelSubscriptionList.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Configuration/ConfigVendorModelSubscriptionList.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct ConfigVendorModelSubscriptionList: ConfigModelSubscriptionList, ConfigVendorModelMessage {
+public struct ConfigVendorModelSubscriptionList: ConfigResponse, ConfigStatusMessage, ConfigModelSubscriptionList, ConfigVendorModelMessage {
     public static let opCode: UInt32 = 0x802C
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateBeaconGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateBeaconGet.swift
@@ -34,7 +34,7 @@ import Foundation
 /// Private Beacon state and Random Update Interval Steps state of a Node.
 public struct PrivateBeaconGet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8060
-    public static let responseType: StaticMeshMessage.Type = PrivateBeaconStatus.self
+    public static let responseType: StaticMeshResponse.Type = PrivateBeaconStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateBeaconSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateBeaconSet.swift
@@ -34,7 +34,7 @@ import Foundation
 /// Private Beacon state and the Random Update Interval Steps state of a Node.
 public struct PrivateBeaconSet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8061
-    public static let responseType: StaticMeshMessage.Type = PrivateBeaconStatus.self
+    public static let responseType: StaticMeshResponse.Type = PrivateBeaconStatus.self
     
     /// New value of the Private Beacon state.
     public let enabled: Bool

--- a/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateBeaconStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateBeaconStatus.swift
@@ -32,7 +32,7 @@ import Foundation
 
 /// A Private Beacon Status message is an unacknowledged message used to report
 /// the current Private Beacon state and Random Update Interval Steps state of a Node.
-public struct PrivateBeaconStatus: ConfigMessage {
+public struct PrivateBeaconStatus: ConfigResponse {
     public static let opCode: UInt32 = 0x8062
     
     /// Current value of the Private Beacon state.

--- a/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateGATTProxyGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateGATTProxyGet.swift
@@ -34,7 +34,7 @@ import Foundation
 /// current Private GATT Proxy state of a Node.
 public struct PrivateGATTProxyGet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8063
-    public static let responseType: StaticMeshMessage.Type = PrivateGATTProxyStatus.self
+    public static let responseType: StaticMeshResponse.Type = PrivateGATTProxyStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateGATTProxySet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateGATTProxySet.swift
@@ -34,7 +34,7 @@ import Foundation
 /// Private GATT Proxy state of a Node.
 public struct PrivateGATTProxySet: AcknowledgedConfigMessage {
     public static let opCode: UInt32 = 0x8064
-    public static let responseType: StaticMeshMessage.Type = PrivateGATTProxyStatus.self
+    public static let responseType: StaticMeshResponse.Type = PrivateGATTProxyStatus.self
     
     /// New Private GATT Proxy state.
     public let enabled: Bool

--- a/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateGATTProxyStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateGATTProxyStatus.swift
@@ -32,7 +32,7 @@ import Foundation
 
 /// A Private GATT Proxy Status message is an unacknowledged message used to report
 /// the current Private GATT Proxy state of a Node.
-public struct PrivateGATTProxyStatus: ConfigMessage {
+public struct PrivateGATTProxyStatus: ConfigResponse {
     public static let opCode: UInt32 = 0x8065
     
     /// Current Private GATT Proxy state.

--- a/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateNodeIdentityGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateNodeIdentityGet.swift
@@ -34,7 +34,7 @@ import Foundation
 /// current Private Node Identity state for a subnet.
 public struct PrivateNodeIdentityGet: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8066
-    public static let responseType: StaticMeshMessage.Type = PrivateNodeIdentityStatus.self
+    public static let responseType: StaticMeshResponse.Type = PrivateNodeIdentityStatus.self
     
     public let networkKeyIndex: KeyIndex
     

--- a/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateNodeIdentitySet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateNodeIdentitySet.swift
@@ -34,7 +34,7 @@ import Foundation
 /// current Private Node Identity state for a subnet.
 public struct PrivateNodeIdentitySet: AcknowledgedConfigMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8067
-    public static let responseType: StaticMeshMessage.Type = PrivateNodeIdentityStatus.self
+    public static let responseType: StaticMeshResponse.Type = PrivateNodeIdentityStatus.self
     
     public let networkKeyIndex: KeyIndex
     /// Should advertising with Private Node Identity for a subnet be enabled.

--- a/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateNodeIdentityStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Private Beacon/PrivateNodeIdentityStatus.swift
@@ -32,7 +32,7 @@ import Foundation
 
 /// A Private Node Identity Status message is an unacknowledged message used to
 /// report the current Private Node Identity state for a subnet.
-public struct PrivateNodeIdentityStatus: ConfigNetKeyMessage, ConfigStatusMessage {
+public struct PrivateNodeIdentityStatus: ConfigResponse, ConfigStatusMessage, ConfigNetKeyMessage {
     public static let opCode: UInt32 = 0x8068
     
     public let status: ConfigMessageStatus

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningExtendedScanReport.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningExtendedScanReport.swift
@@ -34,7 +34,7 @@ import CoreBluetooth
 /// A Remote Provisioning Extended Scan Report message is an unacknowledged message
 /// used by the Remote Provisioning Server to report the advertising data requested
 /// by the client in a Remote Provisioning Extended Scan Start message.
-public struct RemoteProvisioningExtendedScanReport: RemoteProvisioningMessage, RemoteProvisioningStatusMessage {
+public struct RemoteProvisioningExtendedScanReport: RemoteProvisioningStatusMessage {
     public static let opCode: UInt32 = 0x8057
     
     public let status: RemoteProvisioningMessageStatus

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningExtendedScanStart.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningExtendedScanStart.swift
@@ -34,7 +34,7 @@ import CoreBluetooth
 /// A Remote Provisioning Extended Scan Start message is an unacknowledged message
 /// that is used by the Remote Provisioning Client to request additional information
 /// about a specific unprovisioned device or about the Remote Provisioning Server itself.
-public struct RemoteProvisioningExtendedScanStart: RemoteProvisioningMessage {
+public struct RemoteProvisioningExtendedScanStart: UnacknowledgedRemoteProvisioningMessage {
     public static let opCode: UInt32 = 0x8056
     
     /// Number of AD Types in the ADTypeFilter field.

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningLinkClose.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningLinkClose.swift
@@ -35,7 +35,7 @@ import Foundation
 /// Remote Provisioning Server model.
 public struct RemoteProvisioningLinkClose: AcknowledgedRemoteProvisioningMessage {
     public static let opCode: UInt32 = 0x805A
-    public static let responseType: StaticMeshMessage.Type = RemoteProvisioningLinkStatus.self
+    public static let responseType: StaticMeshResponse.Type = RemoteProvisioningLinkStatus.self
     
     /// Provisioning bearer link close reason.
     public let reason: RemoteProvisioningLinkCloseReason

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningLinkGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningLinkGet.swift
@@ -35,7 +35,7 @@ import Foundation
 /// Remote Provisioning Server model.
 public struct RemoteProvisioningLinkGet: AcknowledgedRemoteProvisioningMessage {
     public static let opCode: UInt32 = 0x8058
-    public static let responseType: StaticMeshMessage.Type = RemoteProvisioningLinkStatus.self
+    public static let responseType: StaticMeshResponse.Type = RemoteProvisioningLinkStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningLinkOpen.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningLinkOpen.swift
@@ -37,7 +37,7 @@ import CoreBluetooth
 /// or to open the Node Provisioning Protocol Interface.
 public struct RemoteProvisioningLinkOpen: AcknowledgedRemoteProvisioningMessage {
     public static let opCode: UInt32 = 0x8059
-    public static let responseType: StaticMeshMessage.Type = RemoteProvisioningLinkStatus.self
+    public static let responseType: StaticMeshResponse.Type = RemoteProvisioningLinkStatus.self
     
     /// Device UUID.
     public let uuid: CBUUID?

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningLinkReport.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningLinkReport.swift
@@ -33,7 +33,7 @@ import Foundation
 /// A Remote Provisioning Link Report message is an unacknowledged message used by
 /// the Remote Provisioning Server to report the state change of a provisioning
 /// bearer link or the Node Provisioning Protocol Interface.
-public struct RemoteProvisioningLinkReport: RemoteProvisioningMessage, RemoteProvisioningStatusMessage {
+public struct RemoteProvisioningLinkReport: RemoteProvisioningStatusMessage {
     public static let opCode: UInt32 = 0x805C
     
     public let status: RemoteProvisioningMessageStatus

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningLinkStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningLinkStatus.swift
@@ -34,7 +34,7 @@ import Foundation
 /// the Remote Provisioning Server to acknowledge a Remote Provisioning Link Get
 /// message, a Remote Provisioning Link Open message, or a Remote Provisioning
 /// Link Close message.
-public struct RemoteProvisioningLinkStatus: RemoteProvisioningMessage, RemoteProvisioningStatusMessage {
+public struct RemoteProvisioningLinkStatus: RemoteProvisioningResponse, RemoteProvisioningStatusMessage {
     public static let opCode: UInt32 = 0x805B
     
     public let status: RemoteProvisioningMessageStatus

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningPDUOutboundReport.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningPDUOutboundReport.swift
@@ -36,7 +36,7 @@ import Foundation
 /// a device that is being provisioned or processes locally during the
 /// Device Key Refresh procedure, the Node Address Refresh procedure,
 /// or the Node Composition Refresh procedure.
-public struct RemoteProvisioningPDUOutboundReport: RemoteProvisioningMessage {
+public struct RemoteProvisioningPDUOutboundReport: UnacknowledgedRemoteProvisioningMessage {
     public static let opCode: UInt32 = 0x805E
     
     /// Remote Provisioning Outbound PDU Count state.

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningPDUReport.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningPDUReport.swift
@@ -35,7 +35,7 @@ import Foundation
 /// received from the device being provisioned or was generated locally during the
 /// Device Key Refresh procedure, the Node Address Refresh procedure, or the
 /// Node Composition Refresh procedure.
-public struct RemoteProvisioningPDUReport: RemoteProvisioningMessage {
+public struct RemoteProvisioningPDUReport: UnacknowledgedRemoteProvisioningMessage {
     public static let opCode: UInt32 = 0x805F
     
     /// Number of received Provisioning PDUs.

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningPDUSend.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningPDUSend.swift
@@ -33,7 +33,7 @@ import Foundation
 /// A Remote Provisioning PDU Send message is an unacknowledged message used by
 /// the Remote Provisioning Client to deliver the Provisioning PDU to an
 /// unprovisioned device or to the Node Provisioning Protocol Interface.
-public struct RemoteProvisioningPDUSend: RemoteProvisioningMessage {
+public struct RemoteProvisioningPDUSend: UnacknowledgedRemoteProvisioningMessage {
     public static let opCode: UInt32 = 0x805D
     
     /// The value of the Remote Provisioning Outbound PDU Count state of the

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningScanCapabilitiesGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningScanCapabilitiesGet.swift
@@ -35,7 +35,7 @@ import Foundation
 /// Scan Capabilities state.
 public struct RemoteProvisioningScanCapabilitiesGet: AcknowledgedRemoteProvisioningMessage {
     public static let opCode: UInt32 = 0x804F
-    public static let responseType: StaticMeshMessage.Type = RemoteProvisioningScanCapabilitiesStatus.self
+    public static let responseType: StaticMeshResponse.Type = RemoteProvisioningScanCapabilitiesStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningScanCapabilitiesStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningScanCapabilitiesStatus.swift
@@ -33,7 +33,7 @@ import Foundation
 /// A Remote Provisioning Scan Capabilities Status message is an unacknowledged
 /// message used by the Remote Provisioning Server to report the current value of
 /// the Remote Provisioning Scan Capabilities state of a Remote Provisioning Server.
-public struct RemoteProvisioningScanCapabilitiesStatus: RemoteProvisioningMessage {
+public struct RemoteProvisioningScanCapabilitiesStatus: RemoteProvisioningResponse {
     public static let opCode: UInt32 = 0x8050
     
     /// The maximum number of UUIDs that can be reported during scanning.

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningScanGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningScanGet.swift
@@ -35,7 +35,7 @@ import Foundation
 /// Remote Provisioning Server model.
 public struct RemoteProvisioningScanGet: AcknowledgedRemoteProvisioningMessage {
     public static let opCode: UInt32 = 0x8051
-    public static let responseType: StaticMeshMessage.Type = RemoteProvisioningScanStatus.self
+    public static let responseType: StaticMeshResponse.Type = RemoteProvisioningScanStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningScanReport.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningScanReport.swift
@@ -39,7 +39,7 @@ import CoreBluetooth
 /// Remote Provisioning Servers, the Remote Provisioning Client can select the most
 /// suitable Remote Provisioning Server to execute the Extended Scan procedure
 /// and/or to provision the unprovisioned device.
-public struct RemoteProvisioningScanReport: RemoteProvisioningMessage {
+public struct RemoteProvisioningScanReport: UnacknowledgedRemoteProvisioningMessage {
     public static let opCode: UInt32 = 0x8055
     /// Signed integer that is interpreted as an indication of received signal strength
     /// measured in dBm.

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningScanStart.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningScanStart.swift
@@ -37,7 +37,7 @@ import CoreBluetooth
 /// the Remote Provisioning Server.
 public struct RemoteProvisioningScanStart: AcknowledgedRemoteProvisioningMessage {
     public static let opCode: UInt32 = 0x8052
-    public static let responseType: StaticMeshMessage.Type = RemoteProvisioningScanStatus.self
+    public static let responseType: StaticMeshResponse.Type = RemoteProvisioningScanStatus.self
     
     /// Maximum number of scanned items to be reported.
     ///

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningScanStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningScanStatus.swift
@@ -34,7 +34,7 @@ import Foundation
 /// the Remote Provisioning Server to report the current value of the
 /// Remote Provisioning Scan Parameters state and the Remote Provisioning Scan state
 /// of a Remote Provisioning Server model.
-public struct RemoteProvisioningScanStatus: RemoteProvisioningMessage, RemoteProvisioningStatusMessage {
+public struct RemoteProvisioningScanStatus: RemoteProvisioningResponse, RemoteProvisioningStatusMessage {
     public static let opCode: UInt32 = 0x8054
     
     public let status: RemoteProvisioningMessageStatus

--- a/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningScanStop.swift
+++ b/nRFMeshProvision/Mesh Messages/Foundation/Remote Provisioning/RemoteProvisioningScanStop.swift
@@ -34,7 +34,7 @@ import Foundation
 /// by the Remote Provisioning Client to terminate the Remote Provisioning Scan procedure.
 public struct RemoteProvisioningScanStop: AcknowledgedRemoteProvisioningMessage {
     public static let opCode: UInt32 = 0x8053
-    public static let responseType: StaticMeshMessage.Type = RemoteProvisioningScanStatus.self
+    public static let responseType: StaticMeshResponse.Type = RemoteProvisioningScanStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericBatteryGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericBatteryGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericBatteryGet: AcknowledgedGenericMessage {
+public struct GenericBatteryGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8223
-    public static let responseType: StaticMeshMessage.Type = GenericBatteryStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericBatteryStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericBatteryStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericBatteryStatus.swift
@@ -58,7 +58,7 @@ public enum BatteryServiceability: UInt8 {
     case unknown            = 0b11
 }
 
-public struct GenericBatteryStatus: GenericMessage {
+public struct GenericBatteryStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x8224
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericDefaultTransitionTimeGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericDefaultTransitionTimeGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericDefaultTransitionTimeGet: AcknowledgedGenericMessage {
+public struct GenericDefaultTransitionTimeGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x820D
-    public static let responseType: StaticMeshMessage.Type = GenericDefaultTransitionTimeStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericDefaultTransitionTimeStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericDefaultTransitionTimeSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericDefaultTransitionTimeSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericDefaultTransitionTimeSet: AcknowledgedGenericMessage {
+public struct GenericDefaultTransitionTimeSet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x820E
-    public static let responseType: StaticMeshMessage.Type = GenericDefaultTransitionTimeStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericDefaultTransitionTimeStatus.self
     
     public var parameters: Data? {
         return Data([transitionTime.rawValue])

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericDefaultTransitionTimeSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericDefaultTransitionTimeSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericDefaultTransitionTimeSetUnacknowledged: GenericMessage {
+public struct GenericDefaultTransitionTimeSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x820F
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericDefaultTransitionTimeStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericDefaultTransitionTimeStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericDefaultTransitionTimeStatus: GenericMessage {
+public struct GenericDefaultTransitionTimeStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x8210
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericDeltaSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericDeltaSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericDeltaSet: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+public struct GenericDeltaSet: StaticAcknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x8209
-    public static let responseType: StaticMeshMessage.Type = GenericLevelStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericLevelStatus.self
     
     public var tid: UInt8!
     public var continueTransaction: Bool = true

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericDeltaSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericDeltaSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericDeltaSetUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+public struct GenericDeltaSetUnacknowledged: StaticUnacknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x820A
     
     public var tid: UInt8!

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericLevelGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericLevelGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericLevelGet: AcknowledgedGenericMessage {
+public struct GenericLevelGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8205
-    public static let responseType: StaticMeshMessage.Type = GenericLevelStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericLevelStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericLevelSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericLevelSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericLevelSet: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+public struct GenericLevelSet: StaticAcknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x8206
-    public static let responseType: StaticMeshMessage.Type = GenericLevelStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericLevelStatus.self
     
     public var tid: UInt8!
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericLevelSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericLevelSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericLevelSetUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+public struct GenericLevelSetUnacknowledged: StaticUnacknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x8207
     
     public var tid: UInt8!

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericLevelStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericLevelStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericLevelStatus: GenericMessage, TransitionStatusMessage {
+public struct GenericLevelStatus: StaticMeshResponse, TransitionStatusMessage {
     public static var opCode: UInt32 = 0x8208
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericLocationGlobalGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericLocationGlobalGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericLocationGlobalGet: AcknowledgedGenericMessage {
+public struct GenericLocationGlobalGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8225
-    public static let responseType: StaticMeshMessage.Type = GenericLocationGlobalStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericLocationGlobalStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericLocationGlobalSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericLocationGlobalSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericLocationGlobalSet: AcknowledgedGenericMessage {
+public struct GenericLocationGlobalSet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x41
-    public static let responseType: StaticMeshMessage.Type = GenericLocationGlobalStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericLocationGlobalStatus.self
     
     public var parameters: Data? {
         return Data() + latitude.encode() + longitude.encode() + altitude.encode()

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericLocationGlobalSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericLocationGlobalSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericLocationGlobalSetUnacknowledged: GenericMessage {
+public struct GenericLocationGlobalSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x42
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericLocationGlobalStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericLocationGlobalStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericLocationGlobalStatus: GenericMessage, LocationStatusMessage {
+public struct GenericLocationGlobalStatus: StaticMeshResponse, LocationStatusMessage {
     public static var opCode: UInt32 = 0x40
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericMoveSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericMoveSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericMoveSet: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+public struct GenericMoveSet: StaticAcknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x820B
-    public static let responseType: StaticMeshMessage.Type = GenericLevelStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericLevelStatus.self
     
     public var tid: UInt8!
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericMoveSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericMoveSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericMoveSetUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+public struct GenericMoveSetUnacknowledged: StaticUnacknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x820C
     
     public var tid: UInt8!

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericOnOffGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericOnOffGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericOnOffGet: AcknowledgedGenericMessage {
+public struct GenericOnOffGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8201
-    public static let responseType: StaticMeshMessage.Type = GenericOnOffStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericOnOffStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericOnOffSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericOnOffSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericOnOffSet: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+public struct GenericOnOffSet: StaticAcknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x8202
-    public static let responseType: StaticMeshMessage.Type = GenericOnOffStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericOnOffStatus.self
     
     public var tid: UInt8!
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericOnOffSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericOnOffSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericOnOffSetUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+public struct GenericOnOffSetUnacknowledged: StaticUnacknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x8203
     
     public var tid: UInt8!

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericOnOffStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericOnOffStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericOnOffStatus: GenericMessage, TransitionStatusMessage {
+public struct GenericOnOffStatus: StaticMeshResponse, TransitionStatusMessage {
     public static var opCode: UInt32 = 0x8204
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericOnPowerUpGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericOnPowerUpGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericOnPowerUpGet: AcknowledgedGenericMessage {
+public struct GenericOnPowerUpGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8211
-    public static let responseType: StaticMeshMessage.Type = GenericOnPowerUpStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericOnPowerUpStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericOnPowerUpSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericOnPowerUpSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericOnPowerUpSet: AcknowledgedGenericMessage {
+public struct GenericOnPowerUpSet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8213
-    public static let responseType: StaticMeshMessage.Type = GenericOnPowerUpStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericOnPowerUpStatus.self
     
     public var parameters: Data? {
         return Data([state.rawValue])

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericOnPowerUpSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericOnPowerUpSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericOnPowerUpSetUnacknowledged: GenericMessage {
+public struct GenericOnPowerUpSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8214
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericOnPowerUpStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericOnPowerUpStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericOnPowerUpStatus: GenericMessage {
+public struct GenericOnPowerUpStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x8212
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericPowerDefaultSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericPowerDefaultSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericPowerDefaultSet: AcknowledgedGenericMessage {
+public struct GenericPowerDefaultSet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x821F
-    public static let responseType: StaticMeshMessage.Type = GenericPowerDefaultStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericPowerDefaultStatus.self
     
     public var parameters: Data? {
         return Data() + power

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericPowerDefaultSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericPowerDefaultSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericPowerDefaultSetUnacknowledged: GenericMessage {
+public struct GenericPowerDefaultSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8220
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericPowerDefaultStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericPowerDefaultStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericPowerDefaultStatus: GenericMessage {
+public struct GenericPowerDefaultStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x821C
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericPowerDefautGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericPowerDefautGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericPowerDefaultGet: AcknowledgedGenericMessage {
+public struct GenericPowerDefaultGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x821B
-    public static let responseType: StaticMeshMessage.Type = GenericPowerDefaultStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericPowerDefaultStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericPowerLastGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericPowerLastGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericPowerLastGet: AcknowledgedGenericMessage {
+public struct GenericPowerLastGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8219
-    public static let responseType: StaticMeshMessage.Type = GenericPowerLastStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericPowerLastStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericPowerLastStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericPowerLastStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericPowerLastStatus: GenericMessage {
+public struct GenericPowerLastStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x821A
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericPowerLevelGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericPowerLevelGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericPowerLevelGet: AcknowledgedGenericMessage {
+public struct GenericPowerLevelGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8215
-    public static let responseType: StaticMeshMessage.Type = GenericPowerLevelStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericPowerLevelStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericPowerLevelSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericPowerLevelSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericPowerLevelSet: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+public struct GenericPowerLevelSet: StaticAcknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x8216
-    public static let responseType: StaticMeshMessage.Type = GenericPowerLevelStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericPowerLevelStatus.self
     
     public var tid: UInt8!
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericPowerLevelSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericPowerLevelSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericPowerLevelSetUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+public struct GenericPowerLevelSetUnacknowledged: StaticUnacknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x8217
     
     public var tid: UInt8!

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericPowerLevelStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericPowerLevelStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericPowerLevelStatus: GenericMessage, TransitionStatusMessage {
+public struct GenericPowerLevelStatus: StaticMeshResponse, TransitionStatusMessage {
     public static var opCode: UInt32 = 0x8218
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericPowerRangeGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericPowerRangeGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericPowerRangeGet: AcknowledgedGenericMessage {
+public struct GenericPowerRangeGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x821D
-    public static let responseType: StaticMeshMessage.Type = GenericPowerRangeStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericPowerRangeStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericPowerRangeSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericPowerRangeSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct GenericPowerRangeSet: AcknowledgedGenericMessage {
+public struct GenericPowerRangeSet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8221
-    public static let responseType: StaticMeshMessage.Type = GenericPowerRangeStatus.self
+    public static let responseType: StaticMeshResponse.Type = GenericPowerRangeStatus.self
     
     public var parameters: Data? {
         return Data() + range.lowerBound + range.upperBound

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericPowerRangeSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericPowerRangeSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct GenericPowerRangeSetUnacknowledged: GenericMessage {
+public struct GenericPowerRangeSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8222
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Generic/GenericPowerRangeStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Generic/GenericPowerRangeStatus.swift
@@ -30,14 +30,14 @@
 
 import Foundation
 
-public struct GenericPowerRangeStatus: GenericStatusMessage {
+public struct GenericPowerRangeStatus: StaticMeshResponse, RangeStatusMessage {
     public static let opCode: UInt32 = 0x821E
     
     public var parameters: Data? {
         return Data([status.rawValue]) + range.lowerBound + range.upperBound
     }
     
-    public let status: GenericMessageStatus
+    public let status: RangeMessageStatus
     /// The value of the Generic Power Range state.
     public let range: ClosedRange<UInt16>
     
@@ -53,7 +53,7 @@ public struct GenericPowerRangeStatus: GenericStatusMessage {
     ///
     /// - parameter status: Status Code for the requesting message.
     /// - parameter request: The request received.
-    public init(_ status: GenericMessageStatus, for request: GenericPowerRangeSet) {
+    public init(_ status: RangeMessageStatus, for request: GenericPowerRangeSet) {
         self.status = status
         self.range = request.range
     }
@@ -62,7 +62,7 @@ public struct GenericPowerRangeStatus: GenericStatusMessage {
     ///
     /// - parameter status: Status Code for the requesting message.
     /// - parameter request: The request received.
-    public init(_ status: GenericMessageStatus, for request: GenericPowerRangeSetUnacknowledged) {
+    public init(_ status: RangeMessageStatus, for request: GenericPowerRangeSetUnacknowledged) {
         self.status = status
         self.range = request.range
     }
@@ -71,7 +71,7 @@ public struct GenericPowerRangeStatus: GenericStatusMessage {
         guard parameters.count == 5 else {
             return nil
         }
-        guard let status = GenericMessageStatus(rawValue: parameters[0]) else {
+        guard let status = RangeMessageStatus(rawValue: parameters[0]) else {
             return nil
         }
         self.status = status

--- a/nRFMeshProvision/Mesh Messages/GenericMessage.swift
+++ b/nRFMeshProvision/Mesh Messages/GenericMessage.swift
@@ -30,32 +30,10 @@
 
 import Foundation
 
-/// A base protocol for generic messages.
-public protocol GenericMessage: StaticMeshMessage {
-    // No additional fields.
-}
-
-/// A base protocol for acknowledged generic messages.
-public protocol AcknowledgedGenericMessage: GenericMessage, StaticAcknowledgedMeshMessage {
-    // No additional fields.
-}
-
-public extension Array where Element == GenericMessage.Type {
-    
-    /// A helper method that can create a map of message types required
-    /// by the ``ModelDelegate`` from a list of ``GenericMessage``s.
-    ///
-    /// - returns: A map of message types.
-    func toMap() -> [UInt32 : MeshMessage.Type] {
-        return (self as [StaticMeshMessage.Type]).toMap()
-    }
-    
-}
-
-// MARK: - GenericMessageStatus
+// MARK: - RangeMessageStatus
 
 /// Enumeration of available statuses of a generic message.
-public enum GenericMessageStatus: UInt8 {
+public enum RangeMessageStatus: UInt8 {
     /// The operation was successful.
     case success           = 0x00
     /// The operation failed. Min range cannot be set.
@@ -65,12 +43,12 @@ public enum GenericMessageStatus: UInt8 {
 }
 
 /// A base protocol for generic status messages.
-public protocol GenericStatusMessage: GenericMessage, StatusMessage {
+public protocol RangeStatusMessage: StatusMessage {
     /// Operation status.
-    var status: GenericMessageStatus { get }
+    var status: RangeMessageStatus { get }
 }
 
-public extension GenericStatusMessage {
+public extension RangeStatusMessage {
     
     /// Whether the operation was successful.
     var isSuccess: Bool {
@@ -84,7 +62,7 @@ public extension GenericStatusMessage {
     
 }
 
-extension GenericMessageStatus: CustomDebugStringConvertible {
+extension RangeMessageStatus: CustomDebugStringConvertible {
     
     public var debugDescription: String {
         switch self {
@@ -112,7 +90,7 @@ public enum SceneMessageStatus: UInt8 {
 }
 
 /// a base protocol for scene status messages.
-public protocol SceneStatusMessage: GenericMessage, StatusMessage {
+public protocol SceneStatusMessage: StatusMessage {
     /// Operation status.
     var status: SceneMessageStatus { get }
 }

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLDefaultGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLDefaultGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightCTLTDefaultGet: AcknowledgedGenericMessage {
+public struct LightCTLTDefaultGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8267
-    public static let responseType: StaticMeshMessage.Type = LightCTLDefaultStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightCTLDefaultStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLDefaultSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLDefaultSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightCTLDefaultSet: AcknowledgedGenericMessage {
+public struct LightCTLDefaultSet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8269
-    public static let responseType: StaticMeshMessage.Type = LightCTLDefaultStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightCTLDefaultStatus.self
     
     public var parameters: Data? {
         return Data() + lightness + temperature + deltaUV

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLDefaultSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLDefaultSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightCTLDefaultSetUnacknowledged: GenericMessage {
+public struct LightCTLDefaultSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x826A
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLDefaultStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLDefaultStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightCTLDefaultStatus: GenericMessage {
+public struct LightCTLDefaultStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x8268
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLGet.swift
@@ -28,15 +28,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
- /*
-  * Created by codepgq.
-  */
-
 import Foundation
 
-public struct LightCTLGet: AcknowledgedGenericMessage {
+public struct LightCTLGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x825D
-    public static let responseType: StaticMeshMessage.Type = LightCTLStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightCTLStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLSet.swift
@@ -28,15 +28,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
- /*
-  * Created by codepgq.
-  */
-
 import Foundation
 
-public struct LightCTLSet: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+public struct LightCTLSet: StaticAcknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x825E
-    public static let responseType: StaticMeshMessage.Type = LightCTLStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightCTLStatus.self
     
     public var tid: UInt8!
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLSetUnackowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLSetUnackowledged.swift
@@ -28,13 +28,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
- /*
-  * Created by codepgq.
-  */
-
 import Foundation
 
-public struct LightCTLSetUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+public struct LightCTLSetUnacknowledged: StaticUnacknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x825F
     
     public var tid: UInt8!

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLStatus.swift
@@ -28,13 +28,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
- /*
-  * Created by codepgq.
-  */
-
 import Foundation
 
-public struct LightCTLStatus: GenericMessage, TransitionStatusMessage {
+public struct LightCTLStatus: StaticMeshResponse, TransitionStatusMessage {
     public static var opCode: UInt32 = 0x8260
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightCTLTemperatureGet: AcknowledgedGenericMessage {
+public struct LightCTLTemperatureGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8261
-    public static let responseType: StaticMeshMessage.Type = LightCTLTemperatureStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightCTLTemperatureStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureRangeGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureRangeGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightCTLTemperatureRangeGet: AcknowledgedGenericMessage {
+public struct LightCTLTemperatureRangeGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8262
-    public static let responseType: StaticMeshMessage.Type = LightCTLTemperatureRangeStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightCTLTemperatureRangeStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureRangeSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureRangeSet.swift
@@ -30,8 +30,9 @@
 
 import Foundation
 
-public struct LightCTLTemperatureRangeSet: GenericMessage {
+public struct LightCTLTemperatureRangeSet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x826B
+    public static let responseType: StaticMeshResponse.Type = LightCTLTemperatureRangeStatus.self
     
     public var parameters: Data? {
         return Data() + min + max

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureRangeSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureRangeSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightCTLTemperatureRangeSetUnacknowledged: GenericMessage {
+public struct LightCTLTemperatureRangeSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x826C
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureRangeStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureRangeStatus.swift
@@ -30,14 +30,14 @@
 
 import Foundation
 
-public struct LightCTLTemperatureRangeStatus: GenericMessage, GenericStatusMessage {
+public struct LightCTLTemperatureRangeStatus: StaticMeshResponse, RangeStatusMessage {
     public static let opCode: UInt32 = 0x8263
     
     public var parameters: Data? {
         return Data([status.rawValue]) + min + max
     }
     
-    public let status: GenericMessageStatus
+    public let status: RangeMessageStatus
     /// The value of the Temperature Range Min field of the Light CTL Temperature
     /// Range state.
     public let min: UInt16
@@ -63,7 +63,7 @@ public struct LightCTLTemperatureRangeStatus: GenericMessage, GenericStatusMessa
     ///
     /// - parameter status: Status Code for the requesting message.
     /// - parameter request: The request received.
-    public init(_ status: GenericMessageStatus,
+    public init(_ status: RangeMessageStatus,
                 for request: LightCTLTemperatureRangeSet) {
         self.status = status
         self.min = request.min
@@ -74,7 +74,7 @@ public struct LightCTLTemperatureRangeStatus: GenericMessage, GenericStatusMessa
     ///
     /// - parameter status: Status Code for the requesting message.
     /// - parameter request: The request received.
-    public init(_ status: GenericMessageStatus,
+    public init(_ status: RangeMessageStatus,
                 for request: LightCTLTemperatureRangeSetUnacknowledged) {
         self.status = status
         self.min = request.min
@@ -85,7 +85,7 @@ public struct LightCTLTemperatureRangeStatus: GenericMessage, GenericStatusMessa
         guard parameters.count == 5 else {
             return nil
         }
-        guard let status = GenericMessageStatus(rawValue: parameters[0]) else {
+        guard let status = RangeMessageStatus(rawValue: parameters[0]) else {
             return nil
         }
         self.status = status

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureSet.swift
@@ -28,15 +28,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
- /*
-  * Created by codepgq.
-  */
-
 import Foundation
 
-public struct LightCTLTemperatureSet: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+public struct LightCTLTemperatureSet: StaticAcknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x8264
-    public static let responseType: StaticMeshMessage.Type = LightCTLTemperatureStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightCTLTemperatureStatus.self
     
     public var tid: UInt8!
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureSetUnacknowledged.swift
@@ -28,13 +28,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
- /*
-  * Created by codepgq.
-  */
-
 import Foundation
 
-public struct LightCTLTemperatureSetUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+public struct LightCTLTemperatureSetUnacknowledged: StaticUnacknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x8265
     
     public var tid: UInt8!

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightCTLTemperatureStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightCTLTemperatureStatus: GenericMessage, TransitionStatusMessage {
+public struct LightCTLTemperatureStatus: StaticMeshResponse, TransitionStatusMessage {
     public static var opCode: UInt32 = 0x8266
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLDefaultGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLDefaultGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightHSLDefaultGet: AcknowledgedGenericMessage {
+public struct LightHSLDefaultGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x827B
-    public static let responseType: StaticMeshMessage.Type = LightHSLDefaultStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightHSLDefaultStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLDefaultSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLDefaultSet.swift
@@ -28,15 +28,11 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-/*
- * Created by codepgq.
- */
-
 import Foundation
 
-public struct LightHSLDefaultSet: AcknowledgedGenericMessage {
+public struct LightHSLDefaultSet: StaticAcknowledgedMeshMessage {
     public static var opCode: UInt32 = 0x827F
-    public static let responseType: StaticMeshMessage.Type = LightHSLDefaultStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightHSLDefaultStatus.self
     
     public var parameters: Data? {
         return Data() + lightness + hue + saturation

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLDefaultSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLDefaultSetUnacknowledged.swift
@@ -28,13 +28,9 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-/*
- * Created by codepgq.
- */
-
 import Foundation
 
-public struct LightHSLDefaultSetUnacknowledged: GenericMessage {
+public struct LightHSLDefaultSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static var opCode: UInt32 = 0x8280
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLDefaultStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLDefaultStatus.swift
@@ -28,13 +28,9 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-/*
- * Created by codepgq.
- */
-
 import Foundation
 
-public struct LightHSLDefaultStatus: GenericMessage {
+public struct LightHSLDefaultStatus: StaticMeshResponse {
     public static var opCode: UInt32 = 0x827C
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLGet.swift
@@ -28,15 +28,11 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-/*
- * Created by codepgq.
- */
-
 import Foundation
 
-public struct LightHSLGet: AcknowledgedGenericMessage {
+public struct LightHSLGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x826D
-    public static let responseType: StaticMeshMessage.Type = LightHSLStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightHSLStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLHueGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLHueGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightHSLHueGet: AcknowledgedGenericMessage {
+public struct LightHSLHueGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x826E
-    public static let responseType: StaticMeshMessage.Type = LightHSLHueStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightHSLHueStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLHueSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLHueSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightHSLHueSet: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+public struct LightHSLHueSet: StaticAcknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static var opCode: UInt32 = 0x826F
-    public static var responseType: StaticMeshMessage.Type = LightHSLHueStatus.self
+    public static var responseType: StaticMeshResponse.Type = LightHSLHueStatus.self
     
     public var tid: UInt8!
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLHueSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLHueSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightHSLHueSetUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+public struct LightHSLHueSetUnacknowledged: StaticUnacknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static var opCode: UInt32 = 0x8270
     
     public var tid: UInt8!

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLHueStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLHueStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightHSLHueStatus: GenericMessage, TransitionStatusMessage {
+public struct LightHSLHueStatus: StaticMeshResponse, TransitionStatusMessage {
     public static var opCode: UInt32 = 0x8271
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLRangeGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLRangeGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightHSLRangeGet: AcknowledgedGenericMessage {
+public struct LightHSLRangeGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x827D
-    public static let responseType: StaticMeshMessage.Type = LightHSLRangeStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightHSLRangeStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLRangeSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLRangeSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightHSLRangeSet: AcknowledgedGenericMessage {
+public struct LightHSLRangeSet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8281
-    public static let responseType: StaticMeshMessage.Type = LightHSLRangeStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightHSLRangeStatus.self
     
     public var parameters: Data? {
         return Data() + minHue + maxHue + minSaturation + maxSaturation

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLRangeSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLRangeSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightHSLRangeSetUnacknowledged: GenericMessage {
+public struct LightHSLRangeSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8282
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLRangeStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLRangeStatus.swift
@@ -30,14 +30,14 @@
 
 import Foundation
 
-public struct LightHSLRangeStatus: GenericMessage, GenericStatusMessage {
+public struct LightHSLRangeStatus: StaticMeshResponse, RangeStatusMessage {
     public static let opCode: UInt32 = 0x827E
     
     public var parameters: Data? {
         return Data([status.rawValue]) + minHue + maxHue + minSaturation + maxSaturation
     }
     
-    public let status: GenericMessageStatus
+    public let status: RangeMessageStatus
     /// The value of the Hue Range Min field of the Light HSL Range state.
     public let minHue: UInt16
     /// The value of the Hue Range Max field of the Light HSL Range state.
@@ -72,7 +72,7 @@ public struct LightHSLRangeStatus: GenericMessage, GenericStatusMessage {
     ///
     /// - parameter status: Status Code for the requesting message.
     /// - parameter request: The request received.
-    public init(_ status: GenericMessageStatus, for request: LightHSLRangeSet) {
+    public init(_ status: RangeMessageStatus, for request: LightHSLRangeSet) {
         self.status = status
         self.minHue = request.minHue
         self.maxHue = request.maxHue
@@ -84,7 +84,7 @@ public struct LightHSLRangeStatus: GenericMessage, GenericStatusMessage {
     ///
     /// - parameter status: Status Code for the requesting message.
     /// - parameter request: The request received.
-    public init(_ status: GenericMessageStatus, for request: LightHSLRangeSetUnacknowledged) {
+    public init(_ status: RangeMessageStatus, for request: LightHSLRangeSetUnacknowledged) {
         self.status = status
         self.minHue = request.minHue
         self.maxHue = request.maxHue
@@ -96,7 +96,7 @@ public struct LightHSLRangeStatus: GenericMessage, GenericStatusMessage {
         guard parameters.count == 9 else {
             return nil
         }
-        guard let status = GenericMessageStatus(rawValue: parameters[0]) else {
+        guard let status = RangeMessageStatus(rawValue: parameters[0]) else {
             return nil
         }
         self.status = status

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLSaturationGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLSaturationGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightHSLSaturationGet: AcknowledgedGenericMessage {
+public struct LightHSLSaturationGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8272
-    public static let responseType: StaticMeshMessage.Type = LightHSLSaturationStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightHSLSaturationStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLSaturationSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLSaturationSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightHSLSaturationSet: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+public struct LightHSLSaturationSet: StaticAcknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static var opCode: UInt32 = 0x8273
-    public static var responseType: StaticMeshMessage.Type = LightHSLSaturationStatus.self
+    public static var responseType: StaticMeshResponse.Type = LightHSLSaturationStatus.self
     
     public var tid: UInt8!
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLSaturationSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLSaturationSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightHSLSaturationSetUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+public struct LightHSLSaturationSetUnacknowledged: StaticUnacknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static var opCode: UInt32 = 0x8274
     
     public var tid: UInt8!

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLSaturationStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLSaturationStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightHSLSaturationStatus: GenericMessage, TransitionStatusMessage {
+public struct LightHSLSaturationStatus: StaticMeshResponse, TransitionStatusMessage {
     public static var opCode: UInt32 = 0x8275
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLSet.swift
@@ -28,15 +28,11 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-/*
- * Created by codepgq.
- */
-
 import Foundation
 
-public struct LightHSLSet: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+public struct LightHSLSet: StaticAcknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static var opCode: UInt32 = 0x8276
-    public static var responseType: StaticMeshMessage.Type = LightHSLStatus.self
+    public static var responseType: StaticMeshResponse.Type = LightHSLStatus.self
     
     public var tid: UInt8!
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLSetUnackowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLSetUnackowledged.swift
@@ -28,13 +28,9 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-/*
- * Created by codepgq.
- */
-
 import Foundation
 
-public struct LightHSLSetUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+public struct LightHSLSetUnacknowledged: StaticUnacknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static var opCode: UInt32 = 0x8277
     
     public var tid: UInt8!

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLStatus.swift
@@ -28,13 +28,9 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-/*
- * Created by codepgq.
- */
-
 import Foundation
 
-public struct LightHSLStatus: GenericMessage, TransitionStatusMessage {
+public struct LightHSLStatus: StaticMeshResponse, TransitionStatusMessage {
     public static var opCode: UInt32 = 0x8278
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLTargetGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLTargetGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightHSLTargetGet: AcknowledgedGenericMessage {
+public struct LightHSLTargetGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8279
-    public static let responseType: StaticMeshMessage.Type = LightHSLTargetStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightHSLTargetStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightHSLTargetStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightHSLTargetStatus.swift
@@ -28,13 +28,9 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-/*
- * Created by codepgq.
- */
-
 import Foundation
 
-public struct LightHSLTargetStatus: GenericMessage, TransitionStatusMessage {
+public struct LightHSLTargetStatus: StaticMeshResponse, TransitionStatusMessage {
     public static var opCode: UInt32 = 0x827A
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCLightOnOffGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCLightOnOffGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightLCLightOnOffGet: AcknowledgedGenericMessage {
+public struct LightLCLightOnOffGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8299
-    public static let responseType: StaticMeshMessage.Type = LightLCLightOnOffStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLCLightOnOffStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCLightOnOffSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCLightOnOffSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightLCLightOnOffSet: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+public struct LightLCLightOnOffSet: StaticAcknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x829A
-    public static let responseType: StaticMeshMessage.Type = LightLCLightOnOffStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLCLightOnOffStatus.self
     
     public var tid: UInt8!
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCLightOnOffSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCLightOnOffSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightLCLightOnOffSetUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+public struct LightLCLightOnOffSetUnacknowledged: StaticUnacknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x829B
     
     public var tid: UInt8!

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCLightOnOffStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCLightOnOffStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightLCLightOnOffStatus: GenericMessage, TransitionStatusMessage {
+public struct LightLCLightOnOffStatus: StaticMeshResponse, TransitionStatusMessage {
     public static var opCode: UInt32 = 0x829C
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCModeGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCModeGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightLCModeGet: AcknowledgedGenericMessage {
+public struct LightLCModeGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8291
-    public static let responseType: StaticMeshMessage.Type = LightLCModeStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLCModeStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCModeSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCModeSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightLCModeSet: AcknowledgedGenericMessage {
+public struct LightLCModeSet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8292
-    public static let responseType: StaticMeshMessage.Type = LightLCModeStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLCModeStatus.self
     
     /// Whether the controller is turned on and the binding with the Light Lightness
     /// state is enabled.

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCModeSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCModeSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightLCModeSetUnacknowledged: GenericMessage {
+public struct LightLCModeSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8293
     
     /// Whether the controller is turned on and the binding with the Light Lightness

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCModeStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCModeStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightLCModeStatus: GenericMessage {
+public struct LightLCModeStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x8294
     
     /// Whether the controller is turned on and the binding with the Light Lightness

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCOccupancyModeGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCOccupancyModeGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightLCOccupancyModeGet: AcknowledgedGenericMessage {
+public struct LightLCOccupancyModeGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8295
-    public static let responseType: StaticMeshMessage.Type = LightLCOccupancyModeStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLCOccupancyModeStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCOccupancyModeSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCOccupancyModeSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightLCOccupancyModeSet: AcknowledgedGenericMessage {
+public struct LightLCOccupancyModeSet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8296
-    public static let responseType: StaticMeshMessage.Type = LightLCOccupancyModeStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLCOccupancyModeStatus.self
     
     /// Whether the controller may transition from a standby state when occupancy
     /// is reported.

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCOccupancyModeSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCOccupancyModeSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightLCOccupancyModeSetUnacknowledged: GenericMessage {
+public struct LightLCOccupancyModeSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8297
     
     /// Whether the controller may transition from a standby state when occupancy

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCOccupancyModeStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCOccupancyModeStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightLCOccupancyModeStatus: GenericMessage {
+public struct LightLCOccupancyModeStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x8298
     
     /// Whether the controller may transition from a standby state when occupancy

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCPropertyGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCPropertyGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightLCPropertyGet: AcknowledgedSensorPropertyMessage {
+public struct LightLCPropertyGet: StaticAcknowledgedMeshMessage, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x829D
-    public static let responseType: StaticMeshMessage.Type = LightLCPropertyStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLCPropertyStatus.self
     
     public let property: DeviceProperty
     

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCPropertySet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCPropertySet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightLCPropertySet: AcknowledgedSensorPropertyMessage {
+public struct LightLCPropertySet: StaticAcknowledgedMeshMessage, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x62
-    public static let responseType: StaticMeshMessage.Type = LightLCPropertyStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLCPropertyStatus.self
     
     public let property: DeviceProperty
     /// Value of the Light LC Property.

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCPropertySetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCPropertySetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightLCPropertySetUnacknowledged: SensorPropertyMessage {
+public struct LightLCPropertySetUnacknowledged: StaticUnacknowledgedMeshMessage, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x63
     
     public let property: DeviceProperty

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLCPropertyStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLCPropertyStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightLCPropertyStatus: SensorPropertyMessage {
+public struct LightLCPropertyStatus: StaticMeshResponse, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x64
     
     public let property: DeviceProperty

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessDefaultGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessDefaultGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightLightnessDefaultGet: AcknowledgedGenericMessage {
+public struct LightLightnessDefaultGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8255
-    public static let responseType: StaticMeshMessage.Type = LightLightnessDefaultStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLightnessDefaultStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessDefaultSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessDefaultSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightLightnessDefaultSet: AcknowledgedGenericMessage {
+public struct LightLightnessDefaultSet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8259
-    public static let responseType: StaticMeshMessage.Type = LightLightnessDefaultStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLightnessDefaultStatus.self
     
     public var parameters: Data? {
         return Data() + lightness

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessDefaultSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessDefaultSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightLightnessDefaultSetUnacknowledged: GenericMessage {
+public struct LightLightnessDefaultSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x825A
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessDefaultStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessDefaultStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightLightnessDefaultStatus: GenericMessage {
+public struct LightLightnessDefaultStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x8256
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessGet.swift
@@ -28,15 +28,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*
- * Created by codepgq.
- */
-
 import Foundation
 
-public struct LightLightnessGet: AcknowledgedGenericMessage {
+public struct LightLightnessGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x824B
-    public static let responseType: StaticMeshMessage.Type = LightLightnessStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLightnessStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessLastGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessLastGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightLightnessLastGet: AcknowledgedGenericMessage {
+public struct LightLightnessLastGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8253
-    public static let responseType: StaticMeshMessage.Type = LightLightnessLastStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLightnessLastStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessLastStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessLastStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightLightnessLastStatus: GenericMessage {
+public struct LightLightnessLastStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x8254
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessLinearGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessLinearGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightLightnessLinearGet: AcknowledgedGenericMessage {
+public struct LightLightnessLinearGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x824F
-    public static let responseType: StaticMeshMessage.Type = LightLightnessLinearStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLightnessLinearStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessLinearSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessLinearSet.swift
@@ -29,9 +29,10 @@
  */
 
 import Foundation
-public struct LightLightnessLinearSet: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+
+public struct LightLightnessLinearSet: StaticAcknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static var opCode: UInt32 = 0x8250
-    public static var responseType: StaticMeshMessage.Type = LightLightnessLinearStatus.self
+    public static var responseType: StaticMeshResponse.Type = LightLightnessLinearStatus.self
     
     public var tid: UInt8!    
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessLinearSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessLinearSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightLightnessLinearSetUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+public struct LightLightnessLinearSetUnacknowledged: StaticUnacknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static var opCode: UInt32 = 0x8251
     
     public var tid: UInt8!

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessLinearStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessLinearStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightLightnessLinearStatus: GenericMessage, TransitionStatusMessage {
+public struct LightLightnessLinearStatus: StaticMeshResponse, TransitionStatusMessage {
     public static let opCode: UInt32 = 0x8252
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessRangeGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessRangeGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightLightnessRangeGet: AcknowledgedGenericMessage {
+public struct LightLightnessRangeGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8257
-    public static let responseType: StaticMeshMessage.Type = LightLightnessRangeStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLightnessRangeStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessRangeSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessRangeSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct LightLightnessRangeSet: AcknowledgedGenericMessage {
+public struct LightLightnessRangeSet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x825B
-    public static let responseType: StaticMeshMessage.Type = LightLightnessRangeStatus.self
+    public static let responseType: StaticMeshResponse.Type = LightLightnessRangeStatus.self
     
     public var parameters: Data? {
         return Data() + min + max

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessRangeSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessRangeSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct LightLightnessRangeSetUnacknowledged: GenericMessage {
+public struct LightLightnessRangeSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x825C
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessRangeStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessRangeStatus.swift
@@ -30,14 +30,14 @@
 
 import Foundation
 
-public struct LightLightnessRangeStatus: GenericMessage, GenericStatusMessage {
+public struct LightLightnessRangeStatus: StaticMeshResponse, RangeStatusMessage {
     public static let opCode: UInt32 = 0x8258
     
     public var parameters: Data? {
         return Data([status.rawValue]) + min + max
     }
     
-    public let status: GenericMessageStatus
+    public let status: RangeMessageStatus
     /// The value of the Light Lightness Min field of the Light Lightness
     /// Range state.
     public let min: UInt16
@@ -63,7 +63,7 @@ public struct LightLightnessRangeStatus: GenericMessage, GenericStatusMessage {
     ///
     /// - parameter status: Status Code for the requesting message.
     /// - parameter request: The request received.
-    public init(_ status: GenericMessageStatus, for request: LightLightnessRangeSet) {
+    public init(_ status: RangeMessageStatus, for request: LightLightnessRangeSet) {
         self.status = status
         self.min = request.min
         self.max = request.max
@@ -73,7 +73,7 @@ public struct LightLightnessRangeStatus: GenericMessage, GenericStatusMessage {
     ///
     /// - parameter status: Status Code for the requesting message.
     /// - parameter request: The request received.
-    public init(_ status: GenericMessageStatus, for request: LightLightnessRangeSetUnacknowledged) {
+    public init(_ status: RangeMessageStatus, for request: LightLightnessRangeSetUnacknowledged) {
         self.status = status
         self.min = request.min
         self.max = request.max
@@ -83,7 +83,7 @@ public struct LightLightnessRangeStatus: GenericMessage, GenericStatusMessage {
         guard parameters.count == 5 else {
             return nil
         }
-        guard let status = GenericMessageStatus(rawValue: parameters[0]) else {
+        guard let status = RangeMessageStatus(rawValue: parameters[0]) else {
             return nil
         }
         self.status = status

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessSet.swift
@@ -28,14 +28,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
- /*
-  * Created by codepgq.
-  */
-
 import Foundation
-public struct LightLightnessSet: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+public struct LightLightnessSet: StaticAcknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static var opCode: UInt32 = 0x824C
-    public static var responseType: StaticMeshMessage.Type = LightLightnessStatus.self
+    public static var responseType: StaticMeshResponse.Type = LightLightnessStatus.self
     
     public var tid: UInt8!    
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessSetUnacknowledged.swift
@@ -28,13 +28,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
- /*
-  * Created by codepgq.
-  */
-
 import Foundation
 
-public struct LightLightnessSetUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+public struct LightLightnessSetUnacknowledged: StaticUnacknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static var opCode: UInt32 = 0x824D
     
     public var tid: UInt8!

--- a/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Lighting/LightLightnessStatus.swift
@@ -28,13 +28,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
- /*
-  * Created by codepgq.
-  */
-
 import Foundation
 
-public struct LightLightnessStatus: GenericMessage, TransitionStatusMessage {
+public struct LightLightnessStatus: StaticMeshResponse, TransitionStatusMessage {
     public static let opCode: UInt32 = 0x824E
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/LocationMessage.swift
+++ b/nRFMeshProvision/Mesh Messages/LocationMessage.swift
@@ -31,23 +31,13 @@
 import Foundation
 
 /// A base protocol for location status messages.
-public protocol LocationStatusMessage: GenericMessage {
+public protocol LocationStatusMessage: MeshMessage {
     /// Latitude
     var latitude: Latitude { get }
     /// Longitude
     var longitude: Longitude { get }
     /// Altitude
     var altitude: Altitude { get }
-}
-
-/// A base protocol for location messafges.
-public protocol LocationMessage: StaticMeshMessage {
-    // No additional fields.
-}
-
-/// A base protocol for acknowledged location messafges.
-public protocol AcknowledgedLocationMessage: LocationMessage, StaticAcknowledgedMeshMessage {
-    // No additional fields.
 }
 
 /// The representation of latitide coordinate.

--- a/nRFMeshProvision/Mesh Messages/MeshMessage.swift
+++ b/nRFMeshProvision/Mesh Messages/MeshMessage.swift
@@ -92,6 +92,16 @@ public protocol MeshMessage: BaseMeshMessage {
     var isSegmented: Bool { get }
 }
 
+/// The base class for unacknowledged messages.
+public protocol UnacknowledgedMeshMessage: MeshMessage {
+    // No additional fields.
+}
+
+/// The base class for response messages.
+public protocol MeshResponse: UnacknowledgedMeshMessage {
+    // No additional fields.
+}
+
 /// The base class for acknowledged messages.
 ///
 /// An acknowledged message is transmitted and acknowledged by each
@@ -99,6 +109,13 @@ public protocol MeshMessage: BaseMeshMessage {
 /// typically a status message. If a response is not received within
 /// an arbitrary time period, the message will be retransmitted
 /// automatically until the timeout occurs.
+///
+/// Acknowledged messages are expected to be replied with a status message
+/// with a message of type set as ``AcknowledgedMeshMessage/responseOpCode``.
+///
+/// Access Layer timer will wait for
+/// ``NetworkParameters/acknowledgmentMessageTimeout`` seconds
+/// before throwing a timeout.
 public protocol AcknowledgedMeshMessage: MeshMessage {
     /// The Op Code of the response message.
     var responseOpCode: UInt32 { get }
@@ -110,17 +127,26 @@ public protocol StaticMeshMessage: MeshMessage {
     static var opCode: UInt32 { get }
 }
 
-/// A base class for acknowledged messages.
+/// The base class for unacknowledged messages with an opcode known at the
+/// compilation time.
+public protocol StaticUnacknowledgedMeshMessage: StaticMeshMessage, UnacknowledgedMeshMessage {
+    // No additional fields.
+}
+
+/// The base class for response messages with an opcode known at the
+/// compilation time.
+public protocol StaticMeshResponse: MeshResponse, StaticUnacknowledgedMeshMessage {
+    // No additional fields.
+}
+
+/// A base class for acknowledged messages which opcode and the type of the
+/// response message are known during compilation time.
 ///
-/// Acknowledged messages are expected to be replied with a status message
-/// with a message of type set as ``StaticAcknowledgedMeshMessage/responseType``.
-///
-/// Access Layer timer will wait for
-/// ``NetworkParameters/acknowledgmentMessageTimeout`` seconds
-/// before throwing a timeout.
-public protocol StaticAcknowledgedMeshMessage: AcknowledgedMeshMessage, StaticMeshMessage {
+/// The message must have the ``StaticAcknowledgedMeshMessage/responseType``
+/// specified.
+public protocol StaticAcknowledgedMeshMessage: StaticMeshMessage, AcknowledgedMeshMessage {
     /// The Type of the response message.
-    static var responseType: StaticMeshMessage.Type { get }
+    static var responseType: StaticMeshResponse.Type { get }
 }
 
 /// A mesh message containing the operation status.

--- a/nRFMeshProvision/Mesh Messages/RemoteProvisioningMessage.swift
+++ b/nRFMeshProvision/Mesh Messages/RemoteProvisioningMessage.swift
@@ -35,6 +35,16 @@ public protocol RemoteProvisioningMessage: StaticMeshMessage {
     // No additional fields.
 }
 
+/// A base protocol for unacknowledged Remote Provisioning messages.
+public protocol UnacknowledgedRemoteProvisioningMessage: RemoteProvisioningMessage, UnacknowledgedMeshMessage {
+    // No additional fields.
+}
+
+/// A base protocol for unacknowledged Remote Provisioning messages.
+public protocol RemoteProvisioningResponse: StaticMeshResponse, UnacknowledgedRemoteProvisioningMessage {
+    // No additional fields.
+}
+
 /// A base protocol for acknowledged Remote Provisioning messages.
 ///
 /// Acknowledged messages will be responded with a status message.
@@ -71,6 +81,9 @@ public enum RemoteProvisioningMessageStatus: UInt8 {
 }
 
 /// A base protocol for config status messages.
+///
+/// Remote Provisioning status message may come as a response to an acknowledged
+/// message, or sent as a Report message.
 public protocol RemoteProvisioningStatusMessage: RemoteProvisioningMessage, StatusMessage {
     /// Status for the requesting message.
     var status: RemoteProvisioningMessageStatus { get }

--- a/nRFMeshProvision/Mesh Messages/SensorMessage.swift
+++ b/nRFMeshProvision/Mesh Messages/SensorMessage.swift
@@ -30,37 +30,10 @@
 
 import Foundation
 
-/// A base protocol for sensor messages.
-public protocol SensorMessage: StaticMeshMessage {
-    // No additional fields.
-}
-
-/// A base protocol for acknowledged sensor messages.
-public protocol AcknowledgedSensorMessage: SensorMessage, StaticAcknowledgedMeshMessage {
-    // No additional fields.
-}
-
-public extension Array where Element == SensorMessage.Type {
-    
-    /// A helper method that can create a map of message types required
-    /// by the ``ModelDelegate`` from a list of ``SensorMessage``s.
-    ///
-    /// - returns: A map of message types.
-    func toMap() -> [UInt32 : MeshMessage.Type] {
-        return (self as [StaticMeshMessage.Type]).toMap()
-    }
-    
-}
-
 /// A base protocol for sensor property messages.
-public protocol SensorPropertyMessage: SensorMessage {
+public protocol SensorPropertyMessage: MeshMessage {
     /// Property for the sensor.
     var property: DeviceProperty { get }
-}
-
-/// A base protocol for acknowledged sensor property messages.
-public protocol AcknowledgedSensorPropertyMessage: SensorPropertyMessage, StaticAcknowledgedMeshMessage {
-    // No additional fields.
 }
 
 /// The Sensor Descriptor state represents the attributes describing the

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorCadenceGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorCadenceGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct SensorCadenceGet: AcknowledgedSensorPropertyMessage {
+public struct SensorCadenceGet: StaticAcknowledgedMeshMessage, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x8234
-    public static let responseType: StaticMeshMessage.Type = SensorCadenceStatus.self
+    public static let responseType: StaticMeshResponse.Type = SensorCadenceStatus.self
     
     public let property: DeviceProperty
     

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorCadenceSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorCadenceSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct SensorCadenceSet: AcknowledgedSensorPropertyMessage {
+public struct SensorCadenceSet: StaticAcknowledgedMeshMessage, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x55
-    public static let responseType: StaticMeshMessage.Type = SensorCadenceStatus.self
+    public static let responseType: StaticMeshResponse.Type = SensorCadenceStatus.self
     
     public let property: DeviceProperty
     

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorCadenceSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorCadenceSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SensorCadenceSetUnacknowledged: SensorPropertyMessage {
+public struct SensorCadenceSetUnacknowledged: StaticUnacknowledgedMeshMessage, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x56
     
     public let property: DeviceProperty

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorCadenceStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorCadenceStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SensorCadenceStatus: SensorPropertyMessage {
+public struct SensorCadenceStatus: StaticMeshResponse, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x57
     
     public let property: DeviceProperty

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorColumnGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorColumnGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct SensorColumnGet: AcknowledgedSensorPropertyMessage {
+public struct SensorColumnGet: StaticAcknowledgedMeshMessage, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x8232
-    public static let responseType: StaticMeshMessage.Type = SensorColumnStatus.self
+    public static let responseType: StaticMeshResponse.Type = SensorColumnStatus.self
     
     public let property: DeviceProperty
     /// Raw value identifying a column.

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorColumnStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorColumnStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SensorColumnStatus: SensorPropertyMessage {
+public struct SensorColumnStatus: StaticMeshResponse, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x53
     
     public let property: DeviceProperty

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorDescriptorGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorDescriptorGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct SensorDescriptorGet: AcknowledgedSensorMessage {
+public struct SensorDescriptorGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8230
-    public static let responseType: StaticMeshMessage.Type = SensorDescriptorStatus.self
+    public static let responseType: StaticMeshResponse.Type = SensorDescriptorStatus.self
     
     /// The sensor property to get the descriptor of.
     ///

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorDescriptorStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorDescriptorStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SensorDescriptorStatus: SensorMessage {
+public struct SensorDescriptorStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x51
     
     /// The result returned in Sensor Descriptor Status message.

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct SensorGet: AcknowledgedSensorMessage {
+public struct SensorGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8231
-    public static let responseType: StaticMeshMessage.Type = SensorStatus.self
+    public static let responseType: StaticMeshResponse.Type = SensorStatus.self
     
     /// The sensor property to get the value of.
     ///

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorSeriesGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorSeriesGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct SensorSeriesGet: AcknowledgedSensorPropertyMessage {
+public struct SensorSeriesGet: StaticAcknowledgedMeshMessage, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x8233
-    public static let responseType: StaticMeshMessage.Type = SensorSeriesStatus.self
+    public static let responseType: StaticMeshResponse.Type = SensorSeriesStatus.self
     
     public let property: DeviceProperty
     /// Raw value identifying a starting column.

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorSeriesStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorSeriesStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SensorSeriesStatus: SensorPropertyMessage {
+public struct SensorSeriesStatus: StaticMeshResponse, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x54
     
     public let property: DeviceProperty

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorSettingGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorSettingGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct SensorSettingGet: AcknowledgedSensorPropertyMessage {
+public struct SensorSettingGet: StaticAcknowledgedMeshMessage, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x8236
-    public static let responseType: StaticMeshMessage.Type = SensorSettingStatus.self
+    public static let responseType: StaticMeshResponse.Type = SensorSettingStatus.self
     
     public let property: DeviceProperty
     /// Setting Property identifying a setting within a sensor.

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorSettingSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorSettingSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct SensorSettingSet: AcknowledgedSensorPropertyMessage {
+public struct SensorSettingSet: StaticAcknowledgedMeshMessage, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x59
-    public static let responseType: StaticMeshMessage.Type = SensorSettingStatus.self
+    public static let responseType: StaticMeshResponse.Type = SensorSettingStatus.self
     
     public let property: DeviceProperty
     /// Setting Property identifying a setting within a sensor.

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorSettingSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorSettingSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SensorSettingSetUnacknowledged: SensorPropertyMessage {
+public struct SensorSettingSetUnacknowledged: StaticUnacknowledgedMeshMessage, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x5A
     
     public let property: DeviceProperty

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorSettingStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorSettingStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SensorSettingStatus: SensorPropertyMessage {
+public struct SensorSettingStatus: StaticMeshResponse, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x5B
     
     /// The Sensor Setting Access field is an enumeration indicating whether

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorSettingsGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorSettingsGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct SensorSettingsGet: AcknowledgedSensorPropertyMessage {
+public struct SensorSettingsGet: StaticAcknowledgedMeshMessage, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x8235
-    public static let responseType: StaticMeshMessage.Type = SensorSettingsStatus.self
+    public static let responseType: StaticMeshResponse.Type = SensorSettingsStatus.self
     
     public let property: DeviceProperty
     

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorSettingsStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorSettingsStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SensorSettingsStatus: SensorPropertyMessage {
+public struct SensorSettingsStatus: StaticMeshResponse, SensorPropertyMessage {
     public static let opCode: UInt32 = 0x58
     
     public let property: DeviceProperty

--- a/nRFMeshProvision/Mesh Messages/Sensors/SensorStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Sensors/SensorStatus.swift
@@ -33,7 +33,7 @@ import Foundation
 /// A Device Property with corresponding characteristic.
 public typealias SensorValue = (property: DeviceProperty, value: DevicePropertyCharacteristic)
 
-public struct SensorStatus: SensorMessage {
+public struct SensorStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x52
     
     /// The sensor values.

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneDelete.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneDelete.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct SceneDelete: AcknowledgedGenericMessage {
+public struct SceneDelete: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x829E
-    public static let responseType: StaticMeshMessage.Type = SceneRegisterStatus.self
+    public static let responseType: StaticMeshResponse.Type = SceneRegisterStatus.self
     
     public var parameters: Data? {
         return Data() + scene

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneDeleteUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneDeleteUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SceneDeleteUnacknowledged: GenericMessage {
+public struct SceneDeleteUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x829F
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct SceneGet: AcknowledgedGenericMessage {
+public struct SceneGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8241
-    public static let responseType: StaticMeshMessage.Type = SceneStatus.self
+    public static let responseType: StaticMeshResponse.Type = SceneStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneRecall.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneRecall.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct SceneRecall: AcknowledgedGenericMessage, TransactionMessage, TransitionMessage {
+public struct SceneRecall: StaticAcknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x8242
-    public static let responseType: StaticMeshMessage.Type = SceneStatus.self
+    public static let responseType: StaticMeshResponse.Type = SceneStatus.self
     
     public var tid: UInt8!
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneRecallUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneRecallUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SceneRecallUnacknowledged: GenericMessage, TransactionMessage, TransitionMessage {
+public struct SceneRecallUnacknowledged: StaticUnacknowledgedMeshMessage, TransactionMessage, TransitionMessage {
     public static let opCode: UInt32 = 0x8243
     
     public var tid: UInt8!

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneRegisterGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneRegisterGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct SceneRegisterGet: AcknowledgedGenericMessage {
+public struct SceneRegisterGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8244
-    public static let responseType: StaticMeshMessage.Type = SceneRegisterStatus.self
+    public static let responseType: StaticMeshResponse.Type = SceneRegisterStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneRegisterStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneRegisterStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SceneRegisterStatus: GenericMessage, SceneStatusMessage {
+public struct SceneRegisterStatus: StaticMeshResponse, SceneStatusMessage {
     public static let opCode: UInt32 = 0x8245
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SceneStatus: GenericMessage, SceneStatusMessage, TransitionStatusMessage {
+public struct SceneStatus: StaticMeshResponse, SceneStatusMessage, TransitionStatusMessage {
     public static let opCode: UInt32 = 0x5E
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneStore.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneStore.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct SceneStore: AcknowledgedGenericMessage {
+public struct SceneStore: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8246
-    public static let responseType: StaticMeshMessage.Type = SceneRegisterStatus.self
+    public static let responseType: StaticMeshResponse.Type = SceneRegisterStatus.self
     
     public var parameters: Data? {
         return Data() + scene

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneStoreUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SceneStoreUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SceneStoreUnacknowledged: GenericMessage {
+public struct SceneStoreUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8247
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SchedulerActionGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SchedulerActionGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct SchedulerActionGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8248
-    public static let responseType: StaticMeshMessage.Type = SchedulerActionStatus.self
+    public static let responseType: StaticMeshResponse.Type = SchedulerActionStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SchedulerActionSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SchedulerActionSet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct SchedulerActionSet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x60
-    public static let responseType: StaticMeshMessage.Type = SchedulerActionStatus.self
+    public static let responseType: StaticMeshResponse.Type = SchedulerActionStatus.self
     
     public var parameters: Data? {
         return SchedulerRegistryEntry.marshal(index: index, entry: entry)

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SchedulerActionSetUnacknowledged.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SchedulerActionSetUnacknowledged.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SchedulerActionSetUnacknowledged: StaticMeshMessage {
+public struct SchedulerActionSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x60
 
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SchedulerActionStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SchedulerActionStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SchedulerActionStatus: GenericMessage {
+public struct SchedulerActionStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x5F
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SchedulerGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SchedulerGet.swift
@@ -32,7 +32,7 @@ import Foundation
 
 public struct SchedulerGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8249
-    public static let responseType: StaticMeshMessage.Type = SchedulerStatus.self
+    public static let responseType: StaticMeshResponse.Type = SchedulerStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/SchedulerStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/SchedulerStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct SchedulerStatus: GenericMessage {
+public struct SchedulerStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x824A
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/TimeGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/TimeGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct TimeGet: AcknowledgedGenericMessage {
+public struct TimeGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8237
-    public static let responseType: StaticMeshMessage.Type = TimeStatus.self
+    public static let responseType: StaticMeshResponse.Type = TimeStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/TimeSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/TimeSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct TimeSet: TimeMessage {
+public struct TimeSet: StaticAcknowledgedMeshMessage, TimeMessage {
     public static let opCode: UInt32 = 0x5C
-    public static let responseType: StaticMeshMessage.Type = TimeStatus.self
+    public static let responseType: StaticMeshResponse.Type = TimeStatus.self
     
     public var parameters: Data? {
         return TaiTime.marshal(time)

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/TimeStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/TimeStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct TimeStatus: GenericMessage {
+public struct TimeStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x5D
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/TimeZoneGet.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/TimeZoneGet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct TimeZoneGet: AcknowledgedGenericMessage {
+public struct TimeZoneGet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x823B
-    public static let responseType: StaticMeshMessage.Type = TimeZoneStatus.self
+    public static let responseType: StaticMeshResponse.Type = TimeZoneStatus.self
     
     public var parameters: Data? {
         return nil

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/TimeZoneSet.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/TimeZoneSet.swift
@@ -30,9 +30,9 @@
 
 import Foundation
 
-public struct TimeZoneSet: AcknowledgedGenericMessage {
+public struct TimeZoneSet: StaticAcknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x823C
-    public static let responseType: StaticMeshMessage.Type = TimeZoneStatus.self
+    public static let responseType: StaticMeshResponse.Type = TimeZoneStatus.self
     
     public var parameters: Data? {
         var data = Data(count: 6)

--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/TimeZoneStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/TimeZoneStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-public struct TimeZoneStatus: GenericMessage {
+public struct TimeZoneStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x823D
     
     public var parameters: Data? {

--- a/nRFMeshProvision/Mesh Messages/TimeMessage.swift
+++ b/nRFMeshProvision/Mesh Messages/TimeMessage.swift
@@ -31,7 +31,8 @@
 import Foundation
 
 /// A base protocol for time messages.
-public protocol TimeMessage: StaticMeshMessage {
+public protocol TimeMessage: MeshMessage {
+    /// The time in TAI format.
     var time: TaiTime { get }
 }
 

--- a/nRFMeshProvision/Mesh Messages/VendorMessage.swift
+++ b/nRFMeshProvision/Mesh Messages/VendorMessage.swift
@@ -40,6 +40,16 @@ public protocol VendorMessage: MeshMessage {
     // No additional fields.
 }
 
+/// A base protocol for unacknowledged vendor message.
+public protocol UnacknowledgedVendorMessage: VendorMessage, UnacknowledgedMeshMessage {
+    // No additional fields.
+}
+
+/// The base class for vendor response messages.
+public protocol VendorResponse: MeshResponse, UnacknowledgedVendorMessage {
+    // No additional fields.
+}
+
 /// A base protocol for acknowledged vendor message.
 public protocol AcknowledgedVendorMessage: VendorMessage, AcknowledgedMeshMessage {
     // No additional fields.
@@ -50,13 +60,23 @@ public protocol StaticVendorMessage: VendorMessage, StaticMeshMessage {
     // No additional fields.
 }
 
+/// A base protocol for static unacknowledged vendor message.
+public protocol UnacknowledgedStaticVendorMessage: StaticVendorMessage, UnacknowledgedMeshMessage {
+    // No additional fields.
+}
+
+/// The base class for vendor response messages.
+public protocol StaticVendorResponse: StaticMeshResponse, UnacknowledgedStaticVendorMessage {
+    // No additional fields.
+}
+
 /// A base protocol for static acknowledged vendor message.
 public protocol AcknowledgedStaticVendorMessage: StaticVendorMessage, StaticAcknowledgedMeshMessage {
     // No additional fields.
 }
 
 /// A base protocol for vendor status message.
-public protocol VendorStatusMessage: StatusMessage {
+public protocol VendorStatusMessage: UnacknowledgedVendorMessage, StatusMessage {
     // No additional fields.
 }
 

--- a/nRFMeshProvision/MeshNetworkManager.swift
+++ b/nRFMeshProvision/MeshNetworkManager.swift
@@ -613,7 +613,8 @@ public extension MeshNetworkManager {
     func send(_ message: AcknowledgedConfigMessage, to destination: Address,
               withTtl initialTtl: UInt8? = nil,
               completion: ((Result<ConfigResponse, Error>) -> ())? = nil) throws -> MessageHandle {
-        guard let networkManager = networkManager, let meshNetwork = meshNetwork else {
+        guard let networkManager = networkManager,
+              let meshNetwork = meshNetwork else {
             print("Error: Mesh Network not created")
             throw MeshNetworkError.noNetwork
         }

--- a/nRFMeshProvision/MeshNetworkManager.swift
+++ b/nRFMeshProvision/MeshNetworkManager.swift
@@ -769,24 +769,30 @@ extension MeshNetworkManager: NetworkManagerDelegate {
     func networkManager(_ manager: NetworkManager,
                         didReceiveMessage message: MeshMessage,
                         sentFrom source: Address, to destination: Address) {
-        delegate?.meshNetworkManager(self, didReceiveMessage: message,
-                                     sentFrom: source, to: destination)
+        delegateQueue.async {
+            self.delegate?.meshNetworkManager(self, didReceiveMessage: message,
+                                              sentFrom: source, to: destination)
+        }
     }
     
     func networkManager(_ manager: NetworkManager,
                         didSendMessage message: MeshMessage,
                         from localElement: Element, to destination: Address) {
-        delegate?.meshNetworkManager(self, didSendMessage: message,
-                                     from: localElement, to: destination)
+        delegateQueue.async {
+            self.delegate?.meshNetworkManager(self, didSendMessage: message,
+                                              from: localElement, to: destination)
+        }
     }
     
     func networkManager(_ manager: NetworkManager,
                         failedToSendMessage message: MeshMessage,
                         from localElement: Element, to destination: Address,
                         error: Error) {
-        delegate?.meshNetworkManager(self, failedToSendMessage: message,
-                                     from: localElement, to: destination,
-                                     error: error)
+        delegateQueue.async {
+            self.delegate?.meshNetworkManager(self, failedToSendMessage: message,
+                                              from: localElement, to: destination,
+                                              error: error)
+        }
     }
     
     func networkDidChange() {

--- a/nRFMeshProvision/MeshNetworkManager.swift
+++ b/nRFMeshProvision/MeshNetworkManager.swift
@@ -620,7 +620,7 @@ public extension MeshNetworkManager {
             throw MeshNetworkError.noNetwork
         }
         guard let localProvisioner = meshNetwork.localProvisioner,
-              let source = localProvisioner.primaryUnicastAddress else {
+              let element = localProvisioner.node?.primaryElement else {
             print("Error: Local Provisioner has no Unicast Address assigned")
             throw AccessError.invalidSource
         }
@@ -651,10 +651,10 @@ public extension MeshNetworkManager {
             throw AccessError.invalidTtl
         }
         queue.async {
-            networkManager.send(message, to: destination,
+            networkManager.send(message, from: element, to: destination,
                                 withTtl: initialTtl, completion: completion)
         }
-        return MessageHandle(for: message, sentFrom: source,
+        return MessageHandle(for: message, sentFrom: element.unicastAddress,
                              to: destination, using: networkManager)
     }
     

--- a/nRFMeshProvision/MeshNetworkManager.swift
+++ b/nRFMeshProvision/MeshNetworkManager.swift
@@ -282,7 +282,7 @@ public extension MeshNetworkManager {
     }
     
     /// This method tries to publish the given message using the
-    /// publication information set in the Model.
+    /// publication information set in the ``Model``.
     ///
     /// If the retransmission is set to a value greater than 0, and the message
     /// is unacknowledged, this method will retransmit it number of times
@@ -291,9 +291,17 @@ public extension MeshNetworkManager {
     /// If the publication is not configured for the given Model, this method
     /// does nothing.
     ///
+    /// - note: This method does not check whether the given Model does support
+    ///         the given message. It will publish whatever message is given using
+    ///         the publication configuration of the given Model.
+    ///
+    /// An appropriate callback of the ``MeshNetworkDelegate`` will be called when
+    /// the message has been sent successfully or a problem occured.
+    ///
     /// - parameters:
     ///   - message: The message to be sent.
     ///   - model:   The model from which to send the message.
+    /// - returns: Message handle that can be used to cancel sending.
     @discardableResult
     func publish(_ message: MeshMessage, from model: Model) -> MessageHandle? {
         guard let networkManager = networkManager,
@@ -309,14 +317,8 @@ public extension MeshNetworkManager {
                              to: publish.publicationAddress.address, using: networkManager)
     }
     
-    /// Encrypts the message with the Application Key and a Network Key
+    /// Encrypts the message with the Application Key and the Network Key
     /// bound to it, and sends to the given destination address.
-    ///
-    /// This method does not send nor return PDUs to be sent. Instead,
-    /// for each created segment it calls transmitter's ``Transmitter/send(_:ofType:)``
-    /// method, which should send the PDU over the air. This is in order to support
-    /// retransmitting in case a packet was lost and needs to be sent again
-    /// after block acknowledgment was received.
     ///
     /// An appropriate callback of the ``MeshNetworkDelegate`` will be called when
     /// the message has been sent successfully or a problem occured.
@@ -371,7 +373,7 @@ public extension MeshNetworkManager {
     }
     
     /// Encrypts the message with the Application Key and a Network Key
-    /// bound to it, and sends to the given Group.
+    /// bound to it, and sends to the given ``Group``.
     ///
     /// An appropriate callback of the ``MeshNetworkDelegate`` will be called when
     /// the message has been sent successfully or a problem occured.
@@ -404,7 +406,7 @@ public extension MeshNetworkManager {
     }
     
     /// Encrypts the message with the first Application Key bound to the given
-    /// Model and a Network Key bound to it, and sends it to the Node
+    /// ``Model`` and the Network Key bound to it, and sends it to the Node
     /// to which the Model belongs to.
     ///
     /// An appropriate callback of the ``MeshNetworkDelegate`` will be called when
@@ -418,7 +420,6 @@ public extension MeshNetworkManager {
     ///   - model:          The destination Model.
     ///   - initialTtl:     The initial TTL (Time To Live) value of the message.
     ///                     If `nil`, the default Node TTL will be used.
-    ///   - applicationKey: The Application Key to sign the message.
     ///   - completion:     The completion handler called when the message
     ///                     has been sent.
     /// - throws: This method throws when the mesh network has not been created,
@@ -448,7 +449,7 @@ public extension MeshNetworkManager {
     }
     
     /// Encrypts the message with the common Application Key bound to both given
-    /// Models and a Network Key bound to it, and sends it to the Node
+    /// ``Model``s and the Network Key bound to it, and sends it to the Node
     /// to which the target Model belongs to.
     ///
     /// An appropriate callback of the ``MeshNetworkDelegate`` will be called when
@@ -590,7 +591,7 @@ public extension MeshNetworkManager {
     /// Sends Configuration Message to the Node with given destination Address.
     ///
     /// The `destination` must be a Unicast Address, otherwise the method
-    /// throws an error.
+    /// throws an ``AccessError/invalidDestination`` error.
     ///
     /// An appropriate callback of the ``MeshNetworkDelegate`` will be called when
     /// the message has been sent successfully or a problem occured.
@@ -657,7 +658,7 @@ public extension MeshNetworkManager {
                              to: destination, using: networkManager)
     }
     
-    /// Sends Configuration Message to the given Node.
+    /// Sends a Configuration Message to the primary Element on the given ``Node``.
     ///
     /// An appropriate callback of the ``MeshNetworkDelegate`` will be called when
     /// the message has been sent successfully or a problem occured.
@@ -684,20 +685,15 @@ public extension MeshNetworkManager {
                         withTtl: initialTtl, completion: completion)
     }
     
-    /// Sends Configuration Message to the local Node.
+    /// Sends the Configuration Message to the primary Element of the local Node.
     ///
     /// An appropriate callback of the ``MeshNetworkDelegate`` will be called when
     /// the message has been sent successfully or a problem occured.
     ///
-    /// - parameters:
-    ///   - message: The message to be sent.
-    ///   - node:    The destination Node.
-    ///   - initialTtl: The initial TTL (Time To Live) value of the message.
-    ///                 If `nil`, the default Node TTL will be used.
+    /// - parameter message: The acknowledged configuration message to be sent.
     /// - throws: This method throws when the mesh network has not been created,
-    ///           the local Node does not have configuration capabilities
-    ///           (no Unicast Address assigned), or the destination address
-    ///           is not a Unicast Address or it belongs to an unknown Node.
+    ///           or the local Node does not have configuration capabilities
+    ///           (no Unicast Address assigned).
     ///           Error ``AccessError/cannotDelete`` is sent when trying to
     ///           delete the last Network Key on the device.
     /// - returns: Message handle that can be used to cancel sending.
@@ -737,9 +733,9 @@ public extension MeshNetworkManager {
         }
     }
     
-    /// Cancels sending the message with the given identifier.
+    /// Cancels sending the message with the given handle.
     ///
-    /// - parameter messageId: The message identifier.
+    /// - parameter messageId: The message handle.
     func cancel(_ messageId: MessageHandle) throws {
         guard let networkManager = networkManager else {
             print("Error: Mesh Network not created")

--- a/nRFMeshProvision/ModelDelegate.swift
+++ b/nRFMeshProvision/ModelDelegate.swift
@@ -95,7 +95,7 @@ public protocol ModelDelegate: AnyObject {
     ///           if the receive message is invalid and no response
     ///           should be replied.
     func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) throws -> MeshMessage
+               from source: Address, sentTo destination: MeshAddress) throws -> MeshResponse
     
     /// This method should handle the received Unacknowledged Message.
     ///
@@ -104,7 +104,7 @@ public protocol ModelDelegate: AnyObject {
     ///   - message: The Unacknowledged Message received.
     ///   - source: The source Unicast Address.
     ///   - destination: The destination address of the request.
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: MeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress)
     
     /// This method should handle the received response to the
@@ -116,7 +116,7 @@ public protocol ModelDelegate: AnyObject {
     ///   - request: The Acknowledged Message sent.
     ///   - source: The Unicast Address of the Element that sent the
     ///             response.
-    func model(_ model: Model, didReceiveResponse response: MeshMessage,
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
                toAcknowledgedMessage request: AcknowledgedMeshMessage,
                from source: Address)
     


### PR DESCRIPTION
This PR adds a long expected feature of callbacks for each sent message, instead of the current single global delegate for all received, sent and failed messages.
The current `MeshNetworkDelegate` will continue to work as before, but each `send(...)` method in `MeshNetworkManager` has now `completion` callback. There are 3 types of those:
1. Unacknowledged messages sent to any address or Acknowledge Messages sent to a group or any address have a callback of type 
```swift
completion: ((Result<Void, Error>) -> ())? = nil
```
called when the message was sent of failed to be sent.
2. Acknowledged messages sent to a `Model` (that is to a Unicast Address) have a callback of type:
```swift
completion: ((Result<MeshResponse, Error>) -> ())? = nil
```
3. Acknowledged config messages sent to any Unicast Address have a callback of type:
```swift
completion: ((Result<ConfigResponse, Error>) -> ())? = nil
```

For that to work, ALL messages have now slightly changed types.
The `GenericMessage`, `AcknowledgedGenericMessage` and other similar types were removed.
Messages that used to extend them now extend their base types.

All unacknowledged messages have gotten a new base type: `UnacknowledgedMeshMessage`. Before all the acknowledged messages were extending `AcknowledgedMeshMessage` but there was not type to unacked messages.
A message MUST be of any of those two types.

All responses got new types: `MeshResponse`, which derives from `UnacknowledgedMeshMessage` and `ConfigResponse` which derives from `UnacknowledgedConfigMessage`.

### Breaking changes

The PR may cause breaking changes due to that. If you're using Vendor Messages, make sure your responses extend `StaticVendorResponse`, your unacked messages extend `UnacknowledgedVendorMessage` etc.