### PR TITLE
Messages as `AsyncStream`

### DIFF
--- a/Example/Tests/FastSending.swift
+++ b/Example/Tests/FastSending.swift
@@ -400,7 +400,7 @@ class FastSending: XCTestCase, MeshNetworkDelegate {
         XCTAssertNotNil(meshNetwork.nodes[0].meshNetwork)
     }
 
-    func testFastSending() throws {
+    func testFastSending() async throws {
         XCTAssertNotNil(manager)
         XCTAssertNotNil(manager.meshNetwork)
         
@@ -436,18 +436,20 @@ class FastSending: XCTestCase, MeshNetworkDelegate {
         
         let bindFirstAppKey = ConfigModelAppBind(applicationKey: firstKey!, to: sceneClientModel!)
         XCTAssertNotNil(bindFirstAppKey)
-        XCTAssertNoThrow(try manager.sendToLocalNode(bindFirstAppKey!))
+        let response1 = try await manager.sendToLocalNode(bindFirstAppKey!)
+        XCTAssert(response1 is ConfigModelAppStatus)
         
         let bindLastAppKey = ConfigModelAppBind(applicationKey: lastKey!, to: sceneClientModel!)
         XCTAssertNotNil(bindLastAppKey)
-        XCTAssertNoThrow(try manager.sendToLocalNode(bindLastAppKey!))
+        let response2 = try await manager.sendToLocalNode(bindLastAppKey!)
+        XCTAssert(response2 is ConfigModelAppStatus)
         
-        wait(for: [messageSent, keyBound, statusSent, statusReceived], timeout: 2)
+        await fulfillment(of: [messageSent, keyBound, statusSent, statusReceived], timeout: 2)
     }
     
     func meshNetworkManager(_ manager: MeshNetworkManager,
                             didReceiveMessage message: MeshMessage,
-                            sentFrom source: Address, to destination: Address) {
+                            sentFrom source: Address, to destination: MeshAddress) {
         if message is ConfigModelAppBind {
             let sceneClientModel = manager.meshNetwork?.localProvisioner?.node?
                 .primaryElement?.model(withSigModelId: .sceneClientModelId)
@@ -464,9 +466,8 @@ class FastSending: XCTestCase, MeshNetworkDelegate {
     }
     
     func meshNetworkManager(_ manager: MeshNetworkManager, didSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address) {
+                            from localElement: Element, to destination: MeshAddress) {
         if message is ConfigModelAppBind {
-            print("AAAA")
             messageSent.fulfill()
         }
         if message is ConfigModelAppStatus {
@@ -475,7 +476,7 @@ class FastSending: XCTestCase, MeshNetworkDelegate {
     }
     
     func meshNetworkManager(_ manager: MeshNetworkManager, failedToSendMessage message: MeshMessage,
-                            from localElement: Element, to destination: Address, error: Error) {
+                            from localElement: Element, to destination: MeshAddress, error: Error) {
         XCTFail(error.localizedDescription)
     }
 

--- a/Example/Tests/Pdus.swift
+++ b/Example/Tests/Pdus.swift
@@ -325,7 +325,7 @@ class Pdus: XCTestCase {
         let pdu = UpperTransportPdu(fromAccessPdu: accessPdu, usingKeySet: keySet,
                                     sequence: sequence, andIvIndex: ivIndex)
         XCTAssertEqual(pdu.source, source)
-        XCTAssertEqual(pdu.destination, destination.address)
+        XCTAssertEqual(pdu.destination, destination)
         XCTAssertEqual(pdu.sequence, sequence)
         XCTAssertNil(pdu.aid)
         XCTAssertEqual(pdu.transportMicSize, 4) // 32-bits
@@ -406,7 +406,7 @@ class Pdus: XCTestCase {
         let pdu = UpperTransportPdu(fromAccessPdu: accessPdu, usingKeySet: keySet,
                                     sequence: sequence, andIvIndex: ivIndex)
         XCTAssertEqual(pdu.source, source)
-        XCTAssertEqual(pdu.destination, destination.address)
+        XCTAssertEqual(pdu.destination, destination)
         XCTAssertEqual(pdu.sequence, sequence)
         XCTAssertNil(pdu.aid)
         XCTAssertEqual(pdu.transportMicSize, 4) // 32-bits
@@ -512,7 +512,7 @@ class Pdus: XCTestCase {
         let pdu = UpperTransportPdu(fromLowerTransportAccessMessage: accessMessage, usingKey: node.deviceKey!)
         XCTAssertNotNil(pdu)
         XCTAssertEqual(pdu?.source, source)
-        XCTAssertEqual(pdu?.destination, destination)
+        XCTAssertEqual(pdu?.destination, MeshAddress(destination))
         XCTAssertNil(pdu?.aid)
         XCTAssertEqual(pdu?.sequence, sequence)
         XCTAssertEqual(pdu?.transportMicSize, 4)
@@ -570,7 +570,7 @@ class Pdus: XCTestCase {
         let pdu = UpperTransportPdu(fromAccessPdu: accessPdu, usingKeySet: keySet,
                                     sequence: sequence, andIvIndex: ivIndex)
         XCTAssertEqual(pdu.source, source)
-        XCTAssertEqual(pdu.destination, virtualGroup!.address.address)
+        XCTAssertEqual(pdu.destination, virtualGroup!.address)
         XCTAssertEqual(pdu.sequence, sequence)
         XCTAssertEqual(pdu.aid, 0x26)
         XCTAssertEqual(pdu.transportMicSize, 4) // 32-bits

--- a/nRFMeshProvision/Documentation.docc/Configuration.md
+++ b/nRFMeshProvision/Documentation.docc/Configuration.md
@@ -12,7 +12,7 @@ and the configured Node, which know the key, can encrypt and decrypt such messag
 Use ``MeshNetworkManager/sendToLocalNode(_:)`` to configure the *local node*. The ``ConfigMessage``s
 will be handled by the *Configuration Server* model automaticaly by the library.
 
-To configure the remote nodes, use ``MeshNetworkManager/send(_:to:withTtl:)-77r3r``.
+To configure the remote nodes, use ``MeshNetworkManager/send(_:to:withTtl:)-2bthl``.
 
 Status messages for configuration messages are delivered using
 ``MeshNetworkDelegate/meshNetworkManager(_:didReceiveMessage:sentFrom:to:)`` to the 

--- a/nRFMeshProvision/Documentation.docc/MeshNetworkManager.md
+++ b/nRFMeshProvision/Documentation.docc/MeshNetworkManager.md
@@ -18,6 +18,7 @@ Use it to create, load or import a Bluetooth mesh network and send messages.
 - ``isNetworkCreated``
 - ``load()``
 - ``save()``
+- ``clear()``
 - ``import(from:)``
 - ``export()``
 - ``export(_:)``
@@ -33,19 +34,64 @@ Use it to create, load or import a Bluetooth mesh network and send messages.
 
 - ``provision(unprovisionedDevice:over:)``
 
-### Sending Messages
+### Publishing
 
 - ``publish(_:from:)``
-- ``send(_:from:to:withTtl:using:)-2qajr``
-- ``send(_:from:to:withTtl:using:)-2o2t9``
-- ``send(_:to:withTtl:)-77r3r``
-- ``send(_:to:withTtl:)-1xxm0``
-- ``send(_:from:to:withTtl:)-36p9o``
-- ``send(_:from:to:withTtl:)-2ogrs``
-- ``send(_:from:to:withTtl:using:)-2o2t9``
+
+### Sending Messages (async)
+
+- ``send(_:from:to:withTtl:using:)-48vjl``
+- ``send(_:from:to:withTtl:using:)-8s58h``
+- ``send(_:from:to:withTtl:)-69yab``
+- ``send(_:from:to:withTtl:)-4meon``
+- ``send(_:from:to:withTtl:)-8vfdy``
+- ``send(_:from:to:withTtl:)-3piwi``
+- ``send(_:to:withTtl:)-1ybmh``
+- ``send(_:to:withTtl:)-2bthl``
+- ``send(_:to:withTtl:)-5vcbr``
+- ``send(_:to:withTtl:)-l73l``
 - ``sendToLocalNode(_:)``
-- ``send(_:)``
+
+### Sending Messages (callbacks)
+
+- ``send(_:from:to:withTtl:using:completion:)-46h4r``
+- ``send(_:from:to:withTtl:using:completion:)-1iylo``
+- ``send(_:from:to:withTtl:completion:)-4il73``
+- ``send(_:from:to:withTtl:completion:)-512i4``
+- ``send(_:from:to:withTtl:completion:)-4u387``
+- ``send(_:from:to:withTtl:completion:)-713ia``
+- ``send(_:to:withTtl:completion:)-55sng``
+- ``send(_:to:withTtl:completion:)-9uy76``
+- ``send(_:to:withTtl:completion:)-7cqf7``
+- ``send(_:to:withTtl:completion:)-1xywq``
+- ``sendToLocalNode(_:completion:)``
 - ``cancel(_:)``
+
+### Awaiting messages (async)
+
+- ``waitFor(messageWithOpCode:from:to:timeout:)-6673k``
+- ``waitFor(messageWithOpCode:from:to:timeout:)-6pbh``
+- ``waitFor(messageFrom:to:timeout:)-24q2d``
+- ``waitFor(messageFrom:to:timeout:)-22y1``
+- ``messages(withOpCode:from:to:)-6y68g``
+- ``messages(withOpCode:from:to:)-6pn3j``
+- ``messages(from:to:)-564th``
+- ``messages(from:to:)-2nxp4``
+
+### Awaiting messages (callbacks)
+
+- ``waitFor(messageWithOpCode:from:to:timeout:completion:)-6i2u4``
+- ``waitFor(messageWithOpCode:from:to:timeout:completion:)-7ry4h``
+- ``waitFor(messageFrom:to:timeout:completion:)-60mxr``
+- ``waitFor(messageFrom:to:timeout:completion:)-4xe02``
+- ``registerCallback(forMessagesWithOpCode:from:to:callback:)-otzg``
+- ``registerCallback(forMessagesWithOpCode:from:to:callback:)-1i8hu``
+- ``registerCallback(forMessagesFrom:to:callback:)-4pyhv``
+- ``registerCallback(forMessagesFrom:to:callback:)-7axud``
+- ``unregisterCallback(forMessagesWithOpCode:from:)-2pj32``
+- ``unregisterCallback(forMessagesWithOpCode:from:)-9rbl0``
+- ``unregisterCallback(forMessagesWithType:from:)-2cij2``
+- ``unregisterCallback(forMessagesWithType:from:)-7mdko``
 
 ### Bearer Callbacks
 
@@ -54,11 +100,13 @@ Use it to create, load or import a Bluetooth mesh network and send messages.
 
 ### Proxy Filter
 
+- ``send(_:)``
 - ``proxyFilter``
 
 ### Mesh Network Parameters
 
 - ``networkParameters``
+- ``NetworkParametersProvider``
 
 ### Advanced Configuration
 

--- a/nRFMeshProvision/Documentation.docc/SendingMessages.md
+++ b/nRFMeshProvision/Documentation.docc/SendingMessages.md
@@ -18,7 +18,7 @@ from the model to a destination specified in the ``Publish`` object. Responses w
 to ``ModelDelegate/model(_:didReceiveResponse:toAcknowledgedMessage:from:)`` of the model delegate.
 
 The second method does not require setting up local models. 
-Use ``MeshNetworkManager/send(_:from:to:withTtl:using:)-2qajr`` or other variants of this method to send 
+Use ``MeshNetworkManager/send(_:from:to:withTtl:using:)-48vjl`` or other variants of this method to send 
 a message to the desired destination.
 
 > All methods used for sending messages in the ``MeshNetworkManager`` are asynchronous.

--- a/nRFMeshProvision/Documentation.docc/nRFMeshProvision.md
+++ b/nRFMeshProvision/Documentation.docc/nRFMeshProvision.md
@@ -113,6 +113,8 @@ provisioning procedure.
 
 - ``MeshNetworkManager``
 - ``MeshNetworkDelegate``
+- ``NetworkParameters``
+- ``NetworkParametersProvider``
 - ``Storage``
 - ``LocalStorage``
 - ``ExportConfiguration``
@@ -257,14 +259,22 @@ Provisioning is the process of adding an unprovisioned device to a mesh network 
 
 - ``MeshMessage``
 - ``AcknowledgedMeshMessage``
+- ``UnacknowledgedMeshMessage``
+- ``MeshResponse``
 - ``StaticMeshMessage``
 - ``StaticAcknowledgedMeshMessage``
+- ``StaticUnacknowledgedMeshMessage``
+- ``StaticMeshResponse``
 - ``StatusMessage``
 
 - ``VendorMessage``
 - ``AcknowledgedVendorMessage``
+- ``UnacknowledgedVendorMessage``
+- ``VendorResponse``
 - ``StaticVendorMessage``
 - ``AcknowledgedStaticVendorMessage``
+- ``UnacknowledgedStaticVendorMessage``
+- ``StaticVendorResponse``
 - ``VendorStatusMessage``
 
 - ``UnknownMessage``
@@ -273,6 +283,8 @@ Provisioning is the process of adding an unprovisioned device to a mesh network 
 
 - ``ConfigMessage``
 - ``AcknowledgedConfigMessage``
+- ``UnacknowledgedConfigMessage``
+- ``ConfigResponse``
 - ``ConfigStatusMessage``
 - ``ConfigMessageStatus``
 
@@ -416,6 +428,8 @@ Provisioning is the process of adding an unprovisioned device to a mesh network 
 
 - ``RemoteProvisioningMessage``
 - ``AcknowledgedRemoteProvisioningMessage``
+- ``UnacknowledgedRemoteProvisioningMessage``
+- ``RemoteProvisioningResponse``
 - ``RemoteProvisioningStatusMessage``
 - ``RemoteProvisioningMessageStatus``
 - ``RemoteProvisioningError``
@@ -448,15 +462,13 @@ Provisioning is the process of adding an unprovisioned device to a mesh network 
 
 ### Generic Message Types
 
-- ``GenericMessage``
-- ``AcknowledgedGenericMessage``
-- ``GenericStatusMessage``
-- ``GenericMessageStatus``
 - ``TransactionMessage``
 - ``TransitionMessage``
 - ``TransitionStatusMessage``
 - ``TransitionTime``
 - ``StepResolution``
+- ``RangeStatusMessage``
+- ``RangeMessageStatus``
 
 ### Generic Messages
 
@@ -600,12 +612,11 @@ Provisioning is the process of adding an unprovisioned device to a mesh network 
 
 ### Sensor Types
 
-- ``SensorMessage``
-- ``AcknowledgedSensorMessage``
 - ``SensorPropertyMessage``
-- ``AcknowledgedSensorPropertyMessage``
 - ``DeviceProperty``
 - ``DevicePropertyCharacteristic``
+- ``TimeExponential``
+- ``ValidDecimal``
 - ``SensorDescriptor``
 - ``SensorSamplingFunction``
 - ``SensorCadence``
@@ -637,9 +648,6 @@ Provisioning is the process of adding an unprovisioned device to a mesh network 
 - ``Latitude``
 - ``Longitude``
 - ``Altitude``
-
-- ``LocationMessage``
-- ``AcknowledgedLocationMessage``
 - ``LocationStatusMessage``
 
 ### Location Messages

--- a/nRFMeshProvision/Layers/MessageHandle.swift
+++ b/nRFMeshProvision/Layers/MessageHandle.swift
@@ -69,7 +69,7 @@ public struct MessageHandle {
     /// (depending on the connection interval and message size)
     /// and therefore cannot be cancelled.
     public func cancel() {
-        manager?.cancel(self)
+        manager?.cancel(messageWithHandler: self)
     }
     
 }

--- a/nRFMeshProvision/Layers/NetworkManager.swift
+++ b/nRFMeshProvision/Layers/NetworkManager.swift
@@ -215,7 +215,7 @@ internal class NetworkManager {
                                  retransmit: false)
             }
         } onCancel: {
-            cancel(MessageHandle(for: message, sentFrom: element.unicastAddress,
+            cancel(messageWithHandler: MessageHandle(for: message, sentFrom: element.unicastAddress,
                                  to: destination, using: self))
         }
     }
@@ -258,7 +258,7 @@ internal class NetworkManager {
                                  retransmit: false)
             }
         } onCancel: {
-            cancel(MessageHandle(for: message, sentFrom: element.unicastAddress,
+            cancel(messageWithHandler: MessageHandle(for: message, sentFrom: element.unicastAddress,
                                  to: meshAddress, using: self))
         }
     }
@@ -298,7 +298,7 @@ internal class NetworkManager {
                                  withTtl: initialTtl)
             }
         } onCancel: {
-            cancel(MessageHandle(for: configMessage, sentFrom: element.unicastAddress,
+            cancel(messageWithHandler: MessageHandle(for: configMessage, sentFrom: element.unicastAddress,
                                  to: meshAddress, using: self))
         }
     }
@@ -341,7 +341,7 @@ internal class NetworkManager {
                                  withTtl: initialTtl)
             }
         } onCancel: {
-            cancel(MessageHandle(for: configMessage, sentFrom: element.unicastAddress,
+            cancel(messageWithHandler: MessageHandle(for: configMessage, sentFrom: element.unicastAddress,
                                  to: meshAddress, using: self))
         }
     }
@@ -469,7 +469,7 @@ internal class NetworkManager {
     /// Cancels sending the message with the given handler.
     ///
     /// - parameter handler: The message identifier.
-    func cancel(_ handler: MessageHandle) {
+    func cancel(messageWithHandler handler: MessageHandle) {
         accessLayer.cancel(handler)
     }
     

--- a/nRFMeshProvision/Layers/NetworkManager.swift
+++ b/nRFMeshProvision/Layers/NetworkManager.swift
@@ -416,7 +416,7 @@ internal class NetworkManager {
         return AsyncStream {
             return try? await self.waitFor(messageWithOpCode: opCode, from: address, to: destination, timeout: 0)
         } onCancel: {
-            self.cancel(messageStreamWithOpCode: opCode, from: address)
+            self.cancel(awaitingMessageWithOpCode: opCode, from: address)
         }
     }
     
@@ -439,7 +439,7 @@ internal class NetworkManager {
         return AsyncStream {
             return try? await self.waitFor(messageWithOpCode: T.opCode, from: address, to: destination, timeout: 0) as? T
         } onCancel: {
-            self.cancel(messageStreamWithOpCode: T.opCode, from: address)
+            self.cancel(awaitingMessageWithOpCode: T.opCode, from: address)
         }
     }
     
@@ -483,7 +483,7 @@ internal class NetworkManager {
     /// - parameters:
     ///   - opCode: The message OpCode.
     ///   - address: The Unicast Address of the sender.
-    func cancel(messageStreamWithOpCode opCode: UInt32, from address: Address) {
+    func cancel(awaitingMessageWithOpCode opCode: UInt32, from address: Address) {
         notifyCallback(awaitingMessageWithOpCode: opCode,
                        sentFrom: address, to: nil,
                        with: .failure(CancellationError()))

--- a/nRFMeshProvision/Layers/NetworkManager.swift
+++ b/nRFMeshProvision/Layers/NetworkManager.swift
@@ -346,6 +346,18 @@ internal class NetworkManager {
         }
     }
     
+    /// Awaits a message with a given OpCode from the specified Unicast Address.
+    ///
+    /// If the destination is optional.
+    ///
+    /// - parameters:
+    ///   - opCode: The message OpCode.
+    ///   - address: The Unicast Address of the source Element.
+    ///   - destination: The optional destination.
+    ///   - timeout: The timeout in seconds.
+    /// - returns: The received mesh message.
+    /// - throws: This method may throw when the manager already awaits messages
+    ///           with the same OpCode and source address or when a timeout occurred.
     func waitFor(messageWithOpCode opCode: UInt32,
                  from address: Address, to destination: MeshAddress?,
                  timeout: TimeInterval) async throws -> MeshMessage {

--- a/nRFMeshProvision/Layers/NetworkManager.swift
+++ b/nRFMeshProvision/Layers/NetworkManager.swift
@@ -383,7 +383,7 @@ internal class NetworkManager {
             }
         }
         if timeout > 0 {
-            let timeoutTask = Task {
+            Task {
                 try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
                 task.cancel()
             }

--- a/nRFMeshProvision/Layers/NetworkParameters.swift
+++ b/nRFMeshProvision/Layers/NetworkParameters.swift
@@ -140,7 +140,7 @@ public struct NetworkParameters {
     /// as the acknowledged message timeout, then the Element may consider the
     /// message has not been delivered, without sending any additional messages.
     ///
-    /// The ``MeshNetworkDelegate/meshNetworkManager(_:failedToSendMessage:from:to:error:)-ogo4``
+    /// The ``MeshNetworkDelegate/meshNetworkManager(_:failedToSendMessage:from:to:error:)-7iylf``
     /// callback will be called on timeout.
     ///
     /// The acknowledged message timeout should be set to a minimum of 30 seconds.

--- a/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
+++ b/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
@@ -586,7 +586,7 @@ public extension MeshNetworkManager {
             throw MeshNetworkError.noNetwork
         }
         Task {
-            networkManager.cancel(messageId)
+            networkManager.cancel(messageWithHandler: messageId)
         }
     }
     

--- a/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
+++ b/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
@@ -721,7 +721,7 @@ public extension MeshNetworkManager {
     ///
     /// The destination is optional. If not set it will not be checked.
     ///
-    /// - important: To unregister the callback call ``unregisterCallback(forMessagesWithOpCode:from:)``.
+    /// - important: To unregister the callback call ``unregisterCallback(forMessagesWithOpCode:from:)-2pj32``.
     ///
     /// - warning: This method is implemented using ``waitFor(messageWithOpCode:from:to:timeout:)-6673k``.
     ///            It is not possible to await a message and message stream simultanosly.
@@ -753,7 +753,7 @@ public extension MeshNetworkManager {
     ///
     /// The destination is optional. If not set it will not be checked.
     ///
-    /// - important: To unregister the callback call ``unregisterCallback(forMessagesWithOpCode:from:)``.
+    /// - important: To unregister the callback call ``unregisterCallback(forMessagesWithOpCode:from:)-9rbl0``.
     ///
     /// - warning: This method is implemented using ``waitFor(messageWithOpCode:from:to:timeout:)-6673k``.
     ///            It is not possible to await a message and message stream simultanosly.
@@ -776,7 +776,7 @@ public extension MeshNetworkManager {
     ///
     /// The destination is optional. If not set it will not be checked.
     ///
-    /// - important: To unregister the callback call ``unregisterCallback(forMessagesWithType:from:)``.
+    /// - important: To unregister the callback call ``unregisterCallback(forMessagesWithType:from:)-2cij2``.
     ///
     /// - warning: This method is implemented using ``waitFor(messageFrom:to:timeout:)-24q2d``.
     ///            It is not possible to await a message and message stream simultanosly.
@@ -807,7 +807,7 @@ public extension MeshNetworkManager {
     ///
     /// The destination is optional. If not set it will not be checked.
     ///
-    /// - important: To unregister the callback call ``unregisterCallback(forMessagesWithType:from:)``.
+    /// - important: To unregister the callback call ``unregisterCallback(forMessagesWithType:from:)-7mdko``.
     ///
     /// - warning: This method is implemented using ``waitFor(messageFrom:to:timeout:)-24q2d``.
     ///            It is not possible to await a message and message stream simultanosly.

--- a/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
+++ b/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
@@ -590,7 +590,7 @@ public extension MeshNetworkManager {
         }
     }
     
-    /// Sets a callback awaiting a mesh message with given OpCode
+    /// Sets a callback awaiting a mesh message with the given OpCode
     /// sent from a specified source Unicast Address.
     ///
     /// The destination is optional. If not set, the destination of the received
@@ -637,7 +637,7 @@ public extension MeshNetworkManager {
         }
     }
     
-    /// Sets a callback awaiting a mesh message with given OpCode
+    /// Sets a callback awaiting a mesh message with the given OpCode
     /// sent from a specified source ``Element``.
     ///
     /// The destination is optional. If not set, the destination of the received
@@ -661,7 +661,7 @@ public extension MeshNetworkManager {
                     timeout: timeout, completion: completion)
     }
     
-    /// Sets a callback awaiting a mesh message with given OpCode
+    /// Sets a callback awaiting a mesh message with the given OpCode
     /// sent from a specified source Unicast Address.
     ///
     /// The destination is optional. If not set, the destination of the received
@@ -693,7 +693,7 @@ public extension MeshNetworkManager {
         }
     }
     
-    /// Sets a callback awaiting a mesh message with given OpCode
+    /// Sets a callback awaiting a mesh message with the given OpCode
     /// sent from a specified source ``Element``.
     ///
     /// The destination is optional. If not set, the destination of the received
@@ -716,7 +716,7 @@ public extension MeshNetworkManager {
                     timeout: timeout, completion: completion)
     }
     
-    /// Registers a callback that will be invoked each time a message with given OpCode
+    /// Registers a callback that will be invoked each time a message with the given OpCode
     /// is sent from an Element with given Unicast Address.
     ///
     /// The destination is optional. If not set it will not be checked.
@@ -746,6 +746,29 @@ public extension MeshNetworkManager {
                 callback(message)
             }
         }
+    }
+    
+    /// Registers a callback that will be invoked each time a message with the given OpCode
+    /// is sent from the specified ``Element``.
+    ///
+    /// The destination is optional. If not set it will not be checked.
+    ///
+    /// - important: To unregister the callback call ``unregisterCallback(forMessagesWithOpCode:from:)``.
+    ///
+    /// - warning: This method is implemented using ``waitFor(messageWithOpCode:from:to:timeout:)-6673k``.
+    ///            It is not possible to await a message and message stream simultanosly.
+    ///
+    /// - parameters:
+    ///   - opCode: Expected message OpCode.
+    ///   - element: The Element from which the messages are expected.
+    ///   - destination: The optional destination.
+    ///   - callback: The callback.
+    func registerCallback(forMessagesWithOpCode opCode: UInt32,
+                          from element: Element, to destination: MeshAddress? = nil,
+                          callback: @escaping (MeshMessage) -> ()) throws {
+        try registerCallback(forMessagesWithOpCode: opCode,
+                             from: element.unicastAddress, to: destination,
+                             callback: callback)
     }
     
     /// Registers a callback that will be invoked each time a message with given OpCode
@@ -779,12 +802,33 @@ public extension MeshNetworkManager {
         }
     }
     
+    /// Registers a callback that will be invoked each time a message with the given OpCode
+    /// is sent from the specified ``Element``.
+    ///
+    /// The destination is optional. If not set it will not be checked.
+    ///
+    /// - important: To unregister the callback call ``unregisterCallback(forMessagesWithType:from:)``.
+    ///
+    /// - warning: This method is implemented using ``waitFor(messageFrom:to:timeout:)-24q2d``.
+    ///            It is not possible to await a message and message stream simultanosly.
+    ///
+    /// - parameters:
+    ///   - element: The Element from which the messages are expected.
+    ///   - destination: The optional destination.
+    ///   - callback: The callback.
+    func registerCallback<T: StaticMeshMessage>(forMessagesFrom element: Element,
+                                                to destination: MeshAddress? = nil,
+                                                callback: @escaping (T) -> ()) throws {
+        try registerCallback(forMessagesFrom: element.unicastAddress,
+                             to: destination, callback: callback)
+    }
+    
     /// Unregisters and cancels previously registered callback.
     ///
     /// This method must be called to unregister previously registered callback.
     ///
-    /// - note: Due to the implementation, this method cancels an awaiting for a message with given parameters.
-    ///
+    /// - note: Due to the implamentation, this method cancels awaiting for messages
+    ///         with given parameters even if no message callbacks were registered.
     ///
     /// - parameters:
     ///   - opCode: The OpCode of messages.
@@ -800,14 +844,42 @@ public extension MeshNetworkManager {
     ///
     /// This method must be called to unregister previously registered callback.
     ///
+    /// - note: Due to the implamentation, this method cancels awaiting for messages
+    ///         with given parameters even if no message callbacks were registered.
+    ///
+    /// - parameters:
+    ///   - opCode: The OpCode of messages.
+    ///   - element: The source Element.
+    func unregisterCallback(forMessagesWithOpCode opCode: UInt32, from element: Element) {
+        unregisterCallback(forMessagesWithOpCode: opCode, from: element.unicastAddress)
+    }
+    
+    /// Unregisters and cancels previously registered callback.
+    ///
+    /// This method must be called to unregister previously registered callback.
+    ///
+    /// - note: Due to the implamentation, this method cancels awaiting for messages
+    ///         with given parameters even if no message callbacks were registered.
+    ///
     /// - parameters:
     ///   - type: The message type.
     ///   - address: The Unicast Address of the source Element.
     func unregisterCallback<T: StaticMeshMessage>(forMessagesWithType type: T, from address: Address) {
-        guard let networkManager = networkManager else {
-            return
-        }
-        networkManager.cancel(awaitingMessageWithOpCode: T.opCode, from: address)
+        unregisterCallback(forMessagesWithOpCode: T.opCode, from: address)
+    }
+    
+    /// Unregisters and cancels previously registered callback.
+    ///
+    /// This method must be called to unregister previously registered callback.
+    ///
+    /// - note: Due to the implamentation, this method cancels awaiting for messages
+    ///         with given parameters even if no message callbacks were registered.
+    ///
+    /// - parameters:
+    ///   - type: The message type.
+    ///   - element: The source Element.
+    func unregisterCallback<T: StaticMeshMessage>(forMessagesWithType type: T, from element: Element) {
+        unregisterCallback(forMessagesWithOpCode: T.opCode, from: element.unicastAddress)
     }
     
 }

--- a/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
+++ b/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
@@ -664,13 +664,20 @@ public extension MeshNetworkManager {
     ///           is not a Unicast Address, `timeout` is negative or the manager is already
     ///           awaiting a message with the same parameters.
     /// - returns: The message received.
-    func waitFor<T: StaticMeshMessage>(messageWithType type: T.Type,
-                 from source: Address, to destination: MeshAddress? = nil,
-                 timeout: TimeInterval,
-                 completion: @escaping (Result<MeshMessage, Error>) -> ()) throws {
-        try waitFor(messageWithOpCode: type.opCode,
+    func waitFor<T: StaticMeshMessage>(messageFrom source: Address,
+                                       to destination: MeshAddress? = nil,
+                                       timeout: TimeInterval,
+                                       completion: @escaping (Result<T, Error>) -> ()) throws {
+        try waitFor(messageWithOpCode: T.opCode,
                     from: source, to: destination,
-                    timeout: timeout, completion: completion)
+                    timeout: timeout) { result in
+            do {
+                let message = try result.get() as! T
+                completion(.success(message))
+            } catch {
+                completion(.failure(error))
+            }
+        }
     }
     
     /// Sets a callback awaiting a mesh message with given OpCode
@@ -688,13 +695,12 @@ public extension MeshNetworkManager {
     /// - throws: This method throws when the network is not created, `timeout` is negative
     ///           or the manager is already awaiting a message with the same parameters.
     /// - returns: The message received.
-    func waitFor<T: StaticMeshMessage>(messageWithType type: T.Type,
-                 from element: Element, to destination: MeshAddress? = nil,
-                 timeout: TimeInterval,
-                 completion: @escaping (Result<MeshMessage, Error>) -> ()) throws {
-        return try waitFor(messageWithOpCode: type.opCode,
-                           from: element.unicastAddress, to: destination,
-                           timeout: timeout, completion: completion)
+    func waitFor<T: StaticMeshMessage>(messageFrom element: Element,
+                                       to destination: MeshAddress? = nil,
+                                       timeout: TimeInterval,
+                                       completion: @escaping (Result<T, Error>) -> ()) throws {
+        try waitFor(messageFrom: element.unicastAddress, to: destination,
+                    timeout: timeout, completion: completion)
     }
     
 }

--- a/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
+++ b/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
@@ -574,7 +574,7 @@ public extension MeshNetworkManager {
             print("Error: Local Provisioner has no Unicast Address assigned")
             throw AccessError.invalidSource
         }
-        return try send(message, to: destination, withTtl: 1)
+        return try send(message, to: destination, withTtl: 1, completion: completion)
     }
     
     /// Cancels sending the message with the given handle.

--- a/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
+++ b/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
@@ -734,7 +734,7 @@ public extension MeshNetworkManager {
     func registerCallback(forMessagesWithOpCode opCode: UInt32,
                           from address: Address, to destination: MeshAddress? = nil,
                           callback: @escaping (MeshMessage) -> ()) throws {
-        guard let networkManager = networkManager else {
+        guard let _ = networkManager else {
             print("Error: Mesh Network not created")
             throw MeshNetworkError.noNetwork
         }
@@ -765,7 +765,7 @@ public extension MeshNetworkManager {
     func registerCallback<T: StaticMeshMessage>(forMessagesFrom address: Address,
                                                 to destination: MeshAddress? = nil,
                                                 callback: @escaping (T) -> ()) throws {
-        guard let networkManager = networkManager else {
+        guard let _ = networkManager else {
             print("Error: Mesh Network not created")
             throw MeshNetworkError.noNetwork
         }

--- a/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
+++ b/nRFMeshProvision/MeshNetworkManager+Callbacks.swift
@@ -793,7 +793,7 @@ public extension MeshNetworkManager {
         guard let networkManager = networkManager else {
             return
         }
-        networkManager.cancel(messageStreamWithOpCode: opCode, from: address)
+        networkManager.cancel(awaitingMessageWithOpCode: opCode, from: address)
     }
     
     /// Unregisters and cancels previously registered callback.
@@ -807,7 +807,7 @@ public extension MeshNetworkManager {
         guard let networkManager = networkManager else {
             return
         }
-        networkManager.cancel(messageStreamWithOpCode: T.opCode, from: address)
+        networkManager.cancel(awaitingMessageWithOpCode: T.opCode, from: address)
     }
     
 }

--- a/nRFMeshProvision/MeshNetworkManager.swift
+++ b/nRFMeshProvision/MeshNetworkManager.swift
@@ -848,12 +848,12 @@ public extension MeshNetworkManager {
     ///           is not a Unicast Address, `timeout` is negative or the manager is already
     ///           awaiting a message with the same parameters.
     /// - returns: The message received.
-    func waitFor<T: StaticMeshMessage>(messageWithType type: T.Type,
-                 from source: Address, to destination: MeshAddress? = nil,
-                 timeout: TimeInterval) async throws -> MeshMessage {
-        return try await waitFor(messageWithOpCode: type.opCode,
+    func waitFor<T: StaticMeshMessage>(messageFrom source: Address,
+                                       to destination: MeshAddress? = nil,
+                                       timeout: TimeInterval) async throws -> T {
+        return try await waitFor(messageWithOpCode: T.opCode,
                                  from: source, to: destination,
-                                 timeout: timeout)
+                                 timeout: timeout) as! T
     }
     
     /// This is a blocking method awaiting a mesh message with given OpCode
@@ -873,12 +873,12 @@ public extension MeshNetworkManager {
     /// - throws: This method throws when the network is not created, `timeout` is negative
     ///           or the manager is already awaiting a message with the same parameters.
     /// - returns: The message received.
-    func waitFor<T: StaticMeshMessage>(messageWithType type: T.Type,
-                 from element: Element, to destination: MeshAddress? = nil,
-                 timeout: TimeInterval) async throws -> MeshMessage {
-        return try await waitFor(messageWithOpCode: type.opCode,
+    func waitFor<T: StaticMeshMessage>(messageFrom element: Element,
+                                       to destination: MeshAddress? = nil,
+                                       timeout: TimeInterval) async throws -> T {
+        return try await waitFor(messageWithOpCode: T.opCode,
                                  from: element.unicastAddress, to: destination,
-                                 timeout: timeout)
+                                 timeout: timeout) as! T
     }
     
     /// Cancels sending the message with the given handle.

--- a/nRFMeshProvision/MeshNetworkManager.swift
+++ b/nRFMeshProvision/MeshNetworkManager.swift
@@ -881,6 +881,53 @@ public extension MeshNetworkManager {
                                  timeout: timeout) as! T
     }
     
+    /// Returns an async stream of messages matching given criteria.
+    ///
+    /// When the task in which the stream is iterated gets cancelled the stream
+    /// will return `nil`. 
+    ///
+    /// - important: This method is using ``waitFor(messageWithOpCode:from:to:timeout:)-6673k`` under the hood.
+    ///              It is not possible to await both at the same time, as they share
+    ///              the same resources.
+    ///
+    /// - parameters:
+    ///   - opCode: The OpCode of the messages to await for.
+    ///   - address: The Unicast Address of the sender.
+    ///   - destination: The optional destination address of the messages.
+    /// - returns: The stream of messages with given OpCode.
+    func messages(withOpCode opCode: UInt32,
+                  from address: Address,
+                  to destination: MeshAddress? = nil) throws -> AsyncStream<MeshMessage> {
+        guard let networkManager = networkManager else {
+            print("Error: Mesh Network not created")
+            throw MeshNetworkError.noNetwork
+        }
+        return networkManager.messages(withOpCode: opCode, from: address, to: destination)
+    }
+    
+    /// Returns an async stream of messages matching given criteria.
+    ///
+    /// When the task in which the stream is iterated gets cancelled the stream
+    /// will return `nil`.
+    ///
+    /// - important: This method is using ``waitFor(messageFrom:to:timeout:)-24q2d`` under the hood.
+    ///              It is not possible to await both at the same time, as they share
+    ///              the same resources.
+    ///
+    /// - parameters:
+    ///   - opCode: The OpCode of the messages to await for.
+    ///   - address: The Unicast Address of the sender.
+    ///   - destination: The optional destination address of the messages.
+    /// - returns: The stream of messages with given type.
+    func messages<T: StaticMeshMessage>(from address: Address,
+                                        to destination: MeshAddress? = nil) throws -> AsyncStream<T> {
+        guard let networkManager = networkManager else {
+            print("Error: Mesh Network not created")
+            throw MeshNetworkError.noNetwork
+        }
+        return networkManager.messages(from: address, to: destination)
+    }
+    
     /// Cancels sending the message with the given handle.
     ///
     /// - parameter messageId: The message handle.

--- a/nRFMeshProvision/MeshNetworkManager.swift
+++ b/nRFMeshProvision/MeshNetworkManager.swift
@@ -884,11 +884,10 @@ public extension MeshNetworkManager {
     /// Returns an async stream of messages matching given criteria.
     ///
     /// When the task in which the stream is iterated gets cancelled the stream
-    /// will return `nil`. 
+    /// will return `nil`.
     ///
-    /// - important: This method is using ``waitFor(messageWithOpCode:from:to:timeout:)-6673k`` under the hood.
-    ///              It is not possible to await both at the same time, as they share
-    ///              the same resources.
+    /// - warning: This method is implemented using ``waitFor(messageWithOpCode:from:to:timeout:)-6673k``.
+    ///            It is not possible to await a message and message stream simultanosly.
     ///
     /// - parameters:
     ///   - opCode: The OpCode of the messages to await for.
@@ -910,9 +909,8 @@ public extension MeshNetworkManager {
     /// When the task in which the stream is iterated gets cancelled the stream
     /// will return `nil`.
     ///
-    /// - important: This method is using ``waitFor(messageFrom:to:timeout:)-24q2d`` under the hood.
-    ///              It is not possible to await both at the same time, as they share
-    ///              the same resources.
+    /// - warning: This method is implemented using ``waitFor(messageFrom:to:timeout:)-24q2d``.
+    ///            It is not possible to await a message and message stream simultanosly.
     ///
     /// - parameters:
     ///   - opCode: The OpCode of the messages to await for.
@@ -926,19 +924,6 @@ public extension MeshNetworkManager {
             throw MeshNetworkError.noNetwork
         }
         return networkManager.messages(from: address, to: destination)
-    }
-    
-    /// Cancels sending the message with the given handle.
-    ///
-    /// - parameter messageId: The message handle.
-    func cancel(_ messageId: MessageHandle) throws {
-        guard let networkManager = networkManager else {
-            print("Error: Mesh Network not created")
-            throw MeshNetworkError.noNetwork
-        }
-        Task {
-            networkManager.cancel(messageId)
-        }
     }
     
 }

--- a/nRFMeshProvision/MeshNetworkManager.swift
+++ b/nRFMeshProvision/MeshNetworkManager.swift
@@ -909,6 +909,25 @@ public extension MeshNetworkManager {
     /// When the task in which the stream is iterated gets cancelled the stream
     /// will return `nil`.
     ///
+    /// - warning: This method is implemented using ``waitFor(messageWithOpCode:from:to:timeout:)-6673k``.
+    ///            It is not possible to await a message and message stream simultanosly.
+    ///
+    /// - parameters:
+    ///   - opCode: The OpCode of the messages to await for.
+    ///   - element: The sender Element.
+    ///   - destination: The optional destination address of the messages.
+    /// - returns: The stream of messages with given OpCode.
+    func messages(withOpCode opCode: UInt32,
+                  from element: Element,
+                  to destination: MeshAddress? = nil) throws -> AsyncStream<MeshMessage> {
+        return try messages(withOpCode: opCode, from: element.unicastAddress, to: destination)
+    }
+    
+    /// Returns an async stream of messages matching given criteria.
+    ///
+    /// When the task in which the stream is iterated gets cancelled the stream
+    /// will return `nil`.
+    ///
     /// - warning: This method is implemented using ``waitFor(messageFrom:to:timeout:)-24q2d``.
     ///            It is not possible to await a message and message stream simultanosly.
     ///
@@ -924,6 +943,24 @@ public extension MeshNetworkManager {
             throw MeshNetworkError.noNetwork
         }
         return networkManager.messages(from: address, to: destination)
+    }
+    
+    /// Returns an async stream of messages matching given criteria.
+    ///
+    /// When the task in which the stream is iterated gets cancelled the stream
+    /// will return `nil`.
+    ///
+    /// - warning: This method is implemented using ``waitFor(messageFrom:to:timeout:)-24q2d``.
+    ///            It is not possible to await a message and message stream simultanosly.
+    ///
+    /// - parameters:
+    ///   - opCode: The OpCode of the messages to await for.
+    ///   - element: The sender Element.
+    ///   - destination: The optional destination address of the messages.
+    /// - returns: The stream of messages with given type.
+    func messages<T: StaticMeshMessage>(from element: Element,
+                                        to destination: MeshAddress? = nil) throws -> AsyncStream<T> {
+        return try messages(from: element.unicastAddress, to: destination)
     }
     
 }


### PR DESCRIPTION
This PR adds new functionality of subscribing to a stream of messages from a given Unicast Address.

- [x] Methods with `AsyncStream`
- [x] Cancellation handling
- [x] Corresponding messages using callbacks

### Usage
```swift
// Await incoming messages for 10 seconds
let task = Task {
    do {
        let manager = MeshNetworkManager.instance
        let sequence: AsyncStream<GenericOnOffSetUnacknowledged> = try manager.messages(from: 0x0001)
        for try await message in sequence {
            print("Button state: \(message.isOn)")
        }
        print("This will be printed after 10 seconds (timeout set below)")
    } catch {
        print("Error: \(error)")
    }
}
Task {
    try await Task.sleep(nanoseconds: UInt64(10 * 1_000_000_000)) // 10 seconds
    task.cancel()
}
```