### PR TITLE
Concurrency improvements

### DIFF
--- a/Library/Layers/Foundation Layer/ConfigurationClientHandler.swift
+++ b/Library/Layers/Foundation Layer/ConfigurationClientHandler.swift
@@ -302,7 +302,10 @@ internal class ConfigurationClientHandler: ModelDelegate {
         // Relay settings
         case let status as ConfigRelayStatus:
             if let node = meshNetwork.node(withAddress: source) {
-                node.ensureFeatures.relay = status.state
+                if node.features == nil {
+                    node.features = NodeFeaturesState()
+                }
+                node.features?.relay = status.state
                 if case .notSupported = status.state {
                     node.relayRetransmit = nil
                 } else {
@@ -313,13 +316,19 @@ internal class ConfigurationClientHandler: ModelDelegate {
         // GATT Proxy settings
         case let status as ConfigGATTProxyStatus:
             if let node = meshNetwork.node(withAddress: source) {
-                node.ensureFeatures.proxy = status.state
+                if node.features == nil {
+                    node.features = NodeFeaturesState()
+                }
+                node.features?.proxy = status.state
             }
             
         // Friend settings
         case let status as ConfigFriendStatus:
             if let node = meshNetwork.node(withAddress: source) {
-                node.ensureFeatures.friend = status.state
+                if node.features == nil {
+                    node.features = NodeFeaturesState()
+                }
+                node.features?.friend = status.state
             }
                 
         // Secure Network Beacon configuration

--- a/Library/Mesh Messages/ConfigMessage.swift
+++ b/Library/Mesh Messages/ConfigMessage.swift
@@ -60,7 +60,7 @@ public protocol AcknowledgedConfigMessage: ConfigMessage, StaticAcknowledgedMesh
 }
 
 /// The status of a Config operation.
-public enum ConfigMessageStatus: UInt8 {
+public enum ConfigMessageStatus: UInt8, Sendable {
     /// Success.
     case success                        = 0x00
     /// Invalid Address.

--- a/Library/Mesh Messages/DeviceProperty.swift
+++ b/Library/Mesh Messages/DeviceProperty.swift
@@ -41,7 +41,7 @@ import Foundation
 ///         implemented in this library. For those,
 ///         ``DevicePropertyCharacteristic/other(_:)`` should be used
 ///         until they are implemented.
-public enum DeviceProperty {
+public enum DeviceProperty: Sendable {
     case averageAmbientTemperatureInAPeriodOfDay
     case averageInputCurrent
     case averageInputVoltage
@@ -1215,7 +1215,7 @@ internal extension DeviceProperty {
 /// An enum representing valid or invalid decimal values.
 ///
 /// - since: 4.0.0
-public enum ValidDecimal: Equatable {
+public enum ValidDecimal: Equatable, Sendable {
     /// The value is valid.
     case valid(Decimal)
     /// The value is invalid.
@@ -1225,10 +1225,10 @@ public enum ValidDecimal: Equatable {
 /// The time is represented by the value `1.1^(N–64)` in seconds, with `N` being the raw 8-bit value.
 ///
 /// - since: 4.0.0
-public enum TimeExponential: Equatable {
+public enum TimeExponential: Equatable, Sendable {
     /// Creates a ``TimeExponential`` object based on the given time.
     ///
-    /// As the time is represented as `1.1^(N-64)` it will be ronded to the nearest possible value.
+    /// As the time is represented as `1.1^(N-64)` it will be rounded to the nearest possible value.
     ///
     /// - parameter seconds: The time in seconds as `TimeInterval`.
     static func interval(_ seconds: TimeInterval) -> TimeExponential {
@@ -1292,7 +1292,7 @@ public enum TimeExponential: Equatable {
 /// The unit of a characteristic is specified in the comment.
 ///
 /// For example, ``DevicePropertyCharacteristic/electricCurrent(_:)`` unit is Ampere
-/// with resulution of 0.01 A.
+/// with resolution of 0.01 A.
 ///
 /// #### Encoding sample
 /// ```swift
@@ -1306,7 +1306,7 @@ public enum TimeExponential: Equatable {
 /// }
 /// print(current) // -> "12.34 A"
 /// ```
-public enum DevicePropertyCharacteristic: Equatable {
+public enum DevicePropertyCharacteristic: Equatable, Sendable {
     /// The integral of Apparent Power over a time interval,
     /// represented in units of kVAh (kilo-volt-ampere-hour).
     ///

--- a/Library/Mesh Messages/Foundation/Configuration/ConfigCompositionDataStatus.swift
+++ b/Library/Mesh Messages/Foundation/Configuration/ConfigCompositionDataStatus.swift
@@ -74,6 +74,96 @@ public struct ConfigCompositionDataStatus: ConfigResponse {
     }
 }
 
+public struct ElementData: Sendable {
+    /// Numeric order of the Element within this Node.
+    let index: UInt8
+    /// Description of the Element's location.
+    let location: Location
+    /// An array of Model objects in the Element.
+    let models: [ModelData]
+    
+    internal init(element: Element) {
+        location = element.location
+        index = element.index
+        models = element.models.map { ModelData(model: $0) }
+    }
+    
+    internal init?(compositionData: Data, offset: inout Int, index: Int) {
+        // Composition Data must have at least 4 bytes: 2 for Location and one for NumS and NumV.
+        guard compositionData.count >= offset + 4 else {
+            return nil
+        }
+        // Is Location valid?
+        let rawValue: UInt16 = compositionData.read(fromOffset: offset)
+        guard let location = Location(rawValue: rawValue) else {
+            return nil
+        }
+        self.location = location
+        
+        // Read NumS and NumV.
+        let sigModelsByteCount    = Int(compositionData[offset + 2]) * 2 // SIG Model ID is 16-bit long.
+        let vendorModelsByteCount = Int(compositionData[offset + 3]) * 4 // Vendor Model ID is 32-bit long.
+        
+        // Ensure the Composition Data have enough data.
+        guard compositionData.count >= offset + 3 + sigModelsByteCount + vendorModelsByteCount else {
+            return nil
+        }
+        // 4 bytes have been read.
+        offset += 4
+        
+        self.index = UInt8(index)
+        
+        // Read models.
+        var models: [ModelData] = []
+        for o in stride(from: offset, to: offset + sigModelsByteCount, by: 2) {
+            let sigModelId: UInt16 = compositionData.read(fromOffset: o)
+            models.append(ModelData(sigModelId: sigModelId))
+        }
+        offset += sigModelsByteCount
+        
+        for o in stride(from: offset, to: offset + vendorModelsByteCount, by: 4) {
+            let companyId: UInt16 = compositionData.read(fromOffset: o)
+            let vendorModelId: UInt16 = compositionData.read(fromOffset: o + 2)
+            models.append(ModelData(vendorModelId: vendorModelId, companyId: companyId))
+        }
+        self.models = models
+        offset += vendorModelsByteCount
+    }
+}
+
+public struct ModelData: Sendable {
+    public let modelId: UInt32
+    
+    /// Bluetooth SIG or vendor-assigned model identifier.
+    public var modelIdentifier: UInt16 {
+        return UInt16(modelId & 0x0000FFFF)
+    }
+    /// The Company Identifier or `nil`, if the model is Bluetooth SIG-assigned.
+    public var companyIdentifier: UInt16? {
+        if modelId > 0xFFFF {
+            return UInt16(modelId >> 16)
+        }
+        return nil
+    }
+    /// Returns `true` for Models with identifiers assigned by Bluetooth SIG,
+    /// `false` otherwise.
+    public var isBluetoothSIGAssigned: Bool {
+        return modelId <= 0xFFFF
+    }
+    
+    internal init(model: Model) {
+        modelId = model.modelId
+    }
+    
+    internal init(sigModelId: UInt16) {
+        modelId = UInt32(sigModelId)
+    }
+    
+    internal init(vendorModelId: UInt16, companyId: UInt16) {
+        modelId = (UInt32(companyId) << 16) | UInt32(vendorModelId)
+    }
+}
+
 /// Composition Data Page 0 shall be present on a Node.
 ///
 /// Composition Data Page 0 shall not change during a term of a Node
@@ -101,7 +191,7 @@ public struct Page0: CompositionDataPage {
     /// message.
     public let features: NodeFeaturesState
     /// An array of Node's Elements.
-    public let elements: [Element]
+    public let elements: [ElementData]
     
     public var parameters: Data? {
         let data = Data([page])
@@ -121,7 +211,7 @@ public struct Page0: CompositionDataPage {
         versionIdentifier = node.versionIdentifier ?? 0
         minimumNumberOfReplayProtectionList = node.minimumNumberOfReplayProtectionList ?? 0
         features = node.features ?? NodeFeaturesState()
-        elements = node.elements
+        elements = node.elements.map { ElementData(element: $0) }
     }
     
     /// This initializer should construct the message based on the
@@ -139,13 +229,12 @@ public struct Page0: CompositionDataPage {
         minimumNumberOfReplayProtectionList = parameters.read(fromOffset: 7)
         features = NodeFeaturesState(mask: parameters.read(fromOffset: 9))
         
-        var readElements: [Element] = []
+        var readElements: [ElementData] = []
         var offset = 11
         while offset < parameters.count {
-            guard let element = Element(compositionData: parameters, offset: &offset) else {
+            guard let element = ElementData(compositionData: parameters, offset: &offset, index: readElements.count) else {
                 return nil
             }
-            element.index = UInt8(readElements.count)
             readElements.append(element)
         }
         elements = readElements
@@ -154,7 +243,7 @@ public struct Page0: CompositionDataPage {
 
 // MARK: - Helper extension
 
-private extension Array where Element == MeshElement {
+private extension Array where Element == ElementData {
     
     /// Returns Elements and their Models as Data, to be sent in
     /// Page 0 of the Composition Data.
@@ -163,8 +252,8 @@ private extension Array where Element == MeshElement {
         for element in self {
             data += element.location.rawValue
             
-            var sigModels: [Model] = []
-            var vendorModel: [Model] = []
+            var sigModels: [ModelData] = []
+            var vendorModel: [ModelData] = []
             for model in element.models {
                 if model.isBluetoothSIGAssigned {
                     sigModels.append(model)

--- a/Library/Mesh Messages/Foundation/Configuration/ConfigCompositionDataStatus.swift
+++ b/Library/Mesh Messages/Foundation/Configuration/ConfigCompositionDataStatus.swift
@@ -36,7 +36,7 @@ import Foundation
 /// the Elements it includes, and the supported models.
 ///
 /// The Composition Data is composed of a number of pages of information.
-public protocol CompositionDataPage {
+public protocol CompositionDataPage: Sendable {
     /// Page number of the Composition Data to get.
     var page: UInt8 { get }
     /// Composition Data parameters as Data.
@@ -100,7 +100,7 @@ public struct Page0: CompositionDataPage {
     /// or not. Read the state of each feature using corresponding Config
     /// message.
     public let features: NodeFeaturesState
-    /// An array of node's elements.
+    /// An array of Node's Elements.
     public let elements: [Element]
     
     public var parameters: Data? {

--- a/Library/Mesh Messages/GenericMessage.swift
+++ b/Library/Mesh Messages/GenericMessage.swift
@@ -33,7 +33,7 @@ import Foundation
 // MARK: - RangeMessageStatus
 
 /// Enumeration of available statuses of a generic message.
-public enum RangeMessageStatus: UInt8 {
+public enum RangeMessageStatus: UInt8, Sendable {
     /// The operation was successful.
     case success           = 0x00
     /// The operation failed. Min range cannot be set.
@@ -80,7 +80,7 @@ extension RangeMessageStatus: CustomDebugStringConvertible {
 // MARK: - SceneMessageStatus
 
 /// Enumeration of available statuses of a scene message.
-public enum SceneMessageStatus: UInt8 {
+public enum SceneMessageStatus: UInt8, Sendable {
     /// The operation was successful.
     case success           = 0x00
     /// The scene register is full and cannot store any mode scenes.

--- a/Library/Mesh Messages/Health/HealthFaultEnum.swift
+++ b/Library/Mesh Messages/Health/HealthFaultEnum.swift
@@ -39,7 +39,7 @@ public enum HealthFault: Sendable {
     case supplyVoltageToHighWarning
     case supplyVoltageToHighError
     case powerSupplyInterruptedWarning
-    case powerSupplyInterrputedError
+    case powerSupplyInterruptedError
     case noLoadWarning
     case noLoadError
     case overloadWarning
@@ -102,7 +102,7 @@ public enum HealthFault: Sendable {
             return 0x06;
         case .powerSupplyInterruptedWarning:
             return 0x07;
-        case .powerSupplyInterrputedError:
+        case .powerSupplyInterruptedError:
             return 0x08;
         case .noLoadWarning:
             return 0x09;
@@ -212,7 +212,7 @@ public enum HealthFault: Sendable {
         case 0x07:
             return .powerSupplyInterruptedWarning;
         case 0x08:
-            return .powerSupplyInterrputedError;
+            return .powerSupplyInterruptedError;
         case 0x09:
             return .noLoadWarning;
         case 0x0A:

--- a/Library/Mesh Messages/Health/HealthFaultEnum.swift
+++ b/Library/Mesh Messages/Health/HealthFaultEnum.swift
@@ -30,7 +30,7 @@
 * Created by Jules DOMMARTIN on 04/11/2024.
 */
 
-public enum HealthFault {
+public enum HealthFault: Sendable {
     case noFault
     case batteryLowWarning
     case batteryLowError

--- a/Library/Mesh Messages/LocationMessage.swift
+++ b/Library/Mesh Messages/LocationMessage.swift
@@ -40,8 +40,8 @@ public protocol LocationStatusMessage: MeshMessage {
     var altitude: Altitude { get }
 }
 
-/// The representation of latitide coordinate.
-public enum Latitude {
+/// The representation of latitude coordinate.
+public enum Latitude: Sendable {
     init(raw parameter: Int32) {
         if (parameter == -1) {
             self = .notConfigured
@@ -87,7 +87,7 @@ public enum Latitude {
 }
 
 /// The representation of longitude coordinate.
-public enum Longitude {
+public enum Longitude: Sendable {
     init(raw parameter: Int32) {
         if (parameter == -1) {
             self = .notConfigured
@@ -133,7 +133,7 @@ public enum Longitude {
 }
 
 /// The representation of altitude above see level.
-public enum Altitude : Equatable {
+public enum Altitude: Equatable, Sendable {
     init(raw parameter: Int16) {
         if (parameter == 0x7FFF) {
             self = .notConfigured

--- a/Library/Mesh Messages/MeshMessage.swift
+++ b/Library/Mesh Messages/MeshMessage.swift
@@ -43,7 +43,7 @@ import Foundation
 /// For unsegmented messages, the size of the TransMIC is 32 bits for data messages.
 ///
 /// Control messages do not have a TransMIC.
-public enum MeshMessageSecurity {
+public enum MeshMessageSecurity: Sendable {
     /// Message will be sent with 32-bit Transport MIC.
     case low
     /// Message will be sent with 64-bit Transport MIC.
@@ -54,7 +54,7 @@ public enum MeshMessageSecurity {
 
 /// The base class of every mesh message. Mesh messages can be sent to and
 /// received from a mesh network.
-public protocol BaseMeshMessage {
+public protocol BaseMeshMessage: Sendable {
     /// Access Layer payload, including the Op Code.
     var parameters: Data? { get }
     

--- a/Library/Mesh Messages/RemoteProvisioningMessage.swift
+++ b/Library/Mesh Messages/RemoteProvisioningMessage.swift
@@ -53,7 +53,7 @@ public protocol AcknowledgedRemoteProvisioningMessage: RemoteProvisioningMessage
 }
 
 /// The status of a Config operation.
-public enum RemoteProvisioningMessageStatus: UInt8 {
+public enum RemoteProvisioningMessageStatus: UInt8, Sendable {
     /// Success.
     case success                            = 0x00
     /// Scanning Cannot Start.
@@ -111,7 +111,7 @@ public extension RemoteProvisioningStatusMessage {
 
 /// The Remote Provisioning Scan state describes the state of the Remote Provisioning
 /// Scan procedure in the Remote Provisioning Server model.
-public enum RemoteProvisioningScanState: UInt8 {
+public enum RemoteProvisioningScanState: UInt8, Sendable {
     /// Idle.
     case idle               = 0x00
     /// Remote Provisioning Multiple Devices Scan (not limited to one device).
@@ -125,7 +125,7 @@ public enum RemoteProvisioningScanState: UInt8 {
 ///
 /// During the execution of any of the Node Provisioning Protocol Interface procedures,
 /// the Link Opening, Outbound Packet Transfer, and Link Closing values are not used.
-public enum RemoteProvisioningLinkState: UInt8 {
+public enum RemoteProvisioningLinkState: UInt8, Sendable {
     /// Idle.
     case idle                   = 0x00
     /// Link Opening.
@@ -139,7 +139,7 @@ public enum RemoteProvisioningLinkState: UInt8 {
 }
 
 /// Provisioning bearer link close reason.
-public enum RemoteProvisioningLinkCloseReason: UInt8 {
+public enum RemoteProvisioningLinkCloseReason: UInt8, Sendable {
     /// Success.
     case success      = 0x00
     // Value 0x01 is prohibited.
@@ -152,7 +152,7 @@ public enum RemoteProvisioningLinkCloseReason: UInt8 {
 /// The Node Provisioning Protocol Interface is an interface used by the Node
 /// to route the Provisioning PDUs between the Provisioner and the layer that
 /// is executing the provisioning protocol.
-public enum NodeProvisioningProtocolInterfaceProcedure: UInt8 {
+public enum NodeProvisioningProtocolInterfaceProcedure: UInt8, Sendable {
     /// The Device Key Refresh procedure is used to change the Device Key
     /// without reprovisioning a Node and without a need to reconfigure the Node.
     ///
@@ -189,7 +189,7 @@ public enum NodeProvisioningProtocolInterfaceProcedure: UInt8 {
 /// - note: This list does not contain Incomplete Lists of Service Class UUIDs and
 ///         Shortened Local Name AD Types, as those are not supported in
 ///         ``RemoteProvisioningExtendedScanStart`` message.
-internal enum AdType: UInt8 {
+internal enum AdType: UInt8, Sendable {
     case localName     = 0x09
     case txPowerLevel  = 0x0A
     case uri           = 0x24
@@ -271,7 +271,7 @@ public struct AdTypes {
 }
 
 /// An Advertising Structure.
-public struct AdStructure {
+public struct AdStructure: Sendable {
     /// The AD Type associated with the value.
     public let type: UInt8
     /// The value.

--- a/Library/Mesh Messages/SchedulerMessage.swift
+++ b/Library/Mesh Messages/SchedulerMessage.swift
@@ -32,7 +32,7 @@ import Foundation
 
 /// Scheduler Registry entry contains the time information,
 /// the scheduler action and Scene Number.
-public struct SchedulerRegistryEntry {
+public struct SchedulerRegistryEntry: Sendable {
     public let year: SchedulerYear
     public let month: SchedulerMonth
     public let day: SchedulerDay
@@ -78,7 +78,7 @@ public struct SchedulerRegistryEntry {
 // MARK: Structures to represent scheduler entry properties.
 
 /// The scheduler year.
-public struct SchedulerYear {
+public struct SchedulerYear: Sendable {
     /// The year in a century.
     ///
     /// This filed contains a 2-digit value in a century. E.g. a year 1985 is stored as 85.
@@ -116,7 +116,7 @@ public enum Month: UInt16 {
 }
 
 /// The scheduler month bit field.
-public struct SchedulerMonth {
+public struct SchedulerMonth: Sendable {
     /// A bit field representing scheduler months.
     public let value: UInt16 // 12 bits
     
@@ -127,7 +127,7 @@ public struct SchedulerMonth {
 }
 
 /// The scheduler day.
-public struct SchedulerDay {
+public struct SchedulerDay: Sendable {
     /// The 5-bit field representing a day number.
     public let value: UInt8 // 5 bits
 
@@ -143,7 +143,7 @@ public struct SchedulerDay {
 }
 
 /// The scheduler hour.
-public struct SchedulerHour {
+public struct SchedulerHour: Sendable {
     /// The 5-bit field representing a hour number.
     public let value: UInt8 // 5 bits
 
@@ -164,7 +164,7 @@ public struct SchedulerHour {
 }
 
 /// The scheduler month.
-public struct SchedulerMinute {
+public struct SchedulerMinute: Sendable {
     /// The 6-bit field representing a minute number.
     public let value: UInt8 // 6 bits
 
@@ -195,7 +195,7 @@ public struct SchedulerMinute {
 }
 
 /// The scheduler second.
-public struct SchedulerSecond {
+public struct SchedulerSecond: Sendable {
     /// The 6-bit field representing a second number.
     public let value: UInt8 // 6 bits
 
@@ -237,7 +237,7 @@ public enum WeekDay: UInt8 {
 }
 
 /// The scheduler day of week.
-public struct SchedulerDayOfWeek {
+public struct SchedulerDayOfWeek: Sendable {
     /// A 7-bit long bit field representation of week days.
     public let value: UInt8 // 7 bits
     
@@ -248,14 +248,14 @@ public struct SchedulerDayOfWeek {
 }
 
 /// The scheduler action enumeration as defined in Mesh Model specification..
-public enum SchedulerAction: UInt8 {
+public enum SchedulerAction: UInt8, Sendable {
     case turnOff     = 0x00
     case turnOn      = 0x01
     case sceneRecall = 0x02
     case noAction    = 0x0F
 }
 
-// MARK: Marshalling
+// MARK: Marshaling
 
 /// Entry is encoded with multiple bitfields to pack data as densely as possible.
 /// Below are the fields in order, with the number of bits each one occupies.

--- a/Library/Mesh Messages/SensorMessage.swift
+++ b/Library/Mesh Messages/SensorMessage.swift
@@ -93,7 +93,7 @@ public struct SensorDescriptor: Sendable {
     /// For those cases where a value for the Sensor Update Interval is
     /// not available or is not applicable, a special number has been assigned
     /// to indicate Not Applicable equal to 0.
-    /// - seeAlso: ``SensorDescriptor/updateInteval``
+    /// - seeAlso: ``SensorDescriptor/updateInterval``
     internal let updateIntervalValue: UInt8
     
     /// Whether the positive tolerance is specified.
@@ -117,7 +117,7 @@ public struct SensorDescriptor: Sendable {
     }
     /// The update interval in seconds, or `nil`, if update interval is
     /// not available or is not applicable.
-    public var updateInteval: TimeInterval? {
+    public var updateInterval: TimeInterval? {
         if updateIntervalValue == 0 {
             return nil
         }

--- a/Library/Mesh Messages/SensorMessage.swift
+++ b/Library/Mesh Messages/SensorMessage.swift
@@ -39,7 +39,7 @@ public protocol SensorPropertyMessage: MeshMessage {
 /// The Sensor Descriptor state represents the attributes describing the
 /// sensor data. This state does not change throughout the lifetime of an
 /// Element.
-public struct SensorDescriptor {
+public struct SensorDescriptor: Sendable {
     /// The Sensor Property describes the meaning and the format of data
     /// reported by a sensor.
     public let property: DeviceProperty
@@ -100,7 +100,7 @@ public struct SensorDescriptor {
     public var isPositiveToleranceSpecified: Bool {
         return positiveTolerance > 0
     }
-    /// Whether the negatove tolerance is specified.
+    /// Whether the negative tolerance is specified.
     public var isNegativeToleranceSpecified: Bool {
         return negativeTolerance > 0
     }
@@ -184,7 +184,7 @@ public struct SensorDescriptor {
         }
         let propertyId: UInt16 = parameters.read(fromOffset: offset)
         self.property = DeviceProperty(propertyId)
-        // Decode two 12-bit tolerace values from 2 bytes.
+        // Decode two 12-bit tolerance values from 2 bytes.
         self.positiveTolerance = UInt16(parameters[offset + 3] & 0x0F) << 8 | UInt16(parameters[offset + 2])
         self.negativeTolerance = UInt16(parameters[offset + 4]) << 4 | UInt16(parameters[offset + 3] >> 4)
         guard let function = SensorSamplingFunction(rawValue: parameters[offset + 5]) else {
@@ -197,7 +197,7 @@ public struct SensorDescriptor {
 }
 
 /// Enumeration of sensor sampling functions.
-public enum SensorSamplingFunction: UInt8 {
+public enum SensorSamplingFunction: UInt8, Sendable {
     /// Sampling function is not made available.
     case unspecified    = 0x00
     /// The presented value is an instantaneous sample.
@@ -228,14 +228,14 @@ public enum SensorSamplingFunction: UInt8 {
 }
 
 /// The structure of sensor cadence.
-public struct SensorCadence {
+public struct SensorCadence: Sendable {
     
     /// The Status Trigger Delta controls the positive and negative
     /// change of a measured quantity that triggers more rapid publication of
     /// a Sensor Status message.
     ///
     /// Depending on the Sensor Trigger Type value, the
-    public enum StatusTriggerDelta {
+    public enum StatusTriggerDelta: Sendable {
         /// The delta type and unit is defined by the Format Type of the characteristic
         /// of the Sensor Property.
         case values(down: DevicePropertyCharacteristic, up: DevicePropertyCharacteristic)

--- a/Library/Mesh Messages/Sensors/SensorDescriptorStatus.swift
+++ b/Library/Mesh Messages/Sensors/SensorDescriptorStatus.swift
@@ -34,7 +34,7 @@ public struct SensorDescriptorStatus: StaticMeshResponse {
     public static let opCode: UInt32 = 0x51
     
     /// The result returned in Sensor Descriptor Status message.
-    public enum Result {
+    public enum Result: Sendable {
         /// List of sensor descriptors returned in the response.
         ///
         /// If Sensor Descriptor Get was sent with the ``SensorDescriptorGet/property``
@@ -42,7 +42,7 @@ public struct SensorDescriptorStatus: StaticMeshResponse {
         /// found on the target Element. Otherwise, in case the requested property
         /// was found, this list will contain only the requested descriptor.
         case descriptors([SensorDescriptor])
-        /// The Propery was not found on the Element.
+        /// The Property was not found on the Element.
         ///
         /// This result is returned when a Sensor Descriptor Get was sent with
         /// a ``SensorDescriptorGet/property`` parameter that does not exist on the

--- a/Library/Mesh Messages/Sensors/SensorSettingStatus.swift
+++ b/Library/Mesh Messages/Sensors/SensorSettingStatus.swift
@@ -35,7 +35,7 @@ public struct SensorSettingStatus: StaticMeshResponse, SensorPropertyMessage {
     
     /// The Sensor Setting Access field is an enumeration indicating whether
     /// the device property can be read or written.
-    public enum SensorSettingAccess: UInt8 {
+    public enum SensorSettingAccess: UInt8, Sendable {
         /// The device property can be read.
         case readonly  = 0x01
         /// The device property can be read and written.

--- a/Library/Mesh Messages/TimeMessage.swift
+++ b/Library/Mesh Messages/TimeMessage.swift
@@ -40,14 +40,14 @@ public protocol TimeMessage: MeshMessage {
 ///
 /// Mesh defines times based on International Atomic Time (TAI). The base representation of times is the number of
 /// seconds after 00:00:00 TAI on 2000-01-01 (that is, 1999-12-31T23:59:28 Coordinated Universal Time (UTC)).
-public struct TaiTime {
+public struct TaiTime: Sendable {
     /// The current TAI time in seconds after the epoch 2000-01-01T00:00:00 TAI (1999-12-31T23:59:28 UTC).
     public let seconds: UInt64
     /// The sub-second time in units of 1/256th second.
     public let subSecond: UInt8
     /// The estimated uncertainty in 10-millisecond steps.
     public let uncertainty: UInt8
-    /// Whether this time is authorative (from a "known good" source, such as GPS or NTP).
+    /// Whether this time is authoritative (from a "known good" source, such as GPS or NTP).
     public let authority: Bool
     /// Current difference between TAI and UTC in seconds (range -255 to 32512).
     public let taiDelta: Int16
@@ -57,7 +57,7 @@ public struct TaiTime {
     /// Creates an unknown TAI time.
     ///
     /// When an element cannot determine the time with the accuracy necessary for the implementation,
-    /// a special value of 0 seonds shall be used.
+    /// a special value of 0 seconds shall be used.
     public init() {
         self.seconds = 0
         self.subSecond = 0
@@ -73,7 +73,7 @@ public struct TaiTime {
     ///   - seconds: The current TAI time in seconds.
     ///   - subSecond: The sub-second time in units of 1/256th second.
     ///   - uncertainty: The estimated uncertainty in 10-millisecond steps.
-    ///   - authority: Whether this time is authorative (from a "known good" source, such as GPS or NTP).
+    ///   - authority: Whether this time is authoritative (from a "known good" source, such as GPS or NTP).
     ///   - taiDelta: Current difference between TAI and UTC in seconds (range -255 to 32512).
     ///   - tzOffset: The Local time zone offset.
     public init(seconds: UInt64, subSecond: UInt8,
@@ -88,7 +88,7 @@ public struct TaiTime {
     }
     
     /// When an element cannot determine the time with the accuracy necessary for the implementation,
-    /// a special value of 0 seonds shall be used, in which case this property returns `false`.
+    /// a special value of 0 seconds shall be used, in which case this property returns `false`.
     public var isKnown: Bool {
         return seconds > 0
     }
@@ -146,7 +146,7 @@ extension TaiTime {
     
     /// Marshals the TAI Time to raw bytes.
     ///
-    /// - parameter time: The TAI time to marshall.
+    /// - parameter time: The TAI time to marshal.
     /// - returns: The raw bytes of length 10.
     public static func marshal(_ time: TaiTime) -> Data {
         var data = Data(count: 10)

--- a/Library/Mesh Model/Element.swift
+++ b/Library/Mesh Model/Element.swift
@@ -91,49 +91,6 @@ public class Element: Codable {
         self.index = 0
     }
     
-    internal init?(compositionData: Data, offset: inout Int) {
-        // Composition Data must have at least 4 bytes: 2 for Location and one for NumS and NumV.
-        guard compositionData.count >= offset + 4 else {
-            return nil
-        }
-        // Is Location valid?
-        let rawValue: UInt16 = compositionData.read(fromOffset: offset)
-        guard let location = Location(rawValue: rawValue) else {
-            return nil
-        }
-        self.location = location
-        
-        // Read NumS and NumV.
-        let sigModelsByteCount    = Int(compositionData[offset + 2]) * 2 // SIG Model ID is 16-bit long.
-        let vendorModelsByteCount = Int(compositionData[offset + 3]) * 4 // Vendor Model ID is 32-bit long.
-        
-        // Ensure the Composition Data have enough data.
-        guard compositionData.count >= offset + 3 + sigModelsByteCount + vendorModelsByteCount else {
-            return nil
-        }
-        // 4 bytes have been read.
-        offset += 4
-        
-        // Set temporary index.
-        // Final index will be set when Element is added to the Node.
-        self.index = 0
-        
-        // Read models.
-        self.models = []
-        for o in stride(from: offset, to: offset + sigModelsByteCount, by: 2) {
-            let sigModelId: UInt16 = compositionData.read(fromOffset: o)
-            add(model: Model(sigModelId: sigModelId))
-        }
-        offset += sigModelsByteCount
-        
-        for o in stride(from: offset, to: offset + vendorModelsByteCount, by: 4) {
-            let companyId: UInt16 = compositionData.read(fromOffset: o)
-            let vendorModelId: UInt16 = compositionData.read(fromOffset: o + 2)
-            add(model: Model(vendorModelId: vendorModelId, companyId: companyId))
-        }
-        offset += vendorModelsByteCount
-    }
-    
     internal init(copy element: Element,
                   andTruncateTo applicationKeys: [ApplicationKey], nodes: [Node], groups: [Group]) {
         self.name = element.name

--- a/Library/Mesh Model/KeyRefreshPhase.swift
+++ b/Library/Mesh Model/KeyRefreshPhase.swift
@@ -31,7 +31,7 @@
 import Foundation
 
 /// The type representing Key Refresh phase.
-public enum KeyRefreshPhase: Int, Codable {
+public enum KeyRefreshPhase: Int, Codable, Sendable {
     /// Phase 0: Normal Operation.
     case normalOperation = 0
     /// Phase 1: Distributing new keys to all nodes. Nodes will transmit using
@@ -57,7 +57,7 @@ public enum KeyRefreshPhase: Int, Codable {
 }
 
 /// The type representing Key Refresh phase transition.
-public enum KeyRefreshPhaseTransition: UInt8 {
+public enum KeyRefreshPhaseTransition: UInt8, Sendable {
     /// The Node will start encoding messages using the new keys,
     /// but will continue to decode using the old and new keys.
     /// The Node will only accept beacons secured using the new

--- a/Library/Mesh Model/Location.swift
+++ b/Library/Mesh Model/Location.swift
@@ -36,7 +36,7 @@ import Foundation
 ///
 /// Imported from:
 /// https://www.bluetooth.com/specifications/assigned-numbers -> GATT Namespace Descriptors
-public enum Location: UInt16, Codable {
+public enum Location: UInt16, Codable, Sendable {
     case auxiliary                    = 0x0108
     case back                         = 0x0101
     case backup                       = 0x0107

--- a/Library/Mesh Model/Node.swift
+++ b/Library/Mesh Model/Node.swift
@@ -886,22 +886,20 @@ internal extension Node {
         // Don't override features if they already were known.
         // Accurate features states could have been acquired by reading each feature state,
         // while the Page 0 of the Composition Data contains only Supported / Not Supported.
-        if let features { // `NodeFeaturesState` is a reference type
-            features.applyMissing(from: page0.features)
+        if features != nil {
+            features?.applyMissing(from: page0.features)
         } else {
             features = page0.features
         }
         // And set the Elements received.
-        set(elements: page0.elements)
-        meshNetwork?.timestamp = Date()
-    }
-    
-    var ensureFeatures: NodeFeaturesState {
-        if features == nil {
-            features = NodeFeaturesState()
+        let elements = page0.elements.map { element in
+            let models = element.models.map { model in
+                return Model(modelId: model.modelId)
+            }
+            return Element(location: element.location, models: models)
         }
+        set(elements: elements)
         meshNetwork?.timestamp = Date()
-        return features!
     }
     
 }

--- a/Library/Mesh Model/NodeFeatures.swift
+++ b/Library/Mesh Model/NodeFeatures.swift
@@ -62,7 +62,7 @@ public enum NodeFeature: String, Codable {
 }
 
 /// A set of currently active features of a Node.
-public struct NodeFeatures: OptionSet {
+public struct NodeFeatures: OptionSet, Sendable {
     public let rawValue: UInt16
     
     /// If present, the ``NodeFeatures/relay`` feature is enabled on the Node.
@@ -99,7 +99,7 @@ public struct NodeFeatures: OptionSet {
 /// The state of a feature.
 ///
 /// A Node can have features enabled, disabled, or may not support one.
-public enum NodeFeatureState: UInt8, Codable {
+public enum NodeFeatureState: UInt8, Codable, Sendable {
     /// The feature is disabled.
     case notEnabled   = 0
     /// The feature is enabled.

--- a/Library/Mesh Model/NodeFeatures.swift
+++ b/Library/Mesh Model/NodeFeatures.swift
@@ -110,7 +110,7 @@ public enum NodeFeatureState: UInt8, Codable, Sendable {
 
 /// The features state object represents the functionality of a mesh node
 /// that is determined by the set features that the node supports.
-public class NodeFeaturesState: Codable {
+public struct NodeFeaturesState: Codable, Sendable {
     /// The state of Relay feature or `nil` if unknown.
     public internal(set) var relay: NodeFeatureState?
     /// The state of Proxy feature or `nil` if unknown.
@@ -169,7 +169,7 @@ public class NodeFeaturesState: Codable {
         self.lowPower = mask & 0x08 == 0 ? .notSupported : .enabled
     }
     
-    internal func applyMissing(from other: NodeFeaturesState) {
+    internal mutating func applyMissing(from other: NodeFeaturesState) {
         if self.friend == nil {
             self.friend = other.friend
         }

--- a/Library/Mesh Model/NodeIdentityState.swift
+++ b/Library/Mesh Model/NodeIdentityState.swift
@@ -33,7 +33,7 @@ import Foundation
 /// The Node Identity state determines if a node is advertising with Node Identity
 /// messages on a subnet. If the Mesh Proxy Service is exposed, the node can be
 /// configured to advertise with Node Identity on a subnet.
-public enum NodeIdentityState: UInt8 {
+public enum NodeIdentityState: UInt8, Sendable {
     /// Advertising with Node Identity for a subnet is stopped.
     case stopped      = 0x00
     /// Advertising with Node Identity for a subnet is running.

--- a/Library/Mesh Model/OnPowerUp.swift
+++ b/Library/Mesh Model/OnPowerUp.swift
@@ -31,7 +31,7 @@
 import Foundation
 
 /// The enumeration for different actions for On Power Up state.
-public enum OnPowerUp: UInt8 {
+public enum OnPowerUp: UInt8, Sendable {
     case off       = 0x00
     case `default` = 0x01
     case restore   = 0x02

--- a/Library/Mesh Model/Publish.swift
+++ b/Library/Mesh Model/Publish.swift
@@ -39,7 +39,7 @@ import Foundation
 /// To set the publication on a Model, send the ``ConfigModelPublicationSet`` or
 /// ``ConfigModelPublicationVirtualAddressSet`` messages to the Configuration Server model
 /// on the Node. The *Set* messages are confirmed with a ``ConfigModelPublicationStatus``.
-public struct Publish: Codable, Equatable {
+public struct Publish: Codable, Equatable, Sendable {
     /// The configuration for disabling publication.
     ///
     /// - since: 3.0
@@ -47,7 +47,7 @@ public struct Publish: Codable, Equatable {
     
     /// The object is used to describe the number of times a message is published and
     /// the interval between retransmissions of the published message.
-    public struct Retransmit: Codable, Equatable {
+    public struct Retransmit: Codable, Equatable, Sendable {
         /// Retransmission of published messages is disabled.
         ///
         /// - since: 3.0
@@ -104,7 +104,7 @@ public struct Publish: Codable, Equatable {
     /// are periodically published by a Model.
     ///
     /// - since: 3.0
-    public struct Period: Codable, Equatable {
+    public struct Period: Codable, Equatable, Sendable {
         /// Periodic publishing of status messages is disabled.
         ///
         /// - since: 3.0

--- a/Library/Mesh Model/StepResolution.swift
+++ b/Library/Mesh Model/StepResolution.swift
@@ -32,7 +32,7 @@ import Foundation
 
 /// The Step Resolution field enumerates the resolution of the Number of Steps field
 /// in ``TransitionTime`` or ``Publish/Period-swift.struct``.
-public enum StepResolution: UInt8 {
+public enum StepResolution: UInt8, Sendable {
     /// The Step Resolution is 100 milliseconds.
     case hundredsOfMilliseconds = 0b00
     /// The Step Resolution is 1 second.

--- a/Library/Mesh Model/TransitionTime.swift
+++ b/Library/Mesh Model/TransitionTime.swift
@@ -35,7 +35,7 @@ import Foundation
 ///
 /// Internally, it uses steps and step resolution. Thanks to that only some time
 /// intervals are possible. Use ``TransitionTime/interval`` to get exact time
-public struct TransitionTime {
+public struct TransitionTime: Sendable {
     /// Transition Number of Steps, 6-bit value.
     ///
     /// Value 0 indicates an immediate transition.

--- a/Library/Provisioning/Algorithm.swift
+++ b/Library/Provisioning/Algorithm.swift
@@ -31,7 +31,7 @@
 import Foundation
 
 /// The algorithm used for calculating Device Key.
-public enum Algorithm {
+public enum Algorithm: Sendable {
     /// FIPS P-256 Elliptic Curve algorithm will be used to calculate the
     /// shared secret.
     ///
@@ -75,7 +75,7 @@ extension Algorithm: CustomDebugStringConvertible {
 }
 
 /// A set of algorithms supported by the Unprovisioned Device.
-public struct Algorithms: OptionSet {
+public struct Algorithms: OptionSet, Sendable {
     public let rawValue: UInt16
     
     /// BTM_ECDH_P256_CMAC_AES128_AES_CCM algorithm is supported.

--- a/Library/Provisioning/Oob.swift
+++ b/Library/Provisioning/Oob.swift
@@ -33,7 +33,7 @@ import CoreBluetooth
 
 /// Information that points to Out-Of-Band (OOB) information
 /// needed for provisioning.
-public struct OobInformation: OptionSet {
+public struct OobInformation: OptionSet, Sendable {
     public let rawValue: UInt16
     
     public static let other          = OobInformation(rawValue: 1 << 0)
@@ -77,7 +77,7 @@ public struct OobInformation: OptionSet {
 }
 
 /// The authentication method chosen for provisioning.
-public enum AuthenticationMethod {
+public enum AuthenticationMethod: Sendable {
     /// No OOB authentication.
     ///
     /// - warning: This method is considered not secure.
@@ -120,7 +120,7 @@ public enum AuthenticationMethod {
 /// For example,if the Unprovisioned Device is a light, then it would blink random
 /// number of times. That number should be provided to
 /// ``ProvisioningDelegate/authenticationActionRequired(_:)``.
-public enum OutputAction: UInt8 {
+public enum OutputAction: UInt8, Sendable {
     case blink              = 0
     case beep               = 1
     case vibrate            = 2
@@ -134,7 +134,7 @@ public enum OutputAction: UInt8 {
 /// the user to input the random number by pressing a button an appropriate number
 /// of times. When the action is complete, ``ProvisioningDelegate/inputComplete()``
 /// will be called.
-public enum InputAction: UInt8 {
+public enum InputAction: UInt8, Sendable {
     case push               = 0
     case twist              = 1
     case inputNumeric       = 2
@@ -170,7 +170,7 @@ open class InputActionValueGenerator {
 }
 
 /// A set of supported Out-Of-Band types.
-public struct OobType: OptionSet {
+public struct OobType: OptionSet, Sendable {
     public let rawValue: UInt8
     
     /// Static OOB Information is available.
@@ -187,7 +187,7 @@ public struct OobType: OptionSet {
 }
 
 /// A set of supported Output Out-of-band actions.
-public struct OutputOobActions: OptionSet {
+public struct OutputOobActions: OptionSet, Sendable {
     public let rawValue: UInt16
     
     public static let blink              = OutputOobActions(rawValue: 1 << 0)
@@ -203,7 +203,7 @@ public struct OutputOobActions: OptionSet {
 }
 
 /// A set of supported Input Out-of-band actions.
-public struct InputOobActions: OptionSet {
+public struct InputOobActions: OptionSet, Sendable {
     public let rawValue: UInt16
     
     public static let push              = InputOobActions(rawValue: 1 << 0)

--- a/Library/Provisioning/ProvisioningCapabilities.swift
+++ b/Library/Provisioning/ProvisioningCapabilities.swift
@@ -32,7 +32,7 @@ import Foundation
 
 /// The device sends this PDU to indicate its supported provisioning
 /// capabilities to a Provisioner.
-public struct ProvisioningCapabilities {
+public struct ProvisioningCapabilities: Sendable {
     /// Number of elements supported by the device.
     public let numberOfElements: UInt8
     /// Supported algorithms and other capabilities.

--- a/Library/Provisioning/ProvisioningPdu.swift
+++ b/Library/Provisioning/ProvisioningPdu.swift
@@ -69,7 +69,7 @@ internal enum ProvisioningPduType: UInt8 {
 }
 
 /// Provisioning requests are sent by the Provisioner to an unprovisioned device.
-public enum ProvisioningRequest {
+public enum ProvisioningRequest: Sendable {
     /// A Provisioner sends a Provisioning Invite PDU to indicate to the intended
     /// Provisionee that the provisioning process is starting.
     case invite(attentionTimer: UInt8)
@@ -138,7 +138,7 @@ public enum ProvisioningRequest {
 
 /// Provisioning responses are sent by the Provisionee to the Provisioner
 /// as a response to ``ProvisioningRequest``.
-public enum ProvisioningResponse {
+public enum ProvisioningResponse: Sendable {
     /// The Provisionee sends a Provisioning Capabilities PDU to indicate its
     /// supported provisioning capabilities to a Provisioner.
     case capabilities(_ capabilities: ProvisioningCapabilities)

--- a/Library/Provisioning/ProvisioningState.swift
+++ b/Library/Provisioning/ProvisioningState.swift
@@ -79,7 +79,7 @@ public enum ProvisioningError: Error {
 
 /// Set of errors which may be reported by an unprovisioned device
 /// during provisioning process.
-public enum RemoteProvisioningError: UInt8 {
+public enum RemoteProvisioningError: UInt8, Sendable {
     /// The provisioning protocol PDU is not recognized by the device.
     case invalidPdu            = 1
     /// The arguments of the protocol PDUs are outside expected values
@@ -105,13 +105,13 @@ public enum RemoteProvisioningError: UInt8 {
 
 /// A set of authentication actions aiming to strengthen device provisioning
 /// security.
-public enum AuthAction {
+public enum AuthAction: Sendable {
     /// The user shall provide 16 byte OOB Static Key.
-    case provideStaticKey(callback: (Data) -> Void)
+    case provideStaticKey(callback: @Sendable (Data) -> Void)
     /// The user shall provide a number.
-    case provideNumeric(maximumNumberOfDigits: UInt8, outputAction: OutputAction, callback: (UInt) -> Void)
+    case provideNumeric(maximumNumberOfDigits: UInt8, outputAction: OutputAction, callback: @Sendable (UInt) -> Void)
     /// The user shall provide an alphanumeric text.
-    case provideAlphanumeric(maximumNumberOfCharacters: UInt8, callback: (String) -> Void)
+    case provideAlphanumeric(maximumNumberOfCharacters: UInt8, callback: @Sendable (String) -> Void)
     /// The application should display this number to the user.
     /// User should perform selected action given number of times,
     /// or enter the number on the remote device.

--- a/Library/Provisioning/PublicKey.swift
+++ b/Library/Provisioning/PublicKey.swift
@@ -34,7 +34,7 @@ import Foundation
 ///
 /// This enumeration is used to specify the Public Key type during provisioning
 /// in ``ProvisioningManager/provision(usingAlgorithm:publicKey:authenticationMethod:)``.
-public enum PublicKey {
+public enum PublicKey: Sendable {
     /// No OOB Public Key is used.
     case noOobPublicKey
     /// OOB Public Key is used. The key must contain the full value of the Public Key,
@@ -69,7 +69,7 @@ extension PublicKey: CustomDebugStringConvertible {
 ///
 /// This enumeration is used in ``ProvisioningRequest/start(algorithm:publicKey:authenticationMethod:)``
 /// to encode the selected Public Key type.
-public enum PublicKeyMethod {
+public enum PublicKeyMethod: Sendable {
     /// No OOB Public Key is used.
     case noOobPublicKey
     /// OOB Public Key is used. The key must contain the full value of the Public Key,
@@ -91,7 +91,7 @@ extension PublicKeyMethod: CustomDebugStringConvertible {
 }
 
 /// The type of Public Key information.
-public struct PublicKeyType: OptionSet {
+public struct PublicKeyType: OptionSet, Sendable {
     public let rawValue: UInt8
     
     /// Public Key OOB Information is available.

--- a/Library/ProxyFilter.swift
+++ b/Library/ProxyFilter.swift
@@ -31,7 +31,7 @@
 import Foundation
 
 /// A type of the Proxy Filter.
-public enum ProxyFilerType {
+public enum ProxyFilerType: Sendable {
     /// An accept list filter has an associated accept list containing
     /// destination addresses that are of interest for the Proxy Client.
     ///


### PR DESCRIPTION
Xcode 16.2 started giving warnings about concurrency issues, including requirements for objects passed to `DispatchQueue.async` to be `Senndable`.
Read more here: https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/dataracesafety

This PR makes all `MeshMessage`es, their subtypes and parameters `Sendable`. They were value types even before (`struct`s), so there should be no issues with that.

In few places some API changes had to be done:
1. In `CompositionData` `Page0` the `Element` and `Model` got new model types instead of using the mesh model types. This is just to make them immutable. The parameter names were left intact, so there should be no API changes requires unless one explicitly had used: 
   ```swift
   let elements: [Element] = page0.elements
   ```
   The type is now `ElementData` and similarly `ModelData`.
2. 2 typos were fixed:
   - In `SensorMessage`: `updateInteval` -> `updateInterval` (missing `r`)
   - In `HealthFaultEnum`: `powerSupplyInterrputedError` -> `powerSupplyInterruptedError` (`pu` -> `up`)