### PR TITLE
Reset counter for app keys in debug keys

### DIFF
--- a/Example/Source/View Controllers/Settings/SettingsViewController.swift
+++ b/Example/Source/View Controllers/Settings/SettingsViewController.swift
@@ -161,6 +161,7 @@ extension SettingsViewController: WizardDelegate {
             index += 1
             _ = try? network.add(networkKey: key, name: "Network Key \(i + 1)")
         }
+        index = 1
         for i in 0..<applicationKeys {
             guard index < UInt8.max else { break }
             let key = fixed ? Data(repeating: 0, count: 15) + index : Data.random128BitKey()


### PR DESCRIPTION
In the initial screen there's an option to add debug keys. They are set to following numbers starting from 1, so the first Network Key gets value 0x000...001, next one 0x000..002, etc.
Before the change, the first app key was assigned the following number (0x000...003 in this case), so its value depended on number of Net Keys. 
After the change, the counter is reset to 1, so App Keys always get the first one starting from 0x000...001.