### PR TITLE
Remove old node only when provisioning succeeds

### DIFF
--- a/Example/Source/View Controllers/Network/Provisioning/ScannerTableViewController.swift
+++ b/Example/Source/View Controllers/Network/Provisioning/ScannerTableViewController.swift
@@ -130,12 +130,11 @@ class ScannerTableViewController: UITableViewController {
         let network = MeshNetworkManager.instance.meshNetwork!
         if let oldNode = network.node(withUuid: unprovisionedDevice.uuid) {
             let removeAction = UIAlertAction(title: "Just reprovision", style: .default) { _ in
-                network.remove(node: oldNode)
+                self.previousNode = nil
                 self.provision(selectedPeripheral)
             }
             let reconfigureAction = UIAlertAction(title: "Reprovision and reconfigure", style: .default) { _ in
                 self.previousNode = oldNode
-                network.remove(node: oldNode)
                 self.provision(selectedPeripheral)
             }
             let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)

--- a/nRFMeshProvision/MeshNetworkManager.swift
+++ b/nRFMeshProvision/MeshNetworkManager.swift
@@ -231,12 +231,7 @@ public extension MeshNetworkManager {
     func provision(unprovisionedDevice: UnprovisionedDevice,
                    over bearer: ProvisioningBearer) throws -> ProvisioningManager {
         guard let meshNetwork = meshNetwork else {
-            print("Error: Mesh Network not created")
             throw MeshNetworkError.noNetwork
-        }
-        guard !meshNetwork.contains(nodeWithUuid: unprovisionedDevice.uuid) &&
-              !meshNetwork.contains(provisionerWithUuid: unprovisionedDevice.uuid) else {
-            throw MeshNetworkError.nodeAlreadyExist
         }
         return ProvisioningManager(for: unprovisionedDevice, over: bearer, in: meshNetwork)
     }

--- a/nRFMeshProvision/Provisioning/ProvisioningManager.swift
+++ b/nRFMeshProvision/Provisioning/ProvisioningManager.swift
@@ -492,6 +492,15 @@ extension ProvisioningManager: BearerDelegate, BearerDataDelegate {
                             andAssignedNetworkKey: provisioningData.networkKey,
                             andAddress: provisioningData.unicastAddress)
             do {
+                // If the node was reprovisioned, remove the old instance.
+                // Note: Before version 4.0.2 the provisioning would instead end with an error.
+                //       This could cause 2 issues:
+                //       - The device was successfully provisioned and is not being added to the
+                //         network. Instead the library forgets the new Node instance.
+                //       - Removing the Node before provisioning could lead to forgetting the
+                //         old Node if provisioning would fail.
+                meshNetwork.remove(nodeWithUuid: node.uuid)
+                // Now it's safe to add the new Node.
                 try meshNetwork.add(node: node)
                 state = .complete
             } catch {


### PR DESCRIPTION
This PR changes behavior of the `ProvisioingManager` in case an Unprovisioned Device with the same UUID as one of the Nodes in the network is being provisioned.

### Before

The `provision` method was throwing `MeshNetworkError.nodeAlreadyExist` error. The Node had to be removed prior to provisioning. This was OK but could lead to some issues with reprovisioning. The app would have to store the old Node until the device was reprovisioned in order to copy its configuration. But if the provisioning pf the new Node would fail, e.g. due to OOB failure, the Node was already removed.

### After

The `ProvisioningManager` allows duplicate UUID and will remove the overwritten Node automatically when provisioning is successful.