### PR TITLE
[App] Display detail button only in Security row

### DIFF
--- a/Example/Source/View Controllers/Network/Configuration/NodeViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeViewController.swift
@@ -204,6 +204,7 @@ class NodeViewController: ProgressViewController {
         }
         if indexPath.isDetailsSection {
             cell.textLabel?.text = indexPath.title
+            cell.accessoryType = .none
             switch indexPath.row {
             case 0:
                 if let id = node.companyIdentifier {


### PR DESCRIPTION
As the rows in table view are reused sometimes the detail button was shown in a random row of *Node Information* section.
The message is actually displayed only for *Security* row.