### PR TITLE
[Breaking] Fixed Equatable implementation

### DIFF
--- a/nRFMeshProvision/Mesh Model/ApplicationKey.swift
+++ b/nRFMeshProvision/Mesh Model/ApplicationKey.swift
@@ -153,7 +153,11 @@ public class ApplicationKey: Key, Codable {
 extension ApplicationKey: Equatable {
     
     public static func == (lhs: ApplicationKey, rhs: ApplicationKey) -> Bool {
-        return lhs.index == rhs.index && lhs.key == rhs.key
+        return lhs.index == rhs.index 
+            && lhs.key == rhs.key
+            && lhs.oldKey == rhs.oldKey
+            && lhs.name == rhs.name
+            && lhs.boundNetworkKeyIndex == rhs.boundNetworkKeyIndex
     }
     
     public static func != (lhs: ApplicationKey, rhs: ApplicationKey) -> Bool {

--- a/nRFMeshProvision/Mesh Model/Element.swift
+++ b/nRFMeshProvision/Mesh Model/Element.swift
@@ -191,11 +191,9 @@ public class Element: Codable {
 extension Element: Equatable, Hashable {
     
     public static func == (lhs: Element, rhs: Element) -> Bool {
-        return lhs.parentNode === rhs.parentNode && lhs.index == rhs.index
-    }
-    
-    public static func != (lhs: Element, rhs: Element) -> Bool {
-        return lhs.parentNode !== rhs.parentNode || lhs.index != rhs.index
+        return lhs.parentNode === rhs.parentNode 
+            && lhs.index == rhs.index
+            && lhs.name == rhs.name
     }
     
     public func hash(into hasher: inout Hasher) {

--- a/nRFMeshProvision/Mesh Model/Group.swift
+++ b/nRFMeshProvision/Mesh Model/Group.swift
@@ -163,10 +163,8 @@ extension Group: Equatable, Hashable {
     
     public static func == (lhs: Group, rhs: Group) -> Bool {
         return lhs.groupAddress == rhs.groupAddress
-    }
-    
-    public static func != (lhs: Group, rhs: Group) -> Bool {
-        return lhs.groupAddress != rhs.groupAddress
+            && lhs.parentAddress == rhs.parentAddress
+            && lhs.name == rhs.name
     }
     
     public func hash(into hasher: inout Hasher) {

--- a/nRFMeshProvision/Mesh Model/Model.swift
+++ b/nRFMeshProvision/Mesh Model/Model.swift
@@ -378,11 +378,11 @@ internal extension Model {
 extension Model: Equatable, Hashable {
     
     public static func == (lhs: Model, rhs: Model) -> Bool {
-        return lhs.modelId == rhs.modelId && lhs.parentElement == rhs.parentElement
-    }
-    
-    public static func != (lhs: Model, rhs: Model) -> Bool {
-        return lhs.modelId != rhs.modelId || lhs.parentElement != rhs.parentElement
+        return lhs.modelId == rhs.modelId 
+            && lhs.parentElement == rhs.parentElement
+            && lhs.bind == rhs.bind
+            && lhs.subscribe == rhs.subscribe
+            && lhs.publish == rhs.publish
     }
     
     public func hash(into hasher: inout Hasher) {

--- a/nRFMeshProvision/Mesh Model/NetworkKey.swift
+++ b/nRFMeshProvision/Mesh Model/NetworkKey.swift
@@ -253,10 +253,10 @@ extension NetworkKey: Equatable {
     
     public static func == (lhs: NetworkKey, rhs: NetworkKey) -> Bool {
         return lhs.index == rhs.index
-    }
-    
-    public static func != (lhs: NetworkKey, rhs: NetworkKey) -> Bool {
-        return lhs.index != rhs.index
+            && lhs.phase == rhs.phase
+            && lhs.key == rhs.key
+            && lhs.oldKey == rhs.oldKey
+            && lhs.name == rhs.name
     }
     
 }

--- a/nRFMeshProvision/Mesh Model/Node.swift
+++ b/nRFMeshProvision/Mesh Model/Node.swift
@@ -944,6 +944,11 @@ extension Node: Equatable {
     
     public static func == (lhs: Node, rhs: Node) -> Bool {
         return lhs.uuid == rhs.uuid
-    }    
+            && lhs.isConfigComplete == rhs.isConfigComplete
+            && lhs.isCompositionDataReceived == rhs.isCompositionDataReceived
+            && lhs.isExcluded == rhs.isExcluded
+            && lhs.name == rhs.name
+            && lhs.defaultTTL == rhs.defaultTTL
+    }
     
 }

--- a/nRFMeshProvision/Mesh Model/Provisioner.swift
+++ b/nRFMeshProvision/Mesh Model/Provisioner.swift
@@ -132,10 +132,10 @@ extension Provisioner: Equatable {
     
     public static func == (lhs: Provisioner, rhs: Provisioner) -> Bool {
         return lhs.uuid == rhs.uuid
-    }
-    
-    public static func != (lhs: Provisioner, rhs: Provisioner) -> Bool {
-        return lhs.uuid != rhs.uuid
+            && lhs.name == rhs.name
+            && lhs.allocatedUnicastRange == rhs.allocatedUnicastRange
+            && lhs.allocatedGroupRange == rhs.allocatedGroupRange
+            && lhs.allocatedSceneRange == rhs.allocatedSceneRange
     }
     
 }

--- a/nRFMeshProvision/Mesh Model/Publish.swift
+++ b/nRFMeshProvision/Mesh Model/Publish.swift
@@ -39,7 +39,7 @@ import Foundation
 /// To set the publication on a Model, send the ``ConfigModelPublicationSet`` or
 /// ``ConfigModelPublicationVirtualAddressSet`` messages to the Configuration Server model
 /// on the Node. The *Set* messages are confirmed with a ``ConfigModelPublicationStatus``.
-public struct Publish: Codable {
+public struct Publish: Codable, Equatable {
     /// The configuration for disabling publication.
     ///
     /// - since: 3.0
@@ -47,7 +47,7 @@ public struct Publish: Codable {
     
     /// The object is used to describe the number of times a message is published and
     /// the interval between retransmissions of the published message.
-    public struct Retransmit: Codable {
+    public struct Retransmit: Codable, Equatable {
         /// Retransmission of published messages is disabled.
         ///
         /// - since: 3.0
@@ -104,7 +104,7 @@ public struct Publish: Codable {
     /// are periodically published by a Model.
     ///
     /// - since: 3.0
-    public struct Period: Codable {
+    public struct Period: Codable, Equatable {
         /// Periodic publishing of status messages is disabled.
         ///
         /// - since: 3.0

--- a/nRFMeshProvision/Mesh Model/Scene.swift
+++ b/nRFMeshProvision/Mesh Model/Scene.swift
@@ -33,7 +33,7 @@ import Foundation
 /// A Scene represents a set of states stored with a Scene Number.
 ///
 /// A Scene is identified by a ``SceneNumber`` and may have a
-/// human-reaadable name associated.
+/// human-readable name associated.
 ///
 /// A Node having a Scene Server model can store the states of other
 /// models and restore them on demand.
@@ -159,6 +159,7 @@ extension Scene: Equatable, Hashable {
     
     public static func == (lhs: Scene, rhs: Scene) -> Bool {
         return lhs.number == rhs.number
+            && lhs.name == rhs.name
     }
     
     public func hash(into hasher: inout Hasher) {


### PR DESCRIPTION
This PR fixes #459.

As `==` is used to detect changes in objects, e.g. in SwiftUI, the new Equatable implementations compare all parameters of objects, not just IDs. This is potentially a breaking change.