### PR TITLE
Fixed handling case with closed PB Bearer

### DIFF
--- a/Example/Source/View Controllers/Network/Provisioning/ScannerTableViewController.swift
+++ b/Example/Source/View Controllers/Network/Provisioning/ScannerTableViewController.swift
@@ -400,9 +400,9 @@ extension ScannerTableViewController: GattBearerDelegate {
     
     func bearer(_ bearer: Bearer, didClose error: Error?) {
         DispatchQueue.main.async {
-            self.alert?.message = "Device disconnected"
-            self.alert?.dismiss(animated: true)
-            self.alert = nil
+            self.alert?.dismiss(animated: true) {
+                self.presentAlert(title: "Status", message: error?.localizedDescription ?? "Device disconnected", cancelable: false)
+            }
             self.selectedDevice = nil
             self.startScanning()
         }

--- a/nRFMeshProvision/Bearer/Remote/PBRemoteBearer.swift
+++ b/nRFMeshProvision/Bearer/Remote/PBRemoteBearer.swift
@@ -35,7 +35,7 @@ final private class Send: AsyncOperation {
     private let destination: Address
     private let manager: MeshNetworkManager
     
-    private var retry = false
+    private var shouldRetry = true
 
     init(message: RemoteProvisioningPDUSend, to destination: Address, over manager: MeshNetworkManager) {
         self.message = message
@@ -49,22 +49,28 @@ final private class Send: AsyncOperation {
                 try result.get()
             } catch {
                 self.manager.logger?.e(.bearer, "Sending \(self.message) to \(self.destination.hex) failed with error: \(error)")
+                if case LowerTransportError.timeout = error {
+                    self.shouldRetry = false
+                }
             }
         }
         
         // TODO: Return error when retry failed
         let callback: (Result<RemoteProvisioningPDUOutboundReport, Error>) -> () = { response in
-            guard !self.retry else { return }
+            guard self.shouldRetry else {
+                self.finish()
+                return
+            }
             guard let report = try? response.get(),
                   report.outboundPduNumber == self.message.outboundPduNumber else {
                 self.manager.logger?.log(message: "Retrying sending \(self.message)", ofCategory: .bearer, withLevel: .warning)
-                self.retry = true
+                self.shouldRetry = false
                 self.main()
                 return
             }
-            self.finish()            
+            self.finish()
         }
-        try? manager.waitFor(messageFrom: destination, timeout: 5, completion: callback)
+        try? manager.waitFor(messageFrom: destination, timeout: 15, completion: callback)
     }
 }
 
@@ -148,19 +154,22 @@ open class PBRemoteBearer: ProvisioningBearer {
         // Send Link Open request.
         let linkOpen = RemoteProvisioningLinkOpen(uuid: unprovisionedDeviceUUID)
         try meshNetworkManager.send(linkOpen, to: address) { result in
-            if let status = try? result.get() as? RemoteProvisioningLinkStatus, status.isSuccess {
-                // Usually, the link state will be `.linkOpening` and we will
-                // get a link report moment later.
-                if status.linkState == .linkActive {
-                    self.bearerDidOpen()
+            do {
+                if let status = try result.get() as? RemoteProvisioningLinkStatus, status.isSuccess {
+                    // Usually, the link state will be `.linkOpening` and we will
+                    // get a link report moment later.
+                    if status.linkState == .linkActive {
+                        self.bearerDidOpen()
+                    }
                 }
+            } catch {
+                self.bearerDidClose(with: error)
             }
         }
     }
     
     public func close() throws {
-        guard isOpened else { return }
-        isOpened = false
+        guard isOpen else { return }
         
         let linkClose = RemoteProvisioningLinkClose(reason: .success)
         try meshNetworkManager.send(linkClose, to: address) { result in
@@ -172,6 +181,9 @@ open class PBRemoteBearer: ProvisioningBearer {
         // We only support what we support, right?
         guard supports(type) else {
             throw BearerError.pduTypeNotSupported
+        }
+        guard isOpen else {
+            throw BearerError.bearerClosed
         }
         
         // The data has to be converted again to Provisioning Request
@@ -199,14 +211,17 @@ open class PBRemoteBearer: ProvisioningBearer {
     }
     
     private func bearerDidClose(with error: Error?) {
-        guard isOpen else { return }
-        
         // Unregister PDU handler and link status handler.
-        meshNetworkManager.unregisterCallback(forMessagesWithType: RemoteProvisioningLinkReport.self, from: address)
-        meshNetworkManager.unregisterCallback(forMessagesWithType: RemoteProvisioningPDUReport.self, from: address)
+        if isOpened {
+            meshNetworkManager.unregisterCallback(forMessagesWithType: RemoteProvisioningLinkReport.self, from: address)
+        }
+        if isOpen {
+            meshNetworkManager.unregisterCallback(forMessagesWithType: RemoteProvisioningPDUReport.self, from: address)
+        }
         
         // Notify the delegate.
         isOpen = false
+        isOpened = false
         delegate?.bearer(self, didClose: error)
     }
     

--- a/nRFMeshProvision/Utils/AsyncResultOperation.swift
+++ b/nRFMeshProvision/Utils/AsyncResultOperation.swift
@@ -46,10 +46,6 @@ internal class AsyncResultOperation<Success, Failure>: AsyncOperation where Fail
         super.finish()
     }
 
-    override open func cancel() {
-        fatalError("Make use of cancel(with:) instead to ensure a result")
-    }
-
     public func cancel(with error: Failure) {
         self.result = .failure(error)
         super.cancel()


### PR DESCRIPTION
This PR fixes incorrect handling of closed PR Remote bearer.

### Story

When trying to provision a device using Remote Provisioning, the phone needs to be connected to a GATT Proxy node, which will retransmit messages to the network, to selected node with Remote Provisioning Server. However, when GATT Proxy node gets switched off just before selecting the PR Remote bearer, all messages will end with `.bearerClosed` error.
The library will try to repeat until the Acknowledged Message Timer expires (default 30 seconds) and will return `AccessError.cancelled`.

### Bug

 Before the change, the error was ignored and the popup showing "Connecting..." would not dismiss. Also, after clicking Cancel button the app would dismiss the popup, but also secretly try to send *Remote Provisioning Link Close* message (to close a closed PB Remote bearer using a closed GATT bearer).

### Bright future

After the fix, the `.cancelled` error is pushed to the app and shown as "Message cancelled.". The app will not try to close the never-open bearer.