### PR TITLE
Breaking: Fixed handling messages sent to virtual address

### DIFF
--- a/Example/Source/View Controllers/Control/ControlViewController.swift
+++ b/Example/Source/View Controllers/Control/ControlViewController.swift
@@ -178,17 +178,17 @@ extension ControlViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Ignore.
     }
     
     func meshNetworkManager(_ manager: MeshNetworkManager, didSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address) {
+                            from localElement: Element, to destination: MeshAddress) {
         // Ignore.
     }
     
     func meshNetworkManager(_ manager: MeshNetworkManager, failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address, error: Error) {
+                            from localElement: Element, to destination: MeshAddress, error: Error) {
         // Ignore.
     }
 }

--- a/Example/Source/View Controllers/Groups/GroupControlViewController.swift
+++ b/Example/Source/View Controllers/Groups/GroupControlViewController.swift
@@ -212,7 +212,7 @@ extension GroupControlViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -222,7 +222,7 @@ extension GroupControlViewController: MeshNetworkDelegate {
     }
     
     func meshNetworkManager(_ manager: MeshNetworkManager, didSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address) {
+                            from localElement: Element, to destination: MeshAddress) {
         if messageInProgress != nil {
             messageInProgress = nil
             done()
@@ -230,7 +230,7 @@ extension GroupControlViewController: MeshNetworkDelegate {
     }
     
     func meshNetworkManager(_ manager: MeshNetworkManager, failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address, error: Error) {
+                            from localElement: Element, to destination: MeshAddress, error: Error) {
         if messageInProgress != nil {
             messageInProgress = nil
             done {

--- a/Example/Source/View Controllers/Network/Configuration/Automation/ConfigurationViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Automation/ConfigurationViewController.swift
@@ -537,7 +537,7 @@ extension ConfigurationViewController: MeshNetworkDelegate {
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
                             sentFrom source: Address,
-                            to destination: Address) {
+                            to destination: MeshAddress) {
         let current = current
         if current >= 0 && current < tasks.count &&
            message.opCode == tasks[current].message.responseOpCode {
@@ -564,7 +564,7 @@ extension ConfigurationViewController: MeshNetworkDelegate {
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
                             from localElement: Element,
-                            to destination: Address,
+                            to destination: MeshAddress,
                             error: Error) {
         inProgress = false
         reload(taskAt: current, with: .failed(error))

--- a/Example/Source/View Controllers/Network/Configuration/ElementViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/ElementViewController.swift
@@ -142,7 +142,7 @@ extension ElementViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()

--- a/Example/Source/View Controllers/Network/Configuration/Model/ConfigurationServerViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/ConfigurationServerViewCell.swift
@@ -156,7 +156,7 @@ class ConfigurationServerViewCell: ModelViewCell {
     
     override func meshNetworkManager(_ manager: MeshNetworkManager,
                                      didReceiveMessage message: MeshMessage,
-                                     sentFrom source: Address, to destination: Address) -> Bool {
+                                     sentFrom source: Address, to destination: MeshAddress) -> Bool {
         switch message {
             
         case is ConfigRelayStatus:

--- a/Example/Source/View Controllers/Network/Configuration/Model/GenericDefaultTransitionTimeViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/GenericDefaultTransitionTimeViewCell.swift
@@ -86,7 +86,7 @@ class GenericDefaultTransitionTimeViewCell: ModelViewCell {
     
     override func meshNetworkManager(_ manager: MeshNetworkManager,
                                      didReceiveMessage message: MeshMessage,
-                                     sentFrom source: Address, to destination: Address) -> Bool {
+                                     sentFrom source: Address, to destination: MeshAddress) -> Bool {
         switch message {
         case let status as GenericDefaultTransitionTimeStatus:
             currentStatusLabel.text = "\(status.transitionTime)"

--- a/Example/Source/View Controllers/Network/Configuration/Model/GenericLevelViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/GenericLevelViewCell.swift
@@ -145,7 +145,7 @@ class GenericLevelViewCell: ModelViewCell {
     
     override func meshNetworkManager(_ manager: MeshNetworkManager,
                                      didReceiveMessage message: MeshMessage,
-                                     sentFrom source: Address, to destination: Address) -> Bool {
+                                     sentFrom source: Address, to destination: MeshAddress) -> Bool {
         switch message {
         case let status as GenericLevelStatus:
             let level = floorf(0.1 + (Float(status.level) + 32768.0) / 655.35)

--- a/Example/Source/View Controllers/Network/Configuration/Model/GenericOnOffViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/GenericOnOffViewCell.swift
@@ -112,7 +112,7 @@ class GenericOnOffViewCell: ModelViewCell {
     
     override func meshNetworkManager(_ manager: MeshNetworkManager,
                                      didReceiveMessage message: MeshMessage,
-                                     sentFrom source: Address, to destination: Address) -> Bool {
+                                     sentFrom source: Address, to destination: MeshAddress) -> Bool {
         switch message {
         case let status as GenericOnOffStatus:
             currentStatusLabel.text = status.isOn ? "ON" : "OFF"

--- a/Example/Source/View Controllers/Network/Configuration/Model/GenericPowerOnOffSetupViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/GenericPowerOnOffSetupViewCell.swift
@@ -75,7 +75,7 @@ class GenericPowerOnOffSetupViewCell: ModelViewCell {
     
     override func meshNetworkManager(_ manager: MeshNetworkManager,
                                      didReceiveMessage message: MeshMessage,
-                                     sentFrom source: Address, to destination: Address) -> Bool {
+                                     sentFrom source: Address, to destination: MeshAddress) -> Bool {
         switch message {
         case let status as GenericOnPowerUpStatus:
             acknowledgedStateLabel.text = status.state.debugDescription

--- a/Example/Source/View Controllers/Network/Configuration/Model/GenericPowerOnOffViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/GenericPowerOnOffViewCell.swift
@@ -64,7 +64,7 @@ class GenericPowerOnOffViewCell: ModelViewCell {
     
     override func meshNetworkManager(_ manager: MeshNetworkManager,
                                      didReceiveMessage message: MeshMessage,
-                                     sentFrom source: Address, to destination: Address) -> Bool {
+                                     sentFrom source: Address, to destination: MeshAddress) -> Bool {
         switch message {
         case let status as GenericOnPowerUpStatus:
             currentStatusLabel.text = status.state.debugDescription

--- a/Example/Source/View Controllers/Network/Configuration/Model/ModelViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/ModelViewCell.swift
@@ -98,7 +98,7 @@ class ModelViewCell: UITableViewCell {
     ///            the request has complete.
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) -> Bool {
+                            sentFrom source: Address, to destination: MeshAddress) -> Bool {
         return false
     }
 

--- a/Example/Source/View Controllers/Network/Configuration/Model/VendorModelViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/VendorModelViewCell.swift
@@ -125,7 +125,7 @@ class VendorModelViewCell: ModelViewCell, UITextFieldDelegate {
     
     override func meshNetworkManager(_ manager: MeshNetworkManager,
                                      didReceiveMessage message: MeshMessage,
-                                     sentFrom source: Address, to destination: Address) -> Bool {
+                                     sentFrom source: Address, to destination: MeshAddress) -> Bool {
         switch message {
         case let message as UnknownMessage where
             (message.opCode & 0xC0FFFF) == (0xC00000 | UInt32(model.companyIdentifier!.bigEndian)):

--- a/Example/Source/View Controllers/Network/Configuration/ModelBindAppKeyViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/ModelBindAppKeyViewController.swift
@@ -139,7 +139,7 @@ extension ModelBindAppKeyViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -181,7 +181,7 @@ extension ModelBindAppKeyViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error) {
         // Ignore messages sent from model publication.
         guard message is ConfigMessage else {

--- a/Example/Source/View Controllers/Network/Configuration/ModelViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/ModelViewController.swift
@@ -646,7 +646,7 @@ extension ModelViewController: ModelViewCellDelegate {
     }
     
     var isRefreshing: Bool {
-        return DispatchQueue.main.sync { refreshControl?.isRefreshing ?? false }
+        return refreshControl?.isRefreshing ?? false
     }
     
 }
@@ -669,7 +669,7 @@ private extension ModelViewController {
     }
     
     func reloadBindings() {
-        let message: ConfigMessage =
+        let message: AcknowledgedConfigMessage =
             ConfigSIGModelAppGet(of: model) ??
             ConfigVendorModelAppGet(of: model)!
         send(message, description: "Reading Bound Application Keys...")
@@ -683,7 +683,7 @@ private extension ModelViewController {
     }
     
     func reloadSubscriptions() {
-        let message: ConfigMessage =
+        let message: AcknowledgedConfigMessage =
             ConfigSIGModelSubscriptionGet(of: model) ??
             ConfigVendorModelSubscriptionGet(of: model)!
         send(message, description: "Reading Subscriptions...")
@@ -722,7 +722,7 @@ private extension ModelViewController {
     ///
     /// - parameter group: The Group to be removed from subscriptions.
     func unsubscribe(from group: Group) {
-        let message: ConfigMessage =
+        let message: AcknowledgedConfigMessage =
             ConfigModelSubscriptionDelete(group: group, from: self.model) ??
             ConfigModelSubscriptionVirtualAddressDelete(group: group, from: self.model)!
         send(message, description: "Unsubscribing...")
@@ -762,7 +762,7 @@ extension ModelViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -952,7 +952,7 @@ extension ModelViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address) {
+                            from localElement: Element, to destination: MeshAddress) {
         guard message.opCode == currentMessage?.opCode else {
             return
         }
@@ -966,7 +966,7 @@ extension ModelViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error) {
         // Ignore messages sent from model publication.
         guard message.opCode == currentMessage?.opCode else {

--- a/Example/Source/View Controllers/Network/Configuration/NodeAddAppKeyViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeAddAppKeyViewController.swift
@@ -145,7 +145,7 @@ extension NodeAddAppKeyViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -187,7 +187,7 @@ extension NodeAddAppKeyViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error) {
         // Ignore messages sent using model publication.
         guard message is ConfigMessage else {

--- a/Example/Source/View Controllers/Network/Configuration/NodeAddNetworkKeyViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeAddNetworkKeyViewController.swift
@@ -142,7 +142,7 @@ extension NodeAddNetworkKeyViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -184,7 +184,7 @@ extension NodeAddNetworkKeyViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error) {
         // Ignore messages sent using model publication.
         guard message is ConfigNetKeyAdd else {

--- a/Example/Source/View Controllers/Network/Configuration/NodeAppKeysViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeAppKeysViewController.swift
@@ -178,7 +178,7 @@ extension NodeAppKeysViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -239,7 +239,7 @@ extension NodeAppKeysViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error) {
         // Ignore messages sent using model publication.
         guard message is ConfigMessage else {

--- a/Example/Source/View Controllers/Network/Configuration/NodeNetworkKeysViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeNetworkKeysViewController.swift
@@ -188,7 +188,7 @@ extension NodeNetworkKeysViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -236,7 +236,7 @@ extension NodeNetworkKeysViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error) {
         // Ignore messages sent using model publication.
         guard message is ConfigMessage else {

--- a/Example/Source/View Controllers/Network/Configuration/NodeScenesViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeScenesViewController.swift
@@ -466,7 +466,7 @@ extension NodeScenesViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -539,7 +539,7 @@ extension NodeScenesViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error) {
         // Ignore messages sent using model publication.
         guard message is ConfigMessage ||

--- a/Example/Source/View Controllers/Network/Configuration/NodeStoreSceneViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeStoreSceneViewController.swift
@@ -184,7 +184,7 @@ extension NodeStoreSceneViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -226,7 +226,7 @@ extension NodeStoreSceneViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error) {
         // Ignore messages sent using model publication.
         guard message is SceneStore else {

--- a/Example/Source/View Controllers/Network/Configuration/NodeViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeViewController.swift
@@ -502,7 +502,7 @@ extension NodeViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -557,7 +557,7 @@ extension NodeViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error) {
         // Ignore messages sent using model publication.
         guard message is ConfigMessage else {

--- a/Example/Source/View Controllers/Network/Configuration/SetHeartbeatPublicationViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/SetHeartbeatPublicationViewController.swift
@@ -278,7 +278,7 @@ extension SetHeartbeatPublicationViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -319,7 +319,7 @@ extension SetHeartbeatPublicationViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error) {
         // Ignore messages sent from model publication.
         guard message is ConfigMessage else {

--- a/Example/Source/View Controllers/Network/Configuration/SetHeartbeatSubscriptionViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/SetHeartbeatSubscriptionViewController.swift
@@ -256,7 +256,7 @@ extension SetHeartbeatSubscriptionViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -297,7 +297,7 @@ extension SetHeartbeatSubscriptionViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error) {
         // Ignore messages sent from model publication.
         guard message is ConfigMessage else {

--- a/Example/Source/View Controllers/Network/Configuration/SetPublicationViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/SetPublicationViewController.swift
@@ -370,7 +370,7 @@ extension SetPublicationViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -411,7 +411,7 @@ extension SetPublicationViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error) {
         // Ignore messages sent from model publication.
         guard message is ConfigMessage else {

--- a/Example/Source/View Controllers/Network/Configuration/SubscribeViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/SubscribeViewController.swift
@@ -184,7 +184,7 @@ extension SubscribeViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         // Has the Node been reset remotely.
         guard !(message is ConfigNodeReset) else {
             (UIApplication.shared.delegate as! AppDelegate).meshNetworkDidChange()
@@ -225,7 +225,7 @@ extension SubscribeViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error) {
         // Ignore messages sent from model publication.
         guard message is ConfigMessage else {

--- a/Example/Source/View Controllers/Network/NetworkViewController.swift
+++ b/Example/Source/View Controllers/Network/NetworkViewController.swift
@@ -256,7 +256,7 @@ extension NetworkViewController: MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         switch message {
             
         case is ConfigNodeReset:

--- a/nRFMeshProvision/Layers/Access Layer/AccessPdu.swift
+++ b/nRFMeshProvision/Layers/Access Layer/AccessPdu.swift
@@ -87,7 +87,7 @@ internal struct AccessPdu {
         message = nil
         userInitiated = false
         source = pdu.source
-        destination = MeshAddress(pdu.destination)
+        destination = pdu.destination
         accessPdu = pdu.accessPdu
         
         // At least 1 octet is required.

--- a/nRFMeshProvision/Layers/Lower Transport Layer/AccessMessage.swift
+++ b/nRFMeshProvision/Layers/Lower Transport Layer/AccessMessage.swift
@@ -115,7 +115,7 @@ internal struct AccessMessage: LowerTransportPdu {
         self.upperTransportPdu = pdu.transportPdu
         self.transportMicSize = 4
         self.source = pdu.source
-        self.destination = pdu.destination
+        self.destination = pdu.destination.address
         self.sequence = pdu.sequence
         self.networkKey = networkKey
         self.ivIndex = pdu.ivIndex

--- a/nRFMeshProvision/Layers/Lower Transport Layer/SegmentedAccessMessage.swift
+++ b/nRFMeshProvision/Layers/Lower Transport Layer/SegmentedAccessMessage.swift
@@ -114,7 +114,7 @@ internal struct SegmentedAccessMessage: SegmentedMessage {
         self.message = pdu.message
         self.aid = pdu.aid
         self.source = pdu.source
-        self.destination = pdu.destination
+        self.destination = pdu.destination.address
         self.networkKey = networkKey
         self.ivIndex = pdu.ivIndex
         self.transportMicSize = pdu.transportMicSize

--- a/nRFMeshProvision/Layers/MessageHandle.swift
+++ b/nRFMeshProvision/Layers/MessageHandle.swift
@@ -50,10 +50,10 @@ public struct MessageHandle {
     /// The destination Address.
     ///
     /// This can be any type of Address.
-    public let destination: Address
+    public let destination: MeshAddress
     
     init(for message: MeshMessage,
-         sentFrom source: Address, to destination: Address,
+         sentFrom source: Address, to destination: MeshAddress,
          using manager: NetworkManager) {
         self.opCode = message.opCode
         self.source = source

--- a/nRFMeshProvision/Layers/NetworkManagerDelegate.swift
+++ b/nRFMeshProvision/Layers/NetworkManagerDelegate.swift
@@ -53,7 +53,7 @@ internal protocol NetworkManagerDelegate: AnyObject {
     ///   - destination: The address to which the message was sent.
     func networkManager(_ manager: NetworkManager,
                         didReceiveMessage message: MeshMessage,
-                        sentFrom source: Address, to destination: Address)
+                        sentFrom source: Address, to destination: MeshAddress)
     
     /// A callback called when an unsegmented message was sent to the
     /// ``Transmitter``, or when all segments of a segmented message targeting
@@ -66,7 +66,7 @@ internal protocol NetworkManagerDelegate: AnyObject {
     ///   - destination:  The address to which the message was sent.
     func networkManager(_ manager: NetworkManager,
                         didSendMessage message: MeshMessage,
-                        from localElement: Element, to destination: Address)
+                        from localElement: Element, to destination: MeshAddress)
     
     /// A callback called when a message failed to be sent to the target
     /// Node, or the response for an acknowledged message hasn't been received
@@ -111,7 +111,7 @@ internal protocol NetworkManagerDelegate: AnyObject {
     ///   - error:        The error that occurred.
     func networkManager(_ manager: NetworkManager,
                         failedToSendMessage message: MeshMessage,
-                        from localElement: Element, to destination: Address,
+                        from localElement: Element, to destination: MeshAddress,
                         error: Error)
     
     /// A callback called when the network configuration has changed.

--- a/nRFMeshProvision/Layers/Upper Transport Layer/UpperTransportPdu.swift
+++ b/nRFMeshProvision/Layers/Upper Transport Layer/UpperTransportPdu.swift
@@ -39,7 +39,7 @@ internal struct UpperTransportPdu {
     /// Source Address.
     let source: Address
     /// Destination Address.
-    let destination: Address
+    let destination: MeshAddress
     /// 6-bit Application Key identifier. This field is set to `nil`
     /// if the message is signed with a Device Key instead.
     let aid: UInt8?
@@ -80,7 +80,7 @@ internal struct UpperTransportPdu {
              return nil
         }
         source = accessMessage.source
-        destination = accessMessage.destination
+        destination = virtualGroup?.address ?? MeshAddress(accessMessage.destination)
         aid = accessMessage.aid
         transportMicSize = accessMessage.transportMicSize
         transportPdu = accessMessage.upperTransportPdu
@@ -96,7 +96,7 @@ internal struct UpperTransportPdu {
         self.message = pdu.message
         self.userInitiated = pdu.userInitiated
         self.source = pdu.source
-        self.destination = pdu.destination.address
+        self.destination = pdu.destination
         self.sequence = sequence
         self.ivIndex = ivIndex.transmitIndex
         let accessPdu = pdu.accessPdu
@@ -115,7 +115,7 @@ internal struct UpperTransportPdu {
         
         let nonce = Data([type, aszmic << 7]) + seq
             + self.source.bigEndian
-            + self.destination.bigEndian
+            + self.destination.address.bigEndian
             + self.ivIndex.bigEndian
         
         self.transportMicSize = aszmic == 0 ? 4 : 8

--- a/nRFMeshProvision/MeshNetworkDelegate.swift
+++ b/nRFMeshProvision/MeshNetworkDelegate.swift
@@ -67,7 +67,7 @@ public protocol MeshNetworkDelegate: AnyObject {
     ///   - destination: The address to which the message was sent.
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address)
+                            sentFrom source: Address, to destination: MeshAddress)
     
     /// A callback called when an unsegmented message was sent to the
     /// ``Transmitter``, or when all segments of a segmented message targeting
@@ -80,7 +80,7 @@ public protocol MeshNetworkDelegate: AnyObject {
     ///   - destination:  The address to which the message was sent.
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address)
+                            from localElement: Element, to destination: MeshAddress)
     
     /// A callback called when a message failed to be sent to the target
     /// Node, or the response for an acknowledged message hasn't been received
@@ -124,7 +124,7 @@ public protocol MeshNetworkDelegate: AnyObject {
     ///   - error:        The error that occurred.
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error)
     
 }
@@ -133,13 +133,13 @@ public extension MeshNetworkDelegate {
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address) {
+                            from localElement: Element, to destination: MeshAddress) {
         // Empty.
     }
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address,
+                            from localElement: Element, to destination: MeshAddress,
                             error: Error) {
         // Empty.
     }

--- a/nRFMeshProvision/MeshNetworkManager.swift
+++ b/nRFMeshProvision/MeshNetworkManager.swift
@@ -303,7 +303,7 @@ public extension MeshNetworkManager {
             networkManager.publish(message, from: model)
         }
         return MessageHandle(for: message, sentFrom: localElement.unicastAddress,
-                             to: publish.publicationAddress.address, using: networkManager)
+                             to: publish.publicationAddress, using: networkManager)
     }
     
     /// Encrypts the message with the Application Key and the Network Key
@@ -799,7 +799,7 @@ extension MeshNetworkManager: NetworkManagerDelegate {
     
     func networkManager(_ manager: NetworkManager,
                         didReceiveMessage message: MeshMessage,
-                        sentFrom source: Address, to destination: Address) {
+                        sentFrom source: Address, to destination: MeshAddress) {
         delegateQueue.async {
             self.delegate?.meshNetworkManager(self, didReceiveMessage: message,
                                               sentFrom: source, to: destination)
@@ -808,7 +808,7 @@ extension MeshNetworkManager: NetworkManagerDelegate {
     
     func networkManager(_ manager: NetworkManager,
                         didSendMessage message: MeshMessage,
-                        from localElement: Element, to destination: Address) {
+                        from localElement: Element, to destination: MeshAddress) {
         delegateQueue.async {
             self.delegate?.meshNetworkManager(self, didSendMessage: message,
                                               from: localElement, to: destination)
@@ -817,7 +817,7 @@ extension MeshNetworkManager: NetworkManagerDelegate {
     
     func networkManager(_ manager: NetworkManager,
                         failedToSendMessage message: MeshMessage,
-                        from localElement: Element, to destination: Address,
+                        from localElement: Element, to destination: MeshAddress,
                         error: Error) {
         delegateQueue.async {
             self.delegate?.meshNetworkManager(self, failedToSendMessage: message,


### PR DESCRIPTION
This PR fixes an issue with how messages sent to a virtual address were handled by the stack.
The message's destination was stored as `Address`, instead of `MeshAddress`. In case of a Virtual Addresses, the Access Layer was comparing the address to subscription addresses and, as the latter included the Virtual Label UUID and the destination address didn't, comparison was failing.
Now, the full destination is stored for messages being sent and received if decoding with the Virtual Label succeeded.

As a consequence of the change `MeshNetworkDelegate` was modified to return destination as `MeshAddress` instead of just an `Address` (`UInt16`).