### PR TITLE
Vendor types refactored

### DIFF
--- a/Example/Source/Mesh Network/Simple OnOff/Messages/SimpleOnOffGet.swift
+++ b/Example/Source/Mesh Network/Simple OnOff/Messages/SimpleOnOffGet.swift
@@ -31,7 +31,7 @@
 import Foundation
 import nRFMeshProvision
 
-struct SimpleOnOffGet: AcknowledgedStaticVendorMessage {    
+struct SimpleOnOffGet: StaticAcknowledgedVendorMessage {    
     // The Op Code consists of:
     // 0xC0-0000 - Vendor Op Code bitmask
     // 0x02-0000 - The Op Code defined by...

--- a/Example/Source/Mesh Network/Simple OnOff/Messages/SimpleOnOffSet.swift
+++ b/Example/Source/Mesh Network/Simple OnOff/Messages/SimpleOnOffSet.swift
@@ -31,7 +31,7 @@
 import Foundation
 import nRFMeshProvision
 
-struct SimpleOnOffSet: AcknowledgedStaticVendorMessage {
+struct SimpleOnOffSet: StaticAcknowledgedVendorMessage {
     // The Op Code consists of:
     // 0xC0-0000 - Vendor Op Code bitmask
     // 0x01-0000 - The Op Code defined by...

--- a/nRFMeshProvision/Documentation.docc/nRFMeshProvision.md
+++ b/nRFMeshProvision/Documentation.docc/nRFMeshProvision.md
@@ -272,8 +272,8 @@ Provisioning is the process of adding an unprovisioned device to a mesh network 
 - ``UnacknowledgedVendorMessage``
 - ``VendorResponse``
 - ``StaticVendorMessage``
-- ``AcknowledgedStaticVendorMessage``
-- ``UnacknowledgedStaticVendorMessage``
+- ``StaticAcknowledgedVendorMessage``
+- ``StaticUnacknowledgedVendorMessage``
 - ``StaticVendorResponse``
 - ``VendorStatusMessage``
 

--- a/nRFMeshProvision/Mesh Messages/VendorMessage.swift
+++ b/nRFMeshProvision/Mesh Messages/VendorMessage.swift
@@ -61,17 +61,17 @@ public protocol StaticVendorMessage: VendorMessage, StaticMeshMessage {
 }
 
 /// A base protocol for static unacknowledged vendor message.
-public protocol UnacknowledgedStaticVendorMessage: StaticVendorMessage, UnacknowledgedMeshMessage {
+public protocol StaticUnacknowledgedVendorMessage: StaticVendorMessage, UnacknowledgedMeshMessage {
     // No additional fields.
 }
 
 /// The base class for vendor response messages.
-public protocol StaticVendorResponse: StaticMeshResponse, UnacknowledgedStaticVendorMessage {
+public protocol StaticVendorResponse: StaticMeshResponse, StaticUnacknowledgedVendorMessage {
     // No additional fields.
 }
 
 /// A base protocol for static acknowledged vendor message.
-public protocol AcknowledgedStaticVendorMessage: StaticVendorMessage, StaticAcknowledgedMeshMessage {
+public protocol StaticAcknowledgedVendorMessage: StaticVendorMessage, StaticAcknowledgedMeshMessage {
     // No additional fields.
 }
 


### PR DESCRIPTION
This PR renames:
- `AcknowledgedStaticVendorMessage` to `StaticAcknowledgedVendorMessage`
- `UnacknowledgedStaticVendorMessage` to `StaticUnacknowledgedVendorMessage`

to match other types.