### PR TITLE
Bug fix: Allowing 5-byte long array of zeros as valid TimeStatus

### DIFF
--- a/nRFMeshProvision/Mesh Messages/Time and Scenes/TimeStatus.swift
+++ b/nRFMeshProvision/Mesh Messages/Time and Scenes/TimeStatus.swift
@@ -45,6 +45,17 @@ public struct TimeStatus: StaticMeshResponse {
     }
     
     public init?(parameters: Data) {
+        // If the TAI Seconds field is 0x0000000000 the Subsecond, Uncertainty,
+        // Time Authority, TAI-UTC Delta and Time Zone Offset fields shall be omitted;
+        // otherwise these fields shall be present.
+        if parameters.count == 5 {
+            let seconds = parameters.readBits(40, fromOffset: 0)
+            guard seconds == 0 else {
+                return nil
+            }
+            time = TaiTime()
+            return
+        }
         guard parameters.count == 10 else {
             return nil
         }

--- a/nRFMeshProvision/Mesh Messages/TimeMessage.swift
+++ b/nRFMeshProvision/Mesh Messages/TimeMessage.swift
@@ -37,8 +37,11 @@ public protocol TimeMessage: MeshMessage {
 }
 
 /// Structure representing time in TAI format.
+///
+/// Mesh defines times based on International Atomic Time (TAI). The base representation of times is the number of
+/// seconds after 00:00:00 TAI on 2000-01-01 (that is, 1999-12-31T23:59:28 Coordinated Universal Time (UTC)).
 public struct TaiTime {
-    /// The current TAI time in seconds.
+    /// The current TAI time in seconds after the epoch 2000-01-01T00:00:00 TAI (1999-12-31T23:59:28 UTC).
     public let seconds: UInt64
     /// The sub-second time in units of 1/256th second.
     public let subSecond: UInt8
@@ -51,6 +54,10 @@ public struct TaiTime {
     /// The Local time zone offset.
     public let tzOffset: TimeZone
     
+    /// Creates an unknown TAI time.
+    ///
+    /// When an element cannot determine the time with the accuracy necessary for the implementation,
+    /// a special value of 0 seonds shall be used.
     public init() {
         self.seconds = 0
         self.subSecond = 0
@@ -60,6 +67,15 @@ public struct TaiTime {
         self.tzOffset = TimeZone.current
     }
     
+    /// Creates the TAI time using the given values.
+    ///
+    /// - parameters:
+    ///   - seconds: The current TAI time in seconds.
+    ///   - subSecond: The sub-second time in units of 1/256th second.
+    ///   - uncertainty: The estimated uncertainty in 10-millisecond steps.
+    ///   - authority: Whether this time is authorative (from a "known good" source, such as GPS or NTP).
+    ///   - taiDelta: Current difference between TAI and UTC in seconds (range -255 to 32512).
+    ///   - tzOffset: The Local time zone offset.
     public init(seconds: UInt64, subSecond: UInt8,
                 uncertainty: UInt8, authority: Bool,
                 taiDelta: Int16, tzOffset: TimeZone) {
@@ -69,6 +85,12 @@ public struct TaiTime {
         self.authority = authority
         self.taiDelta = taiDelta
         self.tzOffset = tzOffset
+    }
+    
+    /// When an element cannot determine the time with the accuracy necessary for the implementation,
+    /// a special value of 0 seonds shall be used, in which case this property returns `false`.
+    public var isKnown: Bool {
+        return seconds > 0
     }
 }
 

--- a/nRFMeshProvision/Type Extensions/Data.swift
+++ b/nRFMeshProvision/Type Extensions/Data.swift
@@ -66,6 +66,7 @@ public extension Data {
 
     /// Read a specific number of bits from an offset in the Data object.
     /// Note that this method does no sanity checks. The Data object must be large enough to read the bits.
+    /// 
     /// - parameters:
     ///   - numBits: The number of bits to read.
     ///   - fromOffset: The offset in bits in the Data to read from.


### PR DESCRIPTION
This PR fixes #543 and adds some documentation.