### PR TITLE
Bugfix: Change multicast retransmissions ot unicast retransmissions

### DIFF
--- a/Library/Layers/Lower Transport Layer/LowerTransportLayer.swift
+++ b/Library/Layers/Lower Transport Layer/LowerTransportLayer.swift
@@ -294,7 +294,7 @@ internal class LowerTransportLayer {
         if pdu.destination.address.isUnicast {
             remainingNumberOfUnicastRetransmissions[sequenceZero] = (
                 networkManager.networkParameters.sarUnicastRetransmissionsCount,
-                networkManager.networkParameters.sarMulticastRetransmissionsCount
+                networkManager.networkParameters.sarUnicastRetransmissionsWithoutProgressCount
             )
         } else {
             remainingNumberOfMulticastRetransmissions[sequenceZero] =


### PR DESCRIPTION
* This PR fixes a possible incorrect assigment where `remainingNumberOfUnicastRetransmissions` should contain `sarUnicastRetransmissionsWithoutProgressCount` not `sarMulticastRetransmissionsCount`