### PR TITLE
CryptoSwift updated to 1.8.1 (SPM)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
   dependencies: [
     .package(
       url: "https://github.com/krzyzanowskim/CryptoSwift", 
-      .upToNextMinor(from: "1.8.0")
+      .upToNextMinor(from: "1.8.1")
     ),
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
   ],


### PR DESCRIPTION
This does the same as #602, but for SPM. I forgot to add it in the other PR.