### PR TITLE
Apply missing node features after receiving composition data

### DIFF
--- a/nRFMeshProvision/Mesh Model/Node.swift
+++ b/nRFMeshProvision/Mesh Model/Node.swift
@@ -886,7 +886,11 @@ internal extension Node {
         // Don't override features if they already were known.
         // Accurate features states could have been acquired by reading each feature state,
         // while the Page 0 of the Composition Data contains only Supported / Not Supported.
-        features = features ?? page0.features
+        if let features { // `NodeFeaturesState` is a reference type
+            features.applyMissing(from: page0.features)
+        } else {
+            features = page0.features
+        }
         // And set the Elements received.
         set(elements: page0.elements)
         meshNetwork?.timestamp = Date()

--- a/nRFMeshProvision/Mesh Model/NodeFeatures.swift
+++ b/nRFMeshProvision/Mesh Model/NodeFeatures.swift
@@ -159,6 +159,24 @@ public class NodeFeaturesState: Codable {
         // The Low Power feature if supported is enabled and cannot be disabled.
         self.lowPower = mask & 0x08 == 0 ? .notSupported : .enabled
     }
+    
+    internal func applyMissing(from other: NodeFeaturesState) {
+        if self.friend == nil {
+            self.friend = other.friend
+        }
+        
+        if self.lowPower == nil {
+            self.lowPower = other.lowPower
+        }
+        
+        if self.proxy == nil {
+            self.proxy = other.proxy
+        }
+        
+        if self.relay == nil {
+            self.relay = other.relay
+        }
+    }
 }
 
 extension NodeFeature: CustomDebugStringConvertible {


### PR DESCRIPTION
This PR revises the processing of the composition data in the case of the node features. The current implementation discarded newly-received node features if **NodeFeaturesState** was already set once. In this PR, the individual node features are now checked for **nil** and, if necessary, replaced by the newly received composition data. 