### PR TITLE
Breaking: Asynchronous message sending with `async`(iOS 13 required)

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,6 +1,6 @@
 use_frameworks!
 
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 target 'nRF Mesh' do
   pod 'nRFMeshProvision', :path => '../'

--- a/Example/Pods/Local Podspecs/nRFMeshProvision.podspec.json
+++ b/Example/Pods/Local Podspecs/nRFMeshProvision.podspec.json
@@ -17,20 +17,15 @@
   },
   "social_media_url": "https://twitter.com/nordictweets",
   "platforms": {
-    "ios": "12.0",
+    "ios": "13.0",
     "osx": "10.15"
   },
   "static_framework": true,
   "swift_versions": [
-    "4.2",
-    "5.0",
-    "5.1",
-    "5.2",
-    "5.3",
-    "5.4",
     "5.5",
     "5.6",
-    "5.7"
+    "5.7",
+    "5.8"
   ],
   "source_files": "nRFMeshProvision/**/*",
   "dependencies": {
@@ -39,5 +34,5 @@
     ]
   },
   "frameworks": "CoreBluetooth",
-  "swift_version": "5.7"
+  "swift_version": "5.8"
 }

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -2826,7 +2826,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/nRFMeshProvision/nRFMeshProvision-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/nRFMeshProvision/nRFMeshProvision-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2903,7 +2903,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -2930,7 +2930,7 @@
 				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = "Target Support Files/Pods-nRF Mesh Tests/Pods-nRF Mesh Tests-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3041,7 +3041,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3067,7 +3067,7 @@
 				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = "Target Support Files/Pods-nRF Mesh/Pods-nRF Mesh-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3105,7 +3105,7 @@
 				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = "Target Support Files/Pods-nRF Mesh Tests/Pods-nRF Mesh Tests-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3143,7 +3143,7 @@
 				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = "Target Support Files/Pods-nRF Mesh/Pods-nRF Mesh-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3219,7 +3219,7 @@
 				GCC_PREFIX_HEADER = "Target Support Files/nRFMeshProvision/nRFMeshProvision-prefix.pch";
 				INFOPLIST_FILE = "Target Support Files/nRFMeshProvision/nRFMeshProvision-Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		52069D025C55D850DC8CC61CB9AD0FA9 /* GenericPowerLevelStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46E865BA7B2152536B88F28180E79235 /* GenericPowerLevelStatus.swift */; };
 		5208862D2A330B9A00C9CE95 /* NetworkParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5208862C2A330B9A00C9CE95 /* NetworkParameters.swift */; };
 		5208862F2A331BDB00C9CE95 /* NetworkManagerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5208862E2A331BDB00C9CE95 /* NetworkManagerDelegate.swift */; };
+		5223F7AD2A4340D00083257A /* MeshNetworkManager+Callbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5223F7AC2A4340D00083257A /* MeshNetworkManager+Callbacks.swift */; };
 		526F24F05DAEE7F5230D97CA1C11C259 /* MeshNetwork+Scenes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE9EBCC249319B11F4761DF3113408D /* MeshNetwork+Scenes.swift */; };
 		529EC8DC2A30B1AA0056BB48 /* Node+Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 529EC8DB2A30B1AA0056BB48 /* Node+Models.swift */; };
 		52E7064F091D1CB785E5377B2234B59F /* BlockCipher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A57B68075D5163750469D071E976128 /* BlockCipher.swift */; };
@@ -736,6 +737,7 @@
 		51A5495D2067D83F1B7534B3B79861F3 /* LowerTransportLayer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LowerTransportLayer.swift; sourceTree = "<group>"; };
 		5208862C2A330B9A00C9CE95 /* NetworkParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkParameters.swift; sourceTree = "<group>"; };
 		5208862E2A331BDB00C9CE95 /* NetworkManagerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManagerDelegate.swift; sourceTree = "<group>"; };
+		5223F7AC2A4340D00083257A /* MeshNetworkManager+Callbacks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "MeshNetworkManager+Callbacks.swift"; path = "nRFMeshProvision/MeshNetworkManager+Callbacks.swift"; sourceTree = "<group>"; };
 		529EC8DB2A30B1AA0056BB48 /* Node+Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Node+Models.swift"; sourceTree = "<group>"; };
 		52F30C30F9FB2AF2D589FBCDA08C46A7 /* NetworkBeaconPdu.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkBeaconPdu.swift; sourceTree = "<group>"; };
 		532748DBB74703B56C6DCEECB478DB9A /* GenericPowerLastStatus.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GenericPowerLastStatus.swift; sourceTree = "<group>"; };
@@ -1293,6 +1295,7 @@
 				8DF9B81EB31DA88D8A9EB79C842414D4 /* MeshNetworkDelegate.swift */,
 				DF728171A88629019323A225E5C03F10 /* MeshNetworkError.swift */,
 				F45322F2584F05712E312F160132BECF /* MeshNetworkManager.swift */,
+				5223F7AC2A4340D00083257A /* MeshNetworkManager+Callbacks.swift */,
 				6DEDCB8F414F54D97F66C289ACA0F9D5 /* ModelDelegate.swift */,
 				E179EB743975E3C9A1B19BB154E8A3DF /* ProxyFilter.swift */,
 				78D918F5DFDAFC07F963DD2141E182AA /* Storage.swift */,
@@ -2520,6 +2523,7 @@
 				59A2D39FBB385F369A2BEE4DB8A0672D /* Node+Elements.swift in Sources */,
 				75A9DF8113B79021B6946FEE36C8524D /* Node+Keys.swift in Sources */,
 				CF94312DE189704A2C9855E83C00D54F /* Node+Provisioner.swift in Sources */,
+				5223F7AD2A4340D00083257A /* MeshNetworkManager+Callbacks.swift in Sources */,
 				826DFE1BDE188AAC3E97DA4F98F37F74 /* Node+Scenes.swift in Sources */,
 				D135D36D533C09BF22367D488114D096 /* NodeFeatures.swift in Sources */,
 				67BBD341F037CE3662F9004226267132 /* NodeIdentity.swift in Sources */,

--- a/Example/Source/Utils/UIViewController+Alert.swift
+++ b/Example/Source/Utils/UIViewController+Alert.swift
@@ -59,8 +59,9 @@ extension UIViewController {
     /// - parameters:
     ///   - title:   The alert title.
     ///   - message: The message below the title.
+    ///   - onCancel:The Cancel button handler.   
     ///   - handler: The Confirm button handler.
-    func confirm(title: String?, message: String?, handler: ((UIAlertAction) -> Void)? = nil) {
+    func confirm(title: String?, message: String?, onCancel: ((UIAlertAction) -> Void)? = nil, handler: ((UIAlertAction) -> Void)? = nil) {
         // TODO: Should only iPad be handled differently? How about carPlay or Apple TV?
         let ipad = UIDevice.current.userInterfaceIdiom == .pad
         let style: UIAlertController.Style = ipad ? .alert : .actionSheet
@@ -68,7 +69,7 @@ extension UIViewController {
             guard let self = self else { return }
             let alert = UIAlertController(title: title, message: message, preferredStyle: style)
             alert.addAction(UIAlertAction(title: "Confirm", style: .destructive, handler: handler))
-            alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+            alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: onCancel))
             self.present(alert, animated: true)
         }
     }

--- a/Example/Source/View Controllers/Groups/GroupsViewController.swift
+++ b/Example/Source/View Controllers/Groups/GroupsViewController.swift
@@ -103,10 +103,14 @@ class GroupsViewController: UITableViewController, Editable, UISearchBarDelegate
         return group.isUsed ? .none : .delete
     }
     
-    override func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let group = filteredGroups[indexPath.row]
         if group.isUsed {
-            return [UITableViewRowAction(style: .normal, title: "In Use", handler: { _,_ in })]
+            return UISwipeActionsConfiguration(actions: [
+                UIContextualAction(style: .normal, title: "In Use", handler: { _, _, completionHandler in
+                    completionHandler(false)
+                })
+            ])
         }
         return nil
     }

--- a/Example/Source/View Controllers/Network/Configuration/ModelViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/ModelViewController.swift
@@ -510,63 +510,62 @@ class ModelViewController: ProgressViewController {
         let section = sections[indexPath.section]
         switch section {
         case .appKeyBinding:
-            return UISwipeActionsConfiguration(actions: [
-                UIContextualAction(style: .destructive, title: "Unbind") { action, view, completionHandler in
-                    guard indexPath.row < self.model.boundApplicationKeys.count else {
-                        completionHandler(false)
-                        return
-                    }
-                    let applicationKey = self.model.boundApplicationKeys[indexPath.row]
-                    
-                    // Let's check if the key that's being unbound is set for publication.
-                    let boundKeyUsedInPublication = self.model.publish?.index == applicationKey.index
-                    // Check also, if any other Node is set to publish to this Model
-                    // (using parent Element's Unicast Address) using this key.
-                    let network = MeshNetworkManager.instance.meshNetwork!
-                    let thisElement = self.model.parentElement!
-                    let thisNode = thisElement.parentNode!
-                    let otherNodes = network.nodes.filter { $0 != thisNode }
-                    let elementsWithCompatibleModels = otherNodes.flatMap {
-                        $0.elements.filter({ $0.contains(modelBoundTo: applicationKey)})
-                    }
-                    let compatibleModels = elementsWithCompatibleModels.flatMap {
-                        $0.models.filter({ $0.isBoundTo(applicationKey) })
-                    }
-                    let boundKeyUsedByOtherNodes = compatibleModels.contains {
-                        $0.publish?.publicationAddress.address == thisElement.unicastAddress &&
-                        $0.publish?.index == applicationKey.index
-                    }
-                    
-                    if boundKeyUsedInPublication || boundKeyUsedByOtherNodes {
-                        var message = "The key you want to unbind is set"
-                        if boundKeyUsedInPublication {
-                            message += " in the publication settings in this model"
-                            if boundKeyUsedByOtherNodes {
-                                message += " and"
-                            }
-                        }
+            let action = UIContextualAction(style: .destructive, title: "Unbind") { _, _, completionHandler in
+                guard indexPath.row < self.model.boundApplicationKeys.count else {
+                    completionHandler(false)
+                    return
+                }
+                let applicationKey = self.model.boundApplicationKeys[indexPath.row]
+                
+                // Let's check if the key that's being unbound is set for publication.
+                let boundKeyUsedInPublication = self.model.publish?.index == applicationKey.index
+                // Check also, if any other Node is set to publish to this Model
+                // (using parent Element's Unicast Address) using this key.
+                let network = MeshNetworkManager.instance.meshNetwork!
+                let thisElement = self.model.parentElement!
+                let thisNode = thisElement.parentNode!
+                let otherNodes = network.nodes.filter { $0 != thisNode }
+                let elementsWithCompatibleModels = otherNodes.flatMap {
+                    $0.elements.filter({ $0.contains(modelBoundTo: applicationKey)})
+                }
+                let compatibleModels = elementsWithCompatibleModels.flatMap {
+                    $0.models.filter({ $0.isBoundTo(applicationKey) })
+                }
+                let boundKeyUsedByOtherNodes = compatibleModels.contains {
+                    $0.publish?.publicationAddress.address == thisElement.unicastAddress &&
+                    $0.publish?.index == applicationKey.index
+                }
+                
+                if boundKeyUsedInPublication || boundKeyUsedByOtherNodes {
+                    var message = "The key you want to unbind is set"
+                    if boundKeyUsedInPublication {
+                        message += " in the publication settings in this model"
                         if boundKeyUsedByOtherNodes {
-                            message += " in at least one model on another node that publish directly to this element."
+                            message += " and"
                         }
-                        if boundKeyUsedInPublication {
-                            if boundKeyUsedByOtherNodes {
-                                message += " The local publication will be cancelled automatically, but other nodes will not be affected. This model will no longer be able to handle those publications."
-                            } else {
-                                message += "\nThe publication will be cancelled automatically."
-                            }
+                    }
+                    if boundKeyUsedByOtherNodes {
+                        message += " in at least one model on another node that publish directly to this element."
+                    }
+                    if boundKeyUsedInPublication {
+                        if boundKeyUsedByOtherNodes {
+                            message += " The local publication will be cancelled automatically, but other nodes will not be affected. This model will no longer be able to handle those publications."
+                        } else {
+                            message += "\nThe publication will be cancelled automatically."
                         }
-                        self.confirm(title: "Key in use", message: message) { _ in
-                            completionHandler(false)
-                        } handler:  { _ in
-                            self.unbindApplicationKey(applicationKey)
-                            completionHandler(true)
-                        }
-                    } else {
+                    }
+                    self.confirm(title: "Key in use", message: message) { _ in
+                        completionHandler(false)
+                    } handler: { _ in
                         self.unbindApplicationKey(applicationKey)
                         completionHandler(true)
                     }
+                } else {
+                    self.unbindApplicationKey(applicationKey)
+                    completionHandler(true)
                 }
-              ])
+            }
+            return UISwipeActionsConfiguration(actions: [action])
         default:
             return nil
         }

--- a/Example/Source/View Controllers/Network/Configuration/NodeAppKeysViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeAppKeysViewController.swift
@@ -121,12 +121,6 @@ class NodeAppKeysViewController: ProgressViewController, Editable {
     }
     
     override func tableView(_ tableView: UITableView,
-                            editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
-        // This is required to allow swipe to delete action.
-        return nil
-    }
-    
-    override func tableView(_ tableView: UITableView,
                             commit editingStyle: UITableViewCell.EditingStyle,
                             forRowAt indexPath: IndexPath) {
         let applicationKey = node.applicationKeys[indexPath.row]
@@ -134,9 +128,9 @@ class NodeAppKeysViewController: ProgressViewController, Editable {
         if node.contains(modelBoundToApplicationKey: applicationKey) {
             confirm(title: "Remove Key", message: "The selected key is bound to one or more " +
                 "models in the Node. When removed, it will be unbound automatically, and the " +
-                "models may stop working.") { _ in
+                "models may stop working.", handler:  { _ in
                 self.delete(applicationKey: applicationKey)
-            }
+            })
         } else {
             // Otherwise, just try removing it.
             delete(applicationKey: applicationKey)

--- a/Example/Source/View Controllers/Network/Configuration/NodeNetworkKeysViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeNetworkKeysViewController.swift
@@ -123,10 +123,13 @@ class NodeNetworkKeysViewController: ProgressViewController, Editable {
         return node.networkKeys.count == 1 ? .none : .delete
     }
     
-    override func tableView(_ tableView: UITableView,
-                            editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         if node.networkKeys.count == 1 {
-            return [UITableViewRowAction(style: .normal, title: "Last Key", handler: {_,_ in })]
+            return UISwipeActionsConfiguration(actions: [
+                UIContextualAction(style: .normal, title: "Last Key", handler: { _, _, completionHandler in
+                    completionHandler(false)
+                })
+            ])
         }
         return nil
     }
@@ -139,9 +142,9 @@ class NodeNetworkKeysViewController: ProgressViewController, Editable {
         if node.contains(applicationKeyBoundToNetworkKey: networkKey) {
             confirm(title: "Remove Key", message: "The selected key is bound to one or more " +
                 "Application Keys in the Node. When removed, those keys will also be removed " +
-                "and all models bound to them will be unbound, which may cause them to stop working.") { _ in
+                "and all models bound to them will be unbound, which may cause them to stop working.", handler: { _ in
                 self.deleteNetworkKey(networkKey)
-            }
+            })
         } else {
             // Otherwise, just try removing it.
             deleteNetworkKey(networkKey)

--- a/Example/Source/View Controllers/Network/Configuration/NodeScenesViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeScenesViewController.swift
@@ -149,13 +149,17 @@ class NodeScenesViewController: ProgressViewController, Editable {
         tableView.deselectRow(at: indexPath, animated: true)
     }
     
-    override func tableView(_ tableView: UITableView,
-                            editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         if !isSceneClientReadyToSetup {
-            return [UITableViewRowAction(style: .normal, title: "Client not ready", handler: {
-                [unowned self] _,_ in
-                _ = self.ensureClientReadyToDelete()
-            })]
+            return UISwipeActionsConfiguration(actions: [
+                UIContextualAction(style: .normal, title: "Client not ready", handler: { [weak self] _, _, completionHandler  in
+                    guard let self = self else {
+                        completionHandler(false)
+                        return
+                    }
+                    completionHandler(self.ensureClientReadyToDelete())
+                })
+            ])
         }
         return nil
     }

--- a/Example/Source/View Controllers/Settings/AppKeysViewController.swift
+++ b/Example/Source/View Controllers/Settings/AppKeysViewController.swift
@@ -148,13 +148,17 @@ class AppKeysViewController: UITableViewController, Editable {
         return applicationKey.isUsed(in: network) ? .none : .delete
     }
     
-    override func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let network = MeshNetworkManager.instance.meshNetwork!
         let applicationKey = network.applicationKeys[indexPath.keyIndex]
         
         // It should not be possible to delete a key that is in use.
         if applicationKey.isUsed(in: network) {
-            return [UITableViewRowAction(style: .normal, title: "Key in use", handler: {_,_ in })]
+            return UISwipeActionsConfiguration(actions: [
+                UIContextualAction(style: .normal, title: "Key in use", handler: { _, _, completionHandler in
+                    completionHandler(false)
+                })
+            ])
         }
         return nil
     }

--- a/Example/Source/View Controllers/Settings/NetworkKeysViewController.swift
+++ b/Example/Source/View Controllers/Settings/NetworkKeysViewController.swift
@@ -118,14 +118,18 @@ class NetworkKeysViewController: UITableViewController, Editable {
         return networkKey.isPrimary || networkKey.isUsed(in: network) ? .none : .delete
     }
     
-    override func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let network = MeshNetworkManager.instance.meshNetwork!
         let networkKey = network.networkKeys[indexPath.keyIndex]
         
         // It should not be possible to delete a key that is in use.
         if networkKey.isPrimary || networkKey.isUsed(in: network) {
             let title = networkKey.isPrimary ? "Primary Key" : "Key in use"
-            return [UITableViewRowAction(style: .normal, title: title, handler: {_,_ in })]
+            return UISwipeActionsConfiguration(actions: [
+                UIContextualAction(style: .normal, title: title, handler: { _, _, completionHandler in
+                    completionHandler(false)
+                })
+            ])
         }
         return nil
     }

--- a/Example/Source/View Controllers/Settings/Provisioners/EditProvisionerViewController.swift
+++ b/Example/Source/View Controllers/Settings/Provisioners/EditProvisionerViewController.swift
@@ -233,7 +233,8 @@ private extension EditProvisionerViewController {
         let nodeAssigned = newAddress != nil || (node != nil && !disableConfigCapabilities)
         let action = !nodeAssigned ? nil : UIAlertAction(title: "Unassign", style: .destructive) { action in
             self.confirm(title: "Disable configuration capabilities",
-                         message: "A Provisioner without the unicast address assigned is not able to perform configuration operations.") { [weak self] _ in
+                         message: "A Provisioner without the unicast address assigned is not able to perform configuration operations.",
+                         handler: { [weak self] _ in
                             guard let self = self else { return }
                             self.disableConfigCapabilities = true
                             self.newAddress = nil
@@ -243,7 +244,7 @@ private extension EditProvisionerViewController {
                             self.newTtl = nil
                             self.deviceKeyCell.detailTextLabel?.text = "N/A"
                             self.deviceKeyCell.detailTextLabel?.font = .systemFont(ofSize: 17)
-            }
+            })
         }
         presentTextAlert(title: "Unicast address", message: "Hexadecimal value in range\n0001 - 7FFF.",
                          text: address, placeHolder: "Address", type: .unicastAddressRequired,

--- a/Example/Source/View Controllers/Settings/Provisioners/ProvisionersViewController.swift
+++ b/Example/Source/View Controllers/Settings/Provisioners/ProvisionersViewController.swift
@@ -126,16 +126,22 @@ class ProvisionersViewController: UITableViewController, Editable {
         return true
     }
     
-    override func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         // It is not possible to remove the last Provisioner. At least 1 is required.
         let count = MeshNetworkManager.instance.meshNetwork?.provisioners.count ?? 0
         guard count > 1 else {
-            return [UITableViewRowAction(style: .normal, title: "Last", handler: {_,_ in })]
+            return UISwipeActionsConfiguration(actions: [
+                UIContextualAction(style: .normal, title: "Last", handler: { _, _, completionHandler in
+                    completionHandler(false)
+                })
+            ])
         }
-        let removeRowAction = UITableViewRowAction(style: .destructive, title: "Delete", handler: { _, indexPath in
-            self.removeProvisioner(at: indexPath)
-        })
-        return [removeRowAction]
+        return UISwipeActionsConfiguration(actions: [
+            UIContextualAction(style: .destructive, title: "Delete", handler: { _, _, completionHandler in
+                self.removeProvisioner(at: indexPath)
+                completionHandler(true)
+            })
+        ])
     }
     
     override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {

--- a/Example/Source/View Controllers/Settings/ScenesViewController.swift
+++ b/Example/Source/View Controllers/Settings/ScenesViewController.swift
@@ -108,13 +108,17 @@ class ScenesViewController: UITableViewController, Editable {
         tableView.deselectRow(at: indexPath, animated: true)
     }
     
-    override func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let network = MeshNetworkManager.instance.meshNetwork!
         let scene = network.scenes[indexPath.sceneIndex]
         
         // It should not be possible to delete a scene that is in use.
         if scene.isUsed {
-            return [UITableViewRowAction(style: .normal, title: "Scene in use", handler: {_,_ in })]
+            return UISwipeActionsConfiguration(actions: [
+                UIContextualAction(style: .normal, title: "Scene in use", handler: { _, _, completionHandler in
+                    completionHandler(false)
+                })
+            ])
         }
         return nil
     }

--- a/Example/nRF Mesh.xcodeproj/project.pbxproj
+++ b/Example/nRF Mesh.xcodeproj/project.pbxproj
@@ -1462,7 +1462,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "";
@@ -1515,7 +1515,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				SDKROOT = iphoneos;
@@ -1537,7 +1537,7 @@
 				DEVELOPMENT_TEAM = P3R8YQEV4L;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Source/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1567,7 +1567,7 @@
 				DEVELOPMENT_TEAM = P3R8YQEV4L;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Source/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1601,6 +1601,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1629,6 +1630,7 @@
 					"$(SDKROOT)/System/Library/Frameworks",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.8
 //
 // The `swift-tools-version` declares the minimum version of Swift required to
 // build this package. Do not remove it.
@@ -9,7 +9,7 @@ let package = Package(
   name: "NordicMesh",
   platforms: [
     .macOS(.v10_15),
-    .iOS(.v10)
+    .iOS(.v13)
   ],
   products: [
     .library(name: "NordicMesh", targets: ["nRFMeshProvision"])

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ and [nRF Connect SDK](https://www.nordicsemi.com/Products/Development-software/n
 
 ## Requirements
 
-* Xcode 12 or newer.
-* An iOS 10.0 or newer device with BLE capabilities.
+* Xcode 13.3 or newer.
+* An iOS 13.0 or newer device with BLE capabilities.
 
 ### Optional
 

--- a/nRFMeshProvision.podspec
+++ b/nRFMeshProvision.podspec
@@ -19,10 +19,10 @@ Pod::Spec.new do |s|
   s.author           = { 'Aleksander Nowakowski' => 'aleksander.nowakowski@nordicsemi.no' }
   s.source           = { :git => 'https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/nordictweets'
-  s.ios.deployment_target  = '12.0'
+  s.ios.deployment_target  = '13.0'
   s.osx.deployment_target  = '10.15'  
   s.static_framework = true
-  s.swift_versions   = ['4.2', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7']
+  s.swift_versions   = ['5.5', '5.6', '5.7', '5.8']
   s.source_files = 'nRFMeshProvision/**/*'
   s.dependency 'CryptoSwift', '= 1.7.0'
   s.frameworks = 'CoreBluetooth'

--- a/nRFMeshProvision/Layers/NetworkManager.swift
+++ b/nRFMeshProvision/Layers/NetworkManager.swift
@@ -227,14 +227,15 @@ internal class NetworkManager {
               from element: Element, to destination: Address,
               withTtl initialTtl: UInt8?,
               using applicationKey: ApplicationKey) async throws -> MeshResponse {
-        try mutex.sync {
-            guard !outgoingMessages.contains(destination) else {
-                throw AccessError.busy
-            }
-            outgoingMessages.insert(destination)
-        }
         return try await withTaskCancellationHandler {
             return try await withCheckedThrowingContinuation { continuation in
+                mutex.sync {
+                    guard !outgoingMessages.contains(destination) else {
+                        continuation.resume(throwing: AccessError.busy)
+                        return
+                    }
+                    outgoingMessages.insert(destination)
+                }
                 setResponseCallback(for: message, from: destination) { result in
                     continuation.resume(with: result)
                 }
@@ -266,14 +267,15 @@ internal class NetworkManager {
     func send(_ configMessage: UnacknowledgedConfigMessage,
               from element: Element, to destination: Address,
               withTtl initialTtl: UInt8?) async throws {
-        try mutex.sync {
-            guard !outgoingMessages.contains(destination) else {
-                throw AccessError.busy
-            }
-            outgoingMessages.insert(destination)
-        }
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
+        return try await withTaskCancellationHandler {
+            return try await withCheckedThrowingContinuation { continuation in
+                mutex.sync {
+                    guard !outgoingMessages.contains(destination) else {
+                        continuation.resume(throwing: AccessError.busy)
+                        return
+                    }
+                    outgoingMessages.insert(destination)
+                }
                 setDeliveryCallback(for: destination) { result in
                     continuation.resume(with: result)
                 }
@@ -307,14 +309,15 @@ internal class NetworkManager {
     func send(_ configMessage: AcknowledgedConfigMessage,
               from element: Element, to destination: Address,
               withTtl initialTtl: UInt8?) async throws -> ConfigResponse {
-        try mutex.sync {
-            guard !outgoingMessages.contains(destination) else {
-                throw AccessError.busy
-            }
-            outgoingMessages.insert(destination)
-        }
         return try await withTaskCancellationHandler {
             return try await withCheckedThrowingContinuation { continuation in
+                mutex.sync {
+                    guard !outgoingMessages.contains(destination) else {
+                        continuation.resume(throwing: AccessError.busy)
+                        return
+                    }
+                    outgoingMessages.insert(destination)
+                }
                 setResponseCallback(for: configMessage, from: destination) { result in
                     continuation.resume(with: result)
                 }

--- a/nRFMeshProvision/Layers/NetworkManager.swift
+++ b/nRFMeshProvision/Layers/NetworkManager.swift
@@ -113,7 +113,7 @@ internal class NetworkManager {
     /// - parameters:
     ///   - pdu:  The data received.
     ///   - type: The PDU type.
-    func handle(incomingPdu pdu: Data, ofType type: PduType) async {
+    func handle(incomingPdu pdu: Data, ofType type: PduType) {
         networkLayer.handle(incomingPdu: pdu, ofType: type)
     }
     

--- a/nRFMeshProvision/Layers/NetworkManager.swift
+++ b/nRFMeshProvision/Layers/NetworkManager.swift
@@ -251,9 +251,6 @@ internal class NetworkManager {
     /// Encrypts the message with the Device Key and the first Network Key
     /// known to the target device, and sends to the given destination address.
     ///
-    /// The ``ConfigNetKeyDelete`` will be signed with a different Network Key
-    /// that is removing.
-    ///
     /// This method does not send nor return PDUs to be sent. Instead,
     /// for each created segment it calls transmitter's ``Transmitter/send(_:ofType:)``
     /// method, which should send the PDU over the air. This is in order to support
@@ -266,23 +263,27 @@ internal class NetworkManager {
     ///   - destination:   The destination address.
     ///   - initialTtl:    The initial TTL (Time To Live) value of the message.
     ///                    If `nil`, the default Node TTL will be used.
-    ///   - completion:     The completion handler called when the message was sent.                    
     func send(_ configMessage: UnacknowledgedConfigMessage,
               from element: Element, to destination: Address,
-              withTtl initialTtl: UInt8?,
-              completion: ((Result<Void, Error>) -> ())?) {
-         mutex.sync {
+              withTtl initialTtl: UInt8?) async throws {
+        try mutex.sync {
             guard !outgoingMessages.contains(destination) else {
-                completion?(.failure(AccessError.busy))
-                return
+                throw AccessError.busy
             }
             outgoingMessages.insert(destination)
-            if let completion = completion {
-                deliveryCallbacks[destination] = completion
-            }
         }
-        accessLayer.send(configMessage, from: element, to: destination,
-                         withTtl: initialTtl)
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                setDeliveryCallback(for: destination) { result in
+                    continuation.resume(with: result)
+                }
+                accessLayer.send(configMessage, from: element, to: destination,
+                                 withTtl: initialTtl)
+            }
+        } onCancel: {
+            cancel(MessageHandle(for: configMessage, sentFrom: element.unicastAddress,
+                                 to: destination, using: self))
+        }
     }
     
     /// Encrypts the message with the Device Key and the first Network Key

--- a/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
+++ b/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
@@ -1,0 +1,452 @@
+/*
+* Copyright (c) 2023, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+public extension MeshNetworkManager {
+    
+    /// Encrypts the message with the Application Key and the Network Key
+    /// bound to it, and sends to the given destination address.
+    ///
+    /// Apart from the `completion` callback, an appropriate callback of the
+    /// ``MeshNetworkDelegate`` will be called when the message has been sent
+    /// successfully or a problem occured.
+    ///
+    /// - parameters:
+    ///   - message:        The message to be sent.
+    ///   - localElement:   The source Element. If `nil`, the primary
+    ///                     Element will be used. The Element must belong
+    ///                     to the local Provisioner's Node.
+    ///   - destination:    The destination address.
+    ///   - initialTtl:     The initial TTL (Time To Live) value of the message.
+    ///                     If `nil`, the default Node TTL will be used.
+    ///   - applicationKey: The Application Key to sign the message.
+    ///   - completion:     The completion handler called when the message
+    ///                     has been sent.
+    /// - throws: This method throws when the mesh network has not been created,
+    ///           the local Node does not have configuration capabilities
+    ///           (no Unicast Address assigned), or the given local Element
+    ///           does not belong to the local Node.
+    /// - returns: Message handle that can be used to cancel sending.
+    @discardableResult
+    func send(_ message: MeshMessage,
+              from localElement: Element? = nil, to destination: MeshAddress,
+              withTtl initialTtl: UInt8? = nil,
+              using applicationKey: ApplicationKey,
+              completion: ((Result<Void, Error>) -> ())? = nil) throws -> MessageHandle {
+        guard let networkManager = networkManager,
+              let meshNetwork = meshNetwork else {
+            print("Error: Mesh Network not created")
+            throw MeshNetworkError.noNetwork
+        }
+        guard let localNode = meshNetwork.localProvisioner?.node,
+              let source = localElement ?? localNode.elements.first else {
+            print("Error: Local Provisioner has no Unicast Address assigned")
+            throw AccessError.invalidSource
+        }
+        guard source.parentNode == localNode else {
+            print("Error: The Element does not belong to the local Node")
+            throw AccessError.invalidElement
+        }
+        guard initialTtl == nil || initialTtl! <= 127 else {
+            print("Error: TTL value \(initialTtl!) is invalid")
+            throw AccessError.invalidTtl
+        }
+        Task {
+            do {
+                try await send(message, from: localElement, to: destination,
+                               withTtl: initialTtl, using: applicationKey)
+                completion?(.success(()))
+            } catch {
+                completion?(.failure(error))
+            }
+        }
+        return MessageHandle(for: message, sentFrom: source.unicastAddress,
+                             to: destination.address, using: networkManager)
+    }
+    
+    /// Encrypts the message with the Application Key and a Network Key
+    /// bound to it, and sends to the given ``Group``.
+    ///
+    /// Apart from the `completion` callback, an appropriate callback of the
+    /// ``MeshNetworkDelegate`` will be called when the message has been sent
+    /// successfully or a problem occured.
+    ///
+    /// - parameters:
+    ///   - message:        The message to be sent.
+    ///   - localElement:   The source Element. If `nil`, the primary
+    ///                     Element will be used. The Element must belong
+    ///                     to the local Provisioner's Node.
+    ///   - group:          The target Group.
+    ///   - initialTtl:     The initial TTL (Time To Live) value of the message.
+    ///                     If `nil`, the default Node TTL will be used.
+    ///   - applicationKey: The Application Key to sign the message.
+    ///   - completion:     The completion handler called when the message
+    ///                     has been sent.
+    /// - throws: This method throws when the mesh network has not been created,
+    ///           the local Node does not have configuration capabilities
+    ///           (no Unicast Address assigned), or the given local Element
+    ///           does not belong to the local Node.
+    /// - returns: Message handle that can be used to cancel sending.
+    @discardableResult
+    func send(_ message: MeshMessage,
+              from localElement: Element? = nil, to group: Group,
+              withTtl initialTtl: UInt8? = nil,
+              using applicationKey: ApplicationKey,
+              completion: ((Result<Void, Error>) -> ())? = nil) throws -> MessageHandle {
+        return try send(message, from: localElement, to: group.address,
+                        withTtl: initialTtl, using: applicationKey,
+                        completion: completion)
+    }
+    
+    /// Encrypts the message with the first Application Key bound to the given
+    /// ``Model`` and the Network Key bound to it, and sends it to the Node
+    /// to which the Model belongs to.
+    ///
+    /// Apart from the `completion` callback, an appropriate callback of the
+    /// ``MeshNetworkDelegate`` will be called when the message has been sent
+    /// successfully or a problem occured.
+    ///
+    /// - parameters:
+    ///   - message:        The message to be sent.
+    ///   - localElement:   The source Element. If `nil`, the primary
+    ///                     Element will be used. The Element must belong
+    ///                     to the local Provisioner's Node.
+    ///   - model:          The destination Model.
+    ///   - initialTtl:     The initial TTL (Time To Live) value of the message.
+    ///                     If `nil`, the default Node TTL will be used.
+    ///   - completion:     The completion handler called when the message
+    ///                     has been sent.
+    /// - throws: This method throws when the mesh network has not been created,
+    ///           the target Model does not belong to any Element, or has
+    ///           no Application Key bound to it, or when
+    ///           the local Node does not have configuration capabilities
+    ///           (no Unicast Address assigned), or the given local Element
+    ///           does not belong to the local Node.
+    /// - returns: Message handle that can be used to cancel sending.
+    @discardableResult
+    func send(_ message: UnacknowledgedMeshMessage,
+              from localElement: Element? = nil, to model: Model,
+              withTtl initialTtl: UInt8? = nil,
+              completion: ((Result<Void, Error>) -> ())? = nil) throws -> MessageHandle {
+        guard let element = model.parentElement else {
+            print("Error: Element does not belong to a Node")
+            throw AccessError.invalidDestination
+        }
+        guard let firstKeyIndex = model.bind.first,
+              let meshNetwork = meshNetwork,
+              let applicationKey = meshNetwork.applicationKeys[firstKeyIndex] else {
+            print("Error: Model is not bound to any Application Key")
+            throw AccessError.modelNotBoundToAppKey
+        }
+        return try send(message, from: localElement, to: MeshAddress(element.unicastAddress),
+                        withTtl: initialTtl, using: applicationKey,
+                        completion: completion)
+    }
+    
+    /// Encrypts the message with the common Application Key bound to both given
+    /// ``Model``s and the Network Key bound to it, and sends it to the Node
+    /// to which the target Model belongs to.
+    ///
+    /// Apart from the `completion` callback, an appropriate callback of the
+    /// ``MeshNetworkDelegate`` will be called when the message has been sent
+    /// successfully or a problem occured.
+    ///
+    /// - parameters:
+    ///   - message:      The message to be sent.
+    ///   - localElement: The source Element. If `nil`, the primary
+    ///                   Element will be used. The Element must belong
+    ///                   to the local Provisioner's Node.
+    ///   - model:        The destination Model.
+    ///   - initialTtl:   The initial TTL (Time To Live) value of the message.
+    ///                   If `nil`, the default Node TTL will be used.
+    ///   - completion:   The completion handler called when the message
+    ///                   has been sent.
+    /// - throws: This method throws when the mesh network has not been created,
+    ///           the local or target Model do not belong to any Element, or have
+    ///           no common Application Key bound to them, or when
+    ///           the local Node does not have configuration capabilities
+    ///           (no Unicast Address assigned), or the given local Element
+    ///           does not belong to the local Node.
+    /// - returns: Message handle that can be used to cancel sending.
+    @discardableResult
+    func send(_ message: UnacknowledgedMeshMessage,
+              from localModel: Model, to model: Model,
+              withTtl initialTtl: UInt8? = nil,
+              completion: ((Result<Void, Error>) -> ())? = nil) throws -> MessageHandle {
+        guard let localElement = localModel.parentElement else {
+            print("Error: Source Model does not belong to an Element")
+            throw AccessError.invalidSource
+        }
+        return try send(message, from: localElement, to: model,
+                        withTtl: initialTtl, completion: completion)
+    }
+    
+    /// Encrypts the message with the first Application Key bound to the given
+    /// Model and a Network Key bound to it, and sends it to the Node
+    /// to which the Model belongs to.
+    ///
+    /// Apart from the `completion` callback, an appropriate callback of the
+    /// ``MeshNetworkDelegate`` will be called when the message has been sent
+    /// successfully or a problem occured.
+    ///
+    /// - parameters:
+    ///   - message:        The message to be sent.
+    ///   - localElement:   The source Element. If `nil`, the primary
+    ///                     Element will be used. The Element must belong
+    ///                     to the local Provisioner's Node.
+    ///   - model:          The destination Model.
+    ///   - initialTtl:     The initial TTL (Time To Live) value of the message.
+    ///                     If `nil`, the default Node TTL will be used.
+    ///   - applicationKey: The Application Key to sign the message.
+    ///   - completion:     The completion handler called when the response
+    ///                     has been received.
+    /// - throws: This method throws when the mesh network has not been created,
+    ///           the target Model does not belong to any Element, or has
+    ///           no Application Key bound to it, or when
+    ///           the local Node does not have configuration capabilities
+    ///           (no Unicast Address assigned), or the given local Element
+    ///           does not belong to the local Node.
+    /// - returns: Message handle that can be used to cancel sending.
+    @discardableResult
+    func send(_ message: AcknowledgedMeshMessage,
+              from localElement: Element? = nil, to model: Model,
+              withTtl initialTtl: UInt8? = nil,
+              completion: ((Result<MeshResponse, Error>) -> ())? = nil) throws -> MessageHandle {
+        guard let networkManager = networkManager,
+              let meshNetwork = meshNetwork else {
+            print("Error: Mesh Network not created")
+            throw MeshNetworkError.noNetwork
+        }
+        guard let element = model.parentElement else {
+            print("Error: Element does not belong to a Node")
+            throw AccessError.invalidDestination
+        }
+        guard let firstKeyIndex = model.bind.first,
+              let _ = meshNetwork.applicationKeys[firstKeyIndex] else {
+            print("Error: Model is not bound to any Application Key")
+            throw AccessError.modelNotBoundToAppKey
+        }
+        guard let localNode = meshNetwork.localProvisioner?.node,
+              let source = localElement ?? localNode.elements.first else {
+            print("Error: Local Provisioner has no Unicast Address assigned")
+            throw AccessError.invalidSource
+        }
+        guard source.parentNode == localNode else {
+            print("Error: The Element does not belong to the local Node")
+            throw AccessError.invalidElement
+        }
+        guard initialTtl == nil || initialTtl! <= 127 else {
+            print("Error: TTL value \(initialTtl!) is invalid")
+            throw AccessError.invalidTtl
+        }
+        Task {
+            do {
+                let response = try await send(message, from: source, to: model,
+                               withTtl: initialTtl)
+                completion?(.success(response))
+            } catch {
+                completion?(.failure(error))
+            }
+        }
+        return MessageHandle(for: message, sentFrom: source.unicastAddress,
+                             to: element.unicastAddress, using: networkManager)
+    }
+    
+    /// Encrypts the message with the common Application Key bound to both given
+    /// Models and a Network Key bound to it, and sends it to the Node
+    /// to which the target Model belongs to.
+    ///
+    /// Apart from the `completion` callback, an appropriate callback of the
+    /// ``MeshNetworkDelegate`` will be called when the message has been sent
+    /// successfully or a problem occured.
+    ///
+    /// - parameters:
+    ///   - message:      The message to be sent.
+    ///   - localElement: The source Element. If `nil`, the primary
+    ///                   Element will be used. The Element must belong
+    ///                   to the local Provisioner's Node.
+    ///   - model:        The destination Model.
+    ///   - initialTtl:   The initial TTL (Time To Live) value of the message.
+    ///                   If `nil`, the default Node TTL will be used.
+    ///   - completion:   The completion handler which is called when the response
+    ///                   has been received.
+    /// - throws: This method throws when the mesh network has not been created,
+    ///           the local or target Model do not belong to any Element, or have
+    ///           no common Application Key bound to them, or when
+    ///           the local Node does not have configuration capabilities
+    ///           (no Unicast Address assigned), or the given local Element
+    ///           does not belong to the local Node.
+    /// - returns: Message handle that can be used to cancel sending.
+    @discardableResult
+    func send(_ message: AcknowledgedMeshMessage,
+              from localModel: Model, to model: Model,
+              withTtl initialTtl: UInt8? = nil,
+              completion: ((Result<MeshResponse, Error>) -> ())? = nil) throws -> MessageHandle {
+        guard let localElement = localModel.parentElement else {
+            print("Error: Source Model does not belong to an Element")
+            throw AccessError.invalidSource
+        }
+        return try send(message, from: localElement, to: model,
+                        withTtl: initialTtl)
+    }
+    
+    /// Sends Configuration Message to the Node with given destination Address.
+    ///
+    /// The `destination` must be a Unicast Address, otherwise the method
+    /// throws an ``AccessError/invalidDestination`` error.
+    ///
+    /// Apart from the `completion` callback, an appropriate callback of the
+    /// ``MeshNetworkDelegate`` will be called when the message has been sent
+    /// successfully or a problem occured.
+    ///
+    /// - parameters:
+    ///   - message:     The message to be sent.
+    ///   - destination: The destination Unicast Address.
+    ///   - initialTtl:  The initial TTL (Time To Live) value of the message.
+    ///                  If `nil`, the default Node TTL will be used.
+    ///   - completion:  The completion handler which is called when the response
+    ///                  has been received.
+    /// - throws: This method throws when the mesh network has not been created,
+    ///           the local Node does not have configuration capabilities
+    ///           (no Unicast Address assigned), or the destination address
+    ///           is not a Unicast Address or it belongs to an unknown Node.
+    ///           Error ``AccessError/cannotDelete`` is sent when trying to
+    ///           delete the last Network Key on the device.
+    /// - returns: Message handle that can be used to cancel sending.
+    @discardableResult
+    func send(_ message: AcknowledgedConfigMessage, to destination: Address,
+              withTtl initialTtl: UInt8? = nil,
+              completion: ((Result<ConfigResponse, Error>) -> ())? = nil) throws -> MessageHandle {
+        guard let networkManager = networkManager,
+              let meshNetwork = meshNetwork else {
+            print("Error: Mesh Network not created")
+            throw MeshNetworkError.noNetwork
+        }
+        guard let localProvisioner = meshNetwork.localProvisioner,
+              let source = localProvisioner.node?.primaryElement else {
+            print("Error: Local Provisioner has no Unicast Address assigned")
+            throw AccessError.invalidSource
+        }
+        guard destination.isUnicast else {
+            print("Error: Address: 0x\(destination.hex) is not a Unicast Address")
+            throw AccessError.invalidDestination
+        }
+        guard let node = meshNetwork.node(withAddress: destination) else {
+            print("Error: Unknown destination Node")
+            throw AccessError.invalidDestination
+        }
+        guard let _ = node.networkKeys.first else {
+            print("Fatal Error: The target Node does not have Network Key")
+            throw AccessError.invalidDestination
+        }
+        guard let _ = node.deviceKey else {
+            print("Error: Node's Device Key is unknown")
+            throw AccessError.noDeviceKey
+        }
+        if message is ConfigNetKeyDelete {
+            guard node.networkKeys.count > 1 else {
+                print("Error: Cannot remove last Network Key")
+                throw AccessError.cannotDelete
+            }
+        }
+        guard initialTtl == nil || initialTtl! <= 127 else {
+            print("Error: TTL value \(initialTtl!) is invalid")
+            throw AccessError.invalidTtl
+        }
+        Task {
+            do {
+                let response = try await send(message, to: destination, withTtl: initialTtl)
+                completion?(.success(response))
+            } catch {
+                completion?(.failure(error))
+            }
+        }
+        return MessageHandle(for: message, sentFrom: source.unicastAddress,
+                             to: destination, using: networkManager)
+    }
+    
+    /// Sends a Configuration Message to the primary Element on the given ``Node``.
+    ///
+    /// Apart from the `completion` callback, an appropriate callback of the
+    /// ``MeshNetworkDelegate`` will be called when the message has been sent
+    /// successfully or a problem occured.
+    ///
+    /// - parameters:
+    ///   - message:    The message to be sent.
+    ///   - node:       The destination Node.
+    ///   - initialTtl: The initial TTL (Time To Live) value of the message.
+    ///                 If `nil`, the default Node TTL will be used.
+    ///   - completion: The completion handler which is called when the response
+    ///                 has been received.
+    /// - throws: This method throws when the mesh network has not been created,
+    ///           the local Node does not have configuration capabilities
+    ///           (no Unicast Address assigned), or the destination address
+    ///           is not a Unicast Address or it belongs to an unknown Node.
+    ///           Error ``AccessError/cannotDelete`` is sent when trying to
+    ///           delete the last Network Key on the device.
+    /// - returns: Message handle that can be used to cancel sending.
+    @discardableResult
+    func send(_ message: AcknowledgedConfigMessage, to node: Node,
+              withTtl initialTtl: UInt8? = nil,
+              completion: ((Result<ConfigResponse, Error>) -> ())? = nil) throws -> MessageHandle {
+        return try send(message, to: node.primaryUnicastAddress,
+                        withTtl: initialTtl, completion: completion)
+    }
+    
+    /// Sends the Configuration Message to the primary Element of the local Node.
+    ///
+    /// Apart from the `completion` callback, an appropriate callback of the
+    /// ``MeshNetworkDelegate`` will be called when the message has been sent
+    /// successfully or a problem occured. 
+    ///
+    /// - parameter message: The acknowledged configuration message to be sent.
+    /// - throws: This method throws when the mesh network has not been created,
+    ///           or the local Node does not have configuration capabilities
+    ///           (no Unicast Address assigned).
+    ///           Error ``AccessError/cannotDelete`` is sent when trying to
+    ///           delete the last Network Key on the device.
+    /// - returns: Message handle that can be used to cancel sending.
+    @discardableResult
+    func sendToLocalNode(_ message: AcknowledgedConfigMessage,
+                         completion: ((Result<ConfigResponse, Error>) -> ())? = nil) throws -> MessageHandle {
+        guard let meshNetwork = meshNetwork else {
+            print("Error: Mesh Network not created")
+            throw MeshNetworkError.noNetwork
+        }
+        guard let localProvisioner = meshNetwork.localProvisioner,
+              let destination = localProvisioner.primaryUnicastAddress else {
+            print("Error: Local Provisioner has no Unicast Address assigned")
+            throw AccessError.invalidSource
+        }
+        return try send(message, to: destination, withTtl: 1)
+    }
+    
+}

--- a/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
+++ b/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
@@ -83,13 +83,21 @@ public extension MeshNetworkManager {
             do {
                 try await send(message, from: localElement, to: destination,
                                withTtl: initialTtl, using: applicationKey)
-                completion?(.success(()))
+                if let completion = completion {
+                    delegateQueue.async {
+                        completion(.success(()))
+                    }
+                }
             } catch {
-                completion?(.failure(error))
+                if let completion = completion {
+                    delegateQueue.async {
+                        completion(.failure(error))
+                    }
+                }
             }
         }
-        return MessageHandle(for: message, sentFrom: source.unicastAddress,
-                             to: destination.address, using: networkManager)
+        return MessageHandle(for: message, sentFrom: destination.address,
+                             to: destination, using: networkManager)
     }
     
     /// Encrypts the message with the Application Key and a Network Key
@@ -271,13 +279,21 @@ public extension MeshNetworkManager {
             do {
                 let response = try await send(message, from: source, to: model,
                                withTtl: initialTtl)
-                completion?(.success(response))
+                if let completion = completion {
+                    delegateQueue.async {
+                        completion(.success(response))
+                    }
+                }
             } catch {
-                completion?(.failure(error))
+                if let completion = completion {
+                    delegateQueue.async {
+                        completion(.failure(error))
+                    }
+                }
             }
         }
         return MessageHandle(for: message, sentFrom: source.unicastAddress,
-                             to: element.unicastAddress, using: networkManager)
+                             to: MeshAddress(element.unicastAddress), using: networkManager)
     }
     
     /// Encrypts the message with the common Application Key bound to both given
@@ -378,13 +394,21 @@ public extension MeshNetworkManager {
         Task {
             do {
                 try await send(message, to: destination, withTtl: initialTtl)
-                completion?(.success(()))
+                if let completion = completion {
+                    delegateQueue.async {
+                        completion(.success(()))
+                    }
+                }
             } catch {
-                completion?(.failure(error))
+                if let completion = completion {
+                    delegateQueue.async {
+                        completion(.failure(error))
+                    }
+                }
             }
         }
         return MessageHandle(for: message, sentFrom: element.unicastAddress,
-                             to: destination, using: networkManager)
+                             to: MeshAddress(destination), using: networkManager)
     }
     
     /// Sends a Configuration Message to the primary Element on the given ``Node``.
@@ -480,13 +504,21 @@ public extension MeshNetworkManager {
         Task {
             do {
                 let response = try await send(message, to: destination, withTtl: initialTtl)
-                completion?(.success(response))
+                if let completion = completion {
+                    delegateQueue.async {
+                        completion(.success(response))
+                    }
+                }
             } catch {
-                completion?(.failure(error))
+                if let completion = completion {
+                    delegateQueue.async {
+                        completion(.failure(error))
+                    }
+                }
             }
         }
         return MessageHandle(for: message, sentFrom: source.unicastAddress,
-                             to: destination, using: networkManager)
+                             to: MeshAddress(destination), using: networkManager)
     }
     
     /// Sends a Configuration Message to the primary Element on the given ``Node``.

--- a/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
+++ b/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
@@ -318,6 +318,102 @@ public extension MeshNetworkManager {
                         withTtl: initialTtl)
     }
     
+    /// Sends a Configuration Message to the Node with given destination address
+    /// and returns the received response.
+    ///
+    /// The `destination` must be a Unicast Address, otherwise the method
+    /// throws an ``AccessError/invalidDestination`` error.
+    ///
+    /// Apart from the `completion` callback, an appropriate callback of the
+    /// ``MeshNetworkDelegate`` will be called when the message has been sent
+    /// successfully or a problem occured.
+    ///
+    /// - parameters:
+    ///   - message:     The message to be sent.
+    ///   - destination: The destination Unicast Address.
+    ///   - initialTtl:  The initial TTL (Time To Live) value of the message.
+    ///                  If `nil`, the default Node TTL will be used.
+    ///   - completion:  The completion handler called when the message
+    ///                  has been sent.
+    /// - throws: This method throws when the mesh network has not been created,
+    ///           the local Node does not have configuration capabilities
+    ///           (no Unicast Address assigned), or the destination address
+    ///           is not a Unicast Address or it belongs to an unknown Node.
+    ///           Error ``AccessError/cannotDelete`` is sent when trying to
+    ///           delete the last Network Key on the device.
+    /// - returns: Message handle that can be used to cancel sending.
+    func send(_ message: UnacknowledgedConfigMessage, to destination: Address,
+              withTtl initialTtl: UInt8? = nil,
+              completion: ((Result<Void, Error>) -> ())? = nil) throws -> MessageHandle {
+        guard let networkManager = networkManager,
+              let meshNetwork = meshNetwork else {
+            print("Error: Mesh Network not created")
+            throw MeshNetworkError.noNetwork
+        }
+        guard let localProvisioner = meshNetwork.localProvisioner,
+              let element = localProvisioner.node?.primaryElement else {
+            print("Error: Local Provisioner has no Unicast Address assigned")
+            throw AccessError.invalidSource
+        }
+        guard destination.isUnicast else {
+            print("Error: Address: 0x\(destination.hex) is not a Unicast Address")
+            throw AccessError.invalidDestination
+        }
+        guard let node = meshNetwork.node(withAddress: destination) else {
+            print("Error: Unknown destination Node")
+            throw AccessError.invalidDestination
+        }
+        guard let _ = node.networkKeys.first else {
+            print("Fatal Error: The target Node does not have Network Key")
+            throw AccessError.invalidDestination
+        }
+        guard let _ = node.deviceKey else {
+            print("Error: Node's Device Key is unknown")
+            throw AccessError.noDeviceKey
+        }
+        guard initialTtl == nil || initialTtl! <= 127 else {
+            print("Error: TTL value \(initialTtl!) is invalid")
+            throw AccessError.invalidTtl
+        }
+        Task {
+            do {
+                try await send(message, to: destination, withTtl: initialTtl)
+                completion?(.success(()))
+            } catch {
+                completion?(.failure(error))
+            }
+        }
+        return MessageHandle(for: message, sentFrom: element.unicastAddress,
+                             to: destination, using: networkManager)
+    }
+    
+    /// Sends a Configuration Message to the primary Element on the given ``Node``.
+    ///
+    /// Apart from the `completion` callback, an appropriate callback of the
+    /// ``MeshNetworkDelegate`` will be called when the message has been sent
+    /// successfully or a problem occured.
+    ///
+    /// - parameters:
+    ///   - message:    The message to be sent.
+    ///   - node:       The destination Node.
+    ///   - initialTtl: The initial TTL (Time To Live) value of the message.
+    ///                 If `nil`, the default Node TTL will be used.
+    ///   - completion:  The completion handler called when the message
+    ///                  has been sent.
+    /// - throws: This method throws when the mesh network has not been created,
+    ///           the local Node does not have configuration capabilities
+    ///           (no Unicast Address assigned), or the destination address
+    ///           is not a Unicast Address or it belongs to an unknown Node.
+    ///           Error ``AccessError/cannotDelete`` is sent when trying to
+    ///           delete the last Network Key on the device.
+    /// - returns: Message handle that can be used to cancel sending.
+    func send(_ message: UnacknowledgedConfigMessage, to node: Node,
+              withTtl initialTtl: UInt8? = nil,
+              completion: ((Result<Void, Error>) -> ())? = nil) throws -> MessageHandle {
+        return try send(message, to: node.primaryUnicastAddress,
+                        withTtl: initialTtl, completion: completion)
+    }
+    
     /// Sends Configuration Message to the Node with given destination Address.
     ///
     /// The `destination` must be a Unicast Address, otherwise the method

--- a/nRFMeshProvision/MeshNetworkManager.swift
+++ b/nRFMeshProvision/MeshNetworkManager.swift
@@ -265,8 +265,8 @@ public extension MeshNetworkManager {
         guard let networkManager = networkManager else {
             return
         }
-        Task {
-            await networkManager.handle(incomingPdu: data, ofType: type)
+        Task.detached {
+            networkManager.handle(incomingPdu: data, ofType: type)
         }
     }
     


### PR DESCRIPTION
This PR is the second attempt after #526 to implement `async` methods for sending messages to the mesh network.

This time message types were left alone, so the `send(...)` methods return generic `MeshResponse` or `ConfigResponse` types and user has to cast manually.

Apart from that:
1. Minimum iOS version was set to 13.0 to support `async`/`await`.
2. Minimum Swift version is 5.5.
3. Messages are sent using a `Task` instead of `DispatchQueue`. The `queue` param in the `MeshNetworkManager.init` is now deprecated and unused.
4. Callback-based `send(..)` methods use the async methods under the hood.
5. It is possible to cancel sending a method using `Task.cancel()`, but the callback-based methods still return `MessageHandle` as they used to.

I did not migrate `NetworkManager` to be an actor. That will have to wait.