### PR TITLE
Fixed resetting Proxy Filter

### DIFF
--- a/nRFMeshProvision/ProxyFilter.swift
+++ b/nRFMeshProvision/ProxyFilter.swift
@@ -265,6 +265,10 @@ public extension ProxyFilter {
         guard let node = provisioner.node else {
             return
         }
+        // Make sure the Filter Type is set to inclusion list.
+        if type == .exclusionList {
+            setType(.inclusionList)
+        }
         var addresses: Set<Address> = []
         // Add Unicast Addresses of all Elements of the Provisioner's Node.
         addresses.formUnion(node.elements.map({ $0.unicastAddress }))


### PR DESCRIPTION
This PR fixes #538. There is no need to send initial Filter Type, as newly connected Proxy Node should have is set to an empty Accept List.