### PR TITLE
Bugfix: Setting correct state value when animation ends

### DIFF
--- a/Example/Source/Mesh Network/GenericState.swift
+++ b/Example/Source/Mesh Network/GenericState.swift
@@ -183,7 +183,7 @@ extension GenericState where T: BinaryInteger {
     init(animateFrom state: GenericState<T>, to targetValue: T,
          delay: TimeInterval, duration: TimeInterval?,
          storedWithScene: Bool = false) {
-        self.value = state.value
+        self.value = state.currentValue
         self.transition = nil
         self.storedWithScene = storedWithScene
         guard let duration = duration,

--- a/Example/Source/View Controllers/Control/Model/GenericLevelServerCell.swift
+++ b/Example/Source/View Controllers/Control/Model/GenericLevelServerCell.swift
@@ -103,7 +103,7 @@ class GenericLevelServerCell: BaseModelControlCell<GenericLevelServerDelegate> {
         let duration: TimeInterval = 2 * Double(Int16.max) / abs(Double(speed))
         
         progress.frame = CGRect(x: 0, y: height - currentHeight,
-                                     width: width, height: currentHeight)
+                                width: width, height: currentHeight)
         UIView.animate(withDuration: duration, delay: 0,
                        options: .curveLinear, animations: { [weak self] in
             guard let self = self else { return }

--- a/Library/ModelDelegate.swift
+++ b/Library/ModelDelegate.swift
@@ -262,10 +262,10 @@ public class TransactionHelper {
         return mutex.sync {
             let lastTransaction = self.lastTransactions[message.opCode]
             let isNew = lastTransaction == nil ||
-            lastTransaction!.source != source ||
-            lastTransaction!.destination != destination ||
-            message.isNewTransaction(previousTid: lastTransaction!.tid,
-                                     timestamp: lastTransaction!.timestamp)
+                        lastTransaction!.source != source ||
+                        lastTransaction!.destination != destination ||
+                        message.isNewTransaction(previousTid: lastTransaction!.tid,
+                                                 timestamp: lastTransaction!.timestamp)
             
             self.lastTransactions[message.opCode] = (
                 source: source, destination: destination,


### PR DESCRIPTION
## Before

When a state was animated (e.g. with `GenericLevelMoveSetUnacknowledged`) and a new animation was started, or the animation was stopped, the value of `state` was set to the value it had when the animation was started, not the current value at the moment when it was stopped.

## After

The new `state` is set to the correct, current value of the old `state`.