### PR TITLE
Clean up UnprovisionedDeviceBeaconDecoder.decode

### DIFF
--- a/nRFMeshProvision/Layers/Network Layer/NetworkLayer.swift
+++ b/nRFMeshProvision/Layers/Network Layer/NetworkLayer.swift
@@ -112,7 +112,7 @@ internal class NetworkLayer {
                 handle(networkBeacon: beaconPdu)
                 return
             }
-            if let beaconPdu = UnprovisionedDeviceBeaconDecoder.decode(pdu, for: meshNetwork) {
+            if let beaconPdu = UnprovisionedDeviceBeaconDecoder.decode(pdu) {
                 logger?.i(.network, "\(beaconPdu) received")
                 handle(unprovisionedDeviceBeacon: beaconPdu)
                 return

--- a/nRFMeshProvision/Layers/Network Layer/UnprovisionedDeviceBeacon.swift
+++ b/nRFMeshProvision/Layers/Network Layer/UnprovisionedDeviceBeacon.swift
@@ -67,14 +67,12 @@ internal struct UnprovisionedDeviceBeacon: BeaconPdu {
 internal struct UnprovisionedDeviceBeaconDecoder {
     private init() {}
     
-    /// This method goes over all Network Keys in the mesh network and tries
-    /// to parse the beacon.
+    /// This method decodes the given pdu and creates an Unprovisioned Device Beacon.
     ///
     /// - parameters:
     ///   - pdu:         The received PDU.
-    ///   - meshNetwork: The mesh network for which the PDU should be decoded.
     /// - returns: The beacon object.
-    static func decode(_ pdu: Data, for meshNetwork: MeshNetwork) -> UnprovisionedDeviceBeacon? {
+    static func decode(_ pdu: Data) -> UnprovisionedDeviceBeacon? {
         guard pdu.count > 1, let beaconType = BeaconType(rawValue: pdu[0]) else {
             return nil
         }

--- a/nRFMeshProvision/Mesh API/ApplicationKey+NetworkKey.swift
+++ b/nRFMeshProvision/Mesh API/ApplicationKey+NetworkKey.swift
@@ -64,7 +64,7 @@ public extension ApplicationKey {
     /// - returns: `True`, if the Application Key is bound to any of
     ///            the given Network Keys.
     func isBound(toAnyOf networkKeys: [NetworkKey]) -> Bool {
-        return networkKeys.contains { $0.index == boundNetworkKeyIndex }
+        return networkKeys.contains { isBound(to: $0) }
     }
 
     /// The Network Key bound to this Application Key.

--- a/nRFMeshProvision/Mesh API/NetworkKeys.swift
+++ b/nRFMeshProvision/Mesh API/NetworkKeys.swift
@@ -43,7 +43,7 @@ public extension Array where Element == NetworkKey {
     /// The primary Network Key, that is the one with key index 0.
     /// If the primary Network Key is not known, it's set to `nil`.
     var primaryKey: NetworkKey? {
-        return first { $0.index == 0 }
+        return first { $0.isPrimary }
     }
     
     /// Returns a new list of Network Keys containing all the Network Keys


### PR DESCRIPTION
* This PR removes the unused unused meshNetwork argument in `UnprovisionedDeviceBeaconDecoder.decode` function.