### PR TITLE
Health messages and Health Server model support

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -569,6 +569,7 @@
 		F0D9EEEB2D47C97F0063AF3E /* HealthAttentionSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEEA2D47C97F0063AF3E /* HealthAttentionSet.swift */; };
 		F0D9EEEF2D4898C00063AF3E /* HealthAttentionSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEEE2D4898C00063AF3E /* HealthAttentionSetUnacknowledged.swift */; };
 		F0D9EEF12D4899B40063AF3E /* HealthAttentionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEF02D4899B40063AF3E /* HealthAttentionStatus.swift */; };
+		F0D9EEF32D489E450063AF3E /* HealthServerHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEF22D489E450063AF3E /* HealthServerHandler.swift */; };
 		F0D9FBB72D3A844300031E7E /* FirmwareUpdateFirmwareMetadataCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9FBB62D3A844300031E7E /* FirmwareUpdateFirmwareMetadataCheck.swift */; };
 		F0D9FBB92D3A869800031E7E /* FirmwareUpdateFirmwareMetadataStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9FBB82D3A869800031E7E /* FirmwareUpdateFirmwareMetadataStatus.swift */; };
 		F0D9FBBB2D3A985B00031E7E /* FirmwareUpdateMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9FBBA2D3A984700031E7E /* FirmwareUpdateMessage.swift */; };
@@ -1243,6 +1244,7 @@
 		F0D9EEEA2D47C97F0063AF3E /* HealthAttentionSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthAttentionSet.swift; sourceTree = "<group>"; };
 		F0D9EEEE2D4898C00063AF3E /* HealthAttentionSetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthAttentionSetUnacknowledged.swift; sourceTree = "<group>"; };
 		F0D9EEF02D4899B40063AF3E /* HealthAttentionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthAttentionStatus.swift; sourceTree = "<group>"; };
+		F0D9EEF22D489E450063AF3E /* HealthServerHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthServerHandler.swift; sourceTree = "<group>"; };
 		F0D9FBB62D3A844300031E7E /* FirmwareUpdateFirmwareMetadataCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareUpdateFirmwareMetadataCheck.swift; sourceTree = "<group>"; };
 		F0D9FBB82D3A869800031E7E /* FirmwareUpdateFirmwareMetadataStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareUpdateFirmwareMetadataStatus.swift; sourceTree = "<group>"; };
 		F0D9FBBA2D3A984700031E7E /* FirmwareUpdateMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareUpdateMessage.swift; sourceTree = "<group>"; };
@@ -1925,6 +1927,7 @@
 				D93DFD4712AACE1484C2B50777573FD2 /* ConfigurationClientHandler.swift */,
 				F2319EF4BFCCA5C949B924616582FB77 /* ConfigurationServerHandler.swift */,
 				E36373F3CAF09318EA80BB1A75396C98 /* HealthClientHandler.swift */,
+				F0D9EEF22D489E450063AF3E /* HealthServerHandler.swift */,
 				18BEBC2D7BBD8ACDBE7477A8868CF9F8 /* PrivateBeaconClientHandler.swift */,
 				8C39493DFD6E3A89B55E1D5BDA26D34E /* RemoteProvisioningClientHandler.swift */,
 				4B40BB694D0289C1331D732DFB0CA3B3 /* SarConfigurationClientHandler.swift */,
@@ -2859,6 +2862,7 @@
 				F9A30F9A5EE05793EA465C7B5F28D160 /* nRFMeshProvision-dummy.m in Sources */,
 				B6CFCC7C995789EE38DED2A1FEDAE8B2 /* OnPowerUp.swift in Sources */,
 				F019B64C2D3E69E60094B0E4 /* FirmwareDistributionReceiversStatus.swift in Sources */,
+				F0D9EEF32D489E450063AF3E /* HealthServerHandler.swift in Sources */,
 				A27255143E672F5A8D89BDA248C14B69 /* Oob.swift in Sources */,
 				1459F32CB80689BF692245727AE5B436 /* OptionSet+Data.swift in Sources */,
 				A8CA9DC15177C2380C28A7E956C86B53 /* PBGattBearer.swift in Sources */,

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -308,7 +308,7 @@
 		8FB8A938079E54A78D3A93AC5785D7D0 /* SensorSettingSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6C81F65ED1AFDA74A2F398D01B8CA2C /* SensorSettingSetUnacknowledged.swift */; };
 		9094732C092F0C3C7837BD1D84FA10FA /* ConfigModelSubscriptionDelete.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDE4A14E2BE2CFFBE3C7B0C786F7B34 /* ConfigModelSubscriptionDelete.swift */; };
 		90AA867C0EEE70EF726FB8A1D3CF49A7 /* Pods-nRF Mesh Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 977CACA35C2CE241D8FFC6B245CCF578 /* Pods-nRF Mesh Tests-dummy.m */; };
-		9100E5DCF0A6F4FA824D1EB73BEC6B95 /* HealthFaultEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 237C56C62770795A78A516CB41086A49 /* HealthFaultEnum.swift */; };
+		9100E5DCF0A6F4FA824D1EB73BEC6B95 /* HealthFault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 237C56C62770795A78A516CB41086A49 /* HealthFault.swift */; };
 		911C89AA798A54E9540128D1145E4B2A /* ConfigGATTProxyStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D73B151D30F2C2757BE1D8FD7ED1CF8 /* ConfigGATTProxyStatus.swift */; };
 		9133B383208719CB386F4AD86F5261A1 /* AsyncResultOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAEBB32257AEACD71D93C6A04DA146A7 /* AsyncResultOperation.swift */; };
 		91345DB642439B79DCD0F710E062DABC /* PrivateBeaconSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A2A19DE4CB954374D6B3EB3B728910 /* PrivateBeaconSet.swift */; };
@@ -556,6 +556,19 @@
 		F019B6782D4442E40094B0E4 /* FirmwareDistributionFirmwareStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F019B6772D4442E40094B0E4 /* FirmwareDistributionFirmwareStatus.swift */; };
 		F05BEB3B3B7D9BA92171DBA20D00D99A /* LightHSLHueGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9459D3C9D4AD25E6F06783A083CDCA /* LightHSLHueGet.swift */; };
 		F0CF8137D4A439F10BA45530CE5A1826 /* HeartbeatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A61AC6EE93C4A0A96E70EB495A0CA1E2 /* HeartbeatMessage.swift */; };
+		F0D9EED52D47A3BB0063AF3E /* HealthFaultGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EED42D47A3BB0063AF3E /* HealthFaultGet.swift */; };
+		F0D9EED92D47A55A0063AF3E /* HealthFaultClear.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EED82D47A55A0063AF3E /* HealthFaultClear.swift */; };
+		F0D9EEDB2D47A5B40063AF3E /* HealthFaultClearUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEDA2D47A5B40063AF3E /* HealthFaultClearUnacknowledged.swift */; };
+		F0D9EEDD2D47A66E0063AF3E /* HealthFaultTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEDC2D47A66E0063AF3E /* HealthFaultTest.swift */; };
+		F0D9EEDF2D47A70C0063AF3E /* HealthFaultTestUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEDE2D47A70C0063AF3E /* HealthFaultTestUnacknowledged.swift */; };
+		F0D9EEE12D47A8FD0063AF3E /* HealthPeriodGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEE02D47A8FD0063AF3E /* HealthPeriodGet.swift */; };
+		F0D9EEE32D47A9AA0063AF3E /* HealthPeriodSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEE22D47A9AA0063AF3E /* HealthPeriodSet.swift */; };
+		F0D9EEE52D47AA370063AF3E /* HealthPeriodSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEE42D47AA370063AF3E /* HealthPeriodSetUnacknowledged.swift */; };
+		F0D9EEE72D47B48D0063AF3E /* HealthPeriodStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEE62D47B48D0063AF3E /* HealthPeriodStatus.swift */; };
+		F0D9EEE92D47C8FC0063AF3E /* HealthAttentionGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEE82D47C8FC0063AF3E /* HealthAttentionGet.swift */; };
+		F0D9EEEB2D47C97F0063AF3E /* HealthAttentionSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEEA2D47C97F0063AF3E /* HealthAttentionSet.swift */; };
+		F0D9EEEF2D4898C00063AF3E /* HealthAttentionSetUnacknowledged.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEEE2D4898C00063AF3E /* HealthAttentionSetUnacknowledged.swift */; };
+		F0D9EEF12D4899B40063AF3E /* HealthAttentionStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9EEF02D4899B40063AF3E /* HealthAttentionStatus.swift */; };
 		F0D9FBB72D3A844300031E7E /* FirmwareUpdateFirmwareMetadataCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9FBB62D3A844300031E7E /* FirmwareUpdateFirmwareMetadataCheck.swift */; };
 		F0D9FBB92D3A869800031E7E /* FirmwareUpdateFirmwareMetadataStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9FBB82D3A869800031E7E /* FirmwareUpdateFirmwareMetadataStatus.swift */; };
 		F0D9FBBB2D3A985B00031E7E /* FirmwareUpdateMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9FBBA2D3A984700031E7E /* FirmwareUpdateMessage.swift */; };
@@ -710,7 +723,7 @@
 		221E23CDC2506A385CFA002A8B9DF45A /* ConfigAppKeyGet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigAppKeyGet.swift; sourceTree = "<group>"; };
 		22DBAA404C11EF4BD2DCECC4FC6E1FCD /* TimeZoneGet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimeZoneGet.swift; sourceTree = "<group>"; };
 		22FC47DB517B264EC4A461F37293645B /* MeshNetwork+Keys.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MeshNetwork+Keys.swift"; sourceTree = "<group>"; };
-		237C56C62770795A78A516CB41086A49 /* HealthFaultEnum.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HealthFaultEnum.swift; sourceTree = "<group>"; };
+		237C56C62770795A78A516CB41086A49 /* HealthFault.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HealthFault.swift; sourceTree = "<group>"; };
 		244C4DDCF3443C7891BBEA2A18147228 /* ProxyProtocolHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ProxyProtocolHandler.swift; sourceTree = "<group>"; };
 		252835519A0093DCAF0E34E9A2EF328E /* ConfigSIGModelSubscriptionList.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigSIGModelSubscriptionList.swift; sourceTree = "<group>"; };
 		25286D10F60C9B274247F124DB81A38E /* AEADChaCha20Poly1305.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AEADChaCha20Poly1305.swift; path = Sources/CryptoSwift/AEAD/AEADChaCha20Poly1305.swift; sourceTree = "<group>"; };
@@ -1217,6 +1230,19 @@
 		F019B6772D4442E40094B0E4 /* FirmwareDistributionFirmwareStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareDistributionFirmwareStatus.swift; sourceTree = "<group>"; };
 		F056F50B3F6A0A1F7E9F8FFB3D12017B /* ConfigModelSubscriptionOverwrite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigModelSubscriptionOverwrite.swift; sourceTree = "<group>"; };
 		F09D785490AE9DC3F13CFBC70C004D2C /* TimeZoneSet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimeZoneSet.swift; sourceTree = "<group>"; };
+		F0D9EED42D47A3BB0063AF3E /* HealthFaultGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthFaultGet.swift; sourceTree = "<group>"; };
+		F0D9EED82D47A55A0063AF3E /* HealthFaultClear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthFaultClear.swift; sourceTree = "<group>"; };
+		F0D9EEDA2D47A5B40063AF3E /* HealthFaultClearUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthFaultClearUnacknowledged.swift; sourceTree = "<group>"; };
+		F0D9EEDC2D47A66E0063AF3E /* HealthFaultTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthFaultTest.swift; sourceTree = "<group>"; };
+		F0D9EEDE2D47A70C0063AF3E /* HealthFaultTestUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthFaultTestUnacknowledged.swift; sourceTree = "<group>"; };
+		F0D9EEE02D47A8FD0063AF3E /* HealthPeriodGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthPeriodGet.swift; sourceTree = "<group>"; };
+		F0D9EEE22D47A9AA0063AF3E /* HealthPeriodSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthPeriodSet.swift; sourceTree = "<group>"; };
+		F0D9EEE42D47AA370063AF3E /* HealthPeriodSetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthPeriodSetUnacknowledged.swift; sourceTree = "<group>"; };
+		F0D9EEE62D47B48D0063AF3E /* HealthPeriodStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthPeriodStatus.swift; sourceTree = "<group>"; };
+		F0D9EEE82D47C8FC0063AF3E /* HealthAttentionGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthAttentionGet.swift; sourceTree = "<group>"; };
+		F0D9EEEA2D47C97F0063AF3E /* HealthAttentionSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthAttentionSet.swift; sourceTree = "<group>"; };
+		F0D9EEEE2D4898C00063AF3E /* HealthAttentionSetUnacknowledged.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthAttentionSetUnacknowledged.swift; sourceTree = "<group>"; };
+		F0D9EEF02D4899B40063AF3E /* HealthAttentionStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthAttentionStatus.swift; sourceTree = "<group>"; };
 		F0D9FBB62D3A844300031E7E /* FirmwareUpdateFirmwareMetadataCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareUpdateFirmwareMetadataCheck.swift; sourceTree = "<group>"; };
 		F0D9FBB82D3A869800031E7E /* FirmwareUpdateFirmwareMetadataStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareUpdateFirmwareMetadataStatus.swift; sourceTree = "<group>"; };
 		F0D9FBBA2D3A984700031E7E /* FirmwareUpdateMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareUpdateMessage.swift; sourceTree = "<group>"; };
@@ -1979,9 +2005,22 @@
 		AB1A0BBE9428A7216DE441C8AAF3A074 /* Health */ = {
 			isa = PBXGroup;
 			children = (
+				237C56C62770795A78A516CB41086A49 /* HealthFault.swift */,
+				F0D9EEE82D47C8FC0063AF3E /* HealthAttentionGet.swift */,
+				F0D9EEEA2D47C97F0063AF3E /* HealthAttentionSet.swift */,
+				F0D9EEEE2D4898C00063AF3E /* HealthAttentionSetUnacknowledged.swift */,
+				F0D9EEF02D4899B40063AF3E /* HealthAttentionStatus.swift */,
 				AF120CE0794B060EE0419AD2ADB14955 /* HealthCurrentStatus.swift */,
-				237C56C62770795A78A516CB41086A49 /* HealthFaultEnum.swift */,
 				B3602E3E61D7BC155094198B769D80B9 /* HealthFaultStatus.swift */,
+				F0D9EED82D47A55A0063AF3E /* HealthFaultClear.swift */,
+				F0D9EEDA2D47A5B40063AF3E /* HealthFaultClearUnacknowledged.swift */,
+				F0D9EED42D47A3BB0063AF3E /* HealthFaultGet.swift */,
+				F0D9EEDC2D47A66E0063AF3E /* HealthFaultTest.swift */,
+				F0D9EEDE2D47A70C0063AF3E /* HealthFaultTestUnacknowledged.swift */,
+				F0D9EEE02D47A8FD0063AF3E /* HealthPeriodGet.swift */,
+				F0D9EEE22D47A9AA0063AF3E /* HealthPeriodSet.swift */,
+				F0D9EEE42D47AA370063AF3E /* HealthPeriodSetUnacknowledged.swift */,
+				F0D9EEE62D47B48D0063AF3E /* HealthPeriodStatus.swift */,
 			);
 			path = Health;
 			sourceTree = "<group>";
@@ -2521,6 +2560,7 @@
 				ACD7331407F0953E885AEFD626F1280B /* ConfigAppKeyStatus.swift in Sources */,
 				B61A0AD5CBFC5EEB3FA23AF6C66E4E4C /* ConfigAppKeyUpdate.swift in Sources */,
 				E5882CF2A3C68BDECEFD431F0E8ABBD0 /* ConfigBeaconGet.swift in Sources */,
+				F0D9EEDD2D47A66E0063AF3E /* HealthFaultTest.swift in Sources */,
 				B47EACEF023AE53D906AB4A389490675 /* ConfigBeaconSet.swift in Sources */,
 				947F2DB3881F568442599C2D36FE2197 /* ConfigBeaconStatus.swift in Sources */,
 				E5DE6AAC44BF6461EC7A956F5DDD396C /* ConfigCompositionDataGet.swift in Sources */,
@@ -2531,6 +2571,7 @@
 				1741F90966D5188A7C5CDB86EAD09F9A /* ConfigFriendGet.swift in Sources */,
 				E8B383561463A2A8A084AA9B0792DEF2 /* ConfigFriendSet.swift in Sources */,
 				B1261C96A971546AD7E2D6E879CAC34A /* ConfigFriendStatus.swift in Sources */,
+				F0D9EEE52D47AA370063AF3E /* HealthPeriodSetUnacknowledged.swift in Sources */,
 				1302484A28D2B4B045C14E9164B0FEEB /* ConfigGATTProxyGet.swift in Sources */,
 				AA56D075427EFDB167025C78BB4DCE33 /* ConfigGATTProxySet.swift in Sources */,
 				911C89AA798A54E9540128D1145E4B2A /* ConfigGATTProxyStatus.swift in Sources */,
@@ -2574,6 +2615,7 @@
 				4D089B31ADF3A46329F780B068768CFF /* ConfigNetworkTransmitStatus.swift in Sources */,
 				040AA70C0FA601E460C4F3DE915E1EA1 /* ConfigNodeIdentityGet.swift in Sources */,
 				40835514A5AB16C7F17896D95D2B6258 /* ConfigNodeIdentitySet.swift in Sources */,
+				F0D9EED92D47A55A0063AF3E /* HealthFaultClear.swift in Sources */,
 				E5C31591BAD83D32839AC4DA6E8BDCC6 /* ConfigNodeIdentityStatus.swift in Sources */,
 				2521C11E11A6D40CB67B42C482A8F701 /* ConfigNodeReset.swift in Sources */,
 				1AA73DF5D69553E4A690FE1C53331A20 /* ConfigNodeResetStatus.swift in Sources */,
@@ -2589,6 +2631,7 @@
 				315BC30B1A566246805657E0C5742203 /* ConfigurationServerHandler.swift in Sources */,
 				F30B329A6BC93AAC1C149EB9CBB915C2 /* ConfigVendorModelAppGet.swift in Sources */,
 				68F6A3BCD4BC12F79DAD44891146B1D3 /* ConfigVendorModelAppList.swift in Sources */,
+				F0D9EEE12D47A8FD0063AF3E /* HealthPeriodGet.swift in Sources */,
 				5A4CD3A7EF64F3BD7DB154E323FFD2A4 /* ConfigVendorModelSubscriptionGet.swift in Sources */,
 				07767BB806ADEB6BB318A51F8C7F7405 /* ConfigVendorModelSubscriptionList.swift in Sources */,
 				F9D21055B61BA503D0EB2591D92CA2E2 /* ControlMessage.swift in Sources */,
@@ -2598,6 +2641,7 @@
 				D46FC30B3ECEF8DAD1894744BB5D73C4 /* Data+Keys.swift in Sources */,
 				70230A8B6E70BB5F5C309B879DB587B3 /* DeviceProperty.swift in Sources */,
 				01B4C1A0E5E4667FF864F5CB09E8814C /* Documentation.docc in Sources */,
+				F0D9EEDF2D47A70C0063AF3E /* HealthFaultTestUnacknowledged.swift in Sources */,
 				8C40F3C150EBD13B90DAE9F8ABF19B28 /* Element.swift in Sources */,
 				3BF18261BC94413E5CE636AE3C260633 /* Element+Address.swift in Sources */,
 				F65ACE0BEF03C2547F0F510E56AD7227 /* Element+Keys.swift in Sources */,
@@ -2659,7 +2703,7 @@
 				4F627ED2E2B0C318AA4B63178FE61B36 /* Group+Scenes.swift in Sources */,
 				89080B4F548D29F2FEB624EFC40700FE /* HealthClientHandler.swift in Sources */,
 				C564A4784B0A9E32D970F5E767FEE72E /* HealthCurrentStatus.swift in Sources */,
-				9100E5DCF0A6F4FA824D1EB73BEC6B95 /* HealthFaultEnum.swift in Sources */,
+				9100E5DCF0A6F4FA824D1EB73BEC6B95 /* HealthFault.swift in Sources */,
 				2AB23765AE53D4E80E922B0F07996C57 /* HealthFaultStatus.swift in Sources */,
 				F0CF8137D4A439F10BA45530CE5A1826 /* HeartbeatMessage.swift in Sources */,
 				D91320C2F43F590460F97FFE4690443F /* HeartbeatPublication.swift in Sources */,
@@ -2763,6 +2807,7 @@
 				0EF68F4DB3B3CED9050D25E8A99E7FE6 /* MeshConstants.swift in Sources */,
 				BAE545A1D9CE9BA9C24DA3D2232B17B8 /* MeshData.swift in Sources */,
 				DECD4F7F582C10CE2D5651549E015211 /* MeshLoggerDelegate.swift in Sources */,
+				F0D9EED52D47A3BB0063AF3E /* HealthFaultGet.swift in Sources */,
 				98B9F95ACF23BF653CAF8EA9A91A0DD6 /* MeshMessage.swift in Sources */,
 				18E86C835F61A9FEE191415FB5465A46 /* MeshNetwork.swift in Sources */,
 				7EC30A72572FA1E705BB2D51C390397A /* MeshNetwork+Address.swift in Sources */,
@@ -2797,6 +2842,7 @@
 				9FE049C7C4944D3E8D9F305A8E025BF8 /* NetworkKeys.swift in Sources */,
 				D02D81C9823C6036EE3D94C95E538029 /* NetworkLayer.swift in Sources */,
 				6CD51086F4C047909850E2A8E42A7DB4 /* NetworkManager.swift in Sources */,
+				F0D9EEEB2D47C97F0063AF3E /* HealthAttentionSet.swift in Sources */,
 				FE4AB33782AA10CA2F549201D6C04D1E /* NetworkManagerDelegate.swift in Sources */,
 				B0DA33644FDF8418A2630DA789714FD2 /* NetworkParameters.swift in Sources */,
 				CDC3DA2F80793246236911B91AF5C31F /* NetworkPdu.swift in Sources */,
@@ -2839,6 +2885,8 @@
 				776E3295F4628CB9442424172C8D85A0 /* ProvisioningPdu.swift in Sources */,
 				9B91C7DE5986F3ADD46736D589CF6C16 /* ProvisioningState.swift in Sources */,
 				33FE42D89519FC0627110197D1BED1BA /* ProxyConfigurationMessage.swift in Sources */,
+				F0D9EEE72D47B48D0063AF3E /* HealthPeriodStatus.swift in Sources */,
+				F0D9EEE92D47C8FC0063AF3E /* HealthAttentionGet.swift in Sources */,
 				439F06D6CDA6D83906DFBC78038ABA4D /* ProxyFilter.swift in Sources */,
 				0875EEE8F2F26318DB33499560C3C1D5 /* ProxyProtocolHandler.swift in Sources */,
 				10794DCA75895F6AB936C643FAC459F2 /* PublicKey.swift in Sources */,
@@ -2849,6 +2897,7 @@
 				D0B3626061E98F17F198DB5346309928 /* RemoteProvisioningClientHandler.swift in Sources */,
 				D3AC2236476532B3F81F6E566D656FA6 /* RemoteProvisioningExtendedScanReport.swift in Sources */,
 				835D636EF7BD15332EA52F450B8EB67E /* RemoteProvisioningExtendedScanStart.swift in Sources */,
+				F0D9EEE32D47A9AA0063AF3E /* HealthPeriodSet.swift in Sources */,
 				F019B6542D3FD56B0094B0E4 /* FirmwareDistributionCapabilitiesGet.swift in Sources */,
 				03E44E0FAD3E14DD8C2B1A0724264463 /* RemoteProvisioningLinkClose.swift in Sources */,
 				2986BC226F48479977F3D319DB86CB74 /* RemoteProvisioningLinkGet.swift in Sources */,
@@ -2896,6 +2945,7 @@
 				9B4D96EF19D97273B16B1A8B2CA02949 /* SchedulerActionGet.swift in Sources */,
 				A972D0861F5357D024BD4C10C749F881 /* SchedulerActionSet.swift in Sources */,
 				12DB96AB61EC6465F9C3916B3F67B963 /* SchedulerActionSetUnacknowledged.swift in Sources */,
+				F0D9EEF12D4899B40063AF3E /* HealthAttentionStatus.swift in Sources */,
 				05A910FFE1C4A22CC37D2E5B0E347579 /* SchedulerActionStatus.swift in Sources */,
 				4EA9C98877CB380B4C65960688A7D2C9 /* SchedulerGet.swift in Sources */,
 				C493FE12DC37B2FFF4DFB08650033CE4 /* SchedulerMessage.swift in Sources */,
@@ -2917,6 +2967,7 @@
 				943A7242E0667E218CA7A4AA75732514 /* SensorDescriptorGet.swift in Sources */,
 				F24A2CBF9EDFB7B647226550B46431F4 /* SensorDescriptorStatus.swift in Sources */,
 				A26BBD6C539A92C843FFF1AE3F1857CD /* SensorGet.swift in Sources */,
+				F0D9EEDB2D47A5B40063AF3E /* HealthFaultClearUnacknowledged.swift in Sources */,
 				DDE4E1A209569B4D8DABC0616693727C /* SensorMessage.swift in Sources */,
 				1C0C67D52BA188C7715405BDEE8AFC87 /* SensorSeriesGet.swift in Sources */,
 				BB5FF877DB157E6F33B7311808395CBC /* SensorSeriesStatus.swift in Sources */,
@@ -2947,6 +2998,7 @@
 				60346D44D80CA99C6827378302E5EDA1 /* UnprovisionedDevice.swift in Sources */,
 				38AF679EE574B1A7BEAA7AFDBC8635D1 /* UnprovisionedDeviceBeacon.swift in Sources */,
 				C7FEC5EC4957B91B71B5BB7AC1BFF3FE /* UpperTransportLayer.swift in Sources */,
+				F0D9EEEF2D4898C00063AF3E /* HealthAttentionSetUnacknowledged.swift in Sources */,
 				A0C3AA19BF4C2836D3B9AC226D7E83DD /* UpperTransportPdu.swift in Sources */,
 				0864ED20B9377E6D850C91AC0C014726 /* UserDefaults+SeqAuth.swift in Sources */,
 				407C910E63A52613177AFED875905667 /* UUID+Hex.swift in Sources */,

--- a/Library/Documentation.docc/NordicMesh.md
+++ b/Library/Documentation.docc/NordicMesh.md
@@ -372,11 +372,31 @@ Provisioning is the process of adding an unprovisioned device to a mesh network 
 - ``SarTransmitterSet``
 - ``SarTransmitterStatus``
 
-### Health Messages
+### Health Types
 
 - ``HealthFault``
+
+### Health Messages
+
 - ``HealthCurrentStatus``
+- ``HealthFaultGet``
+- ``HealthFaultClear``
+- ``HealthFaultClearUnacknowledged``
+- ``HealthFaultTest``
+- ``HealthFaultTestUnacknowledged``
 - ``HealthFaultStatus``
+- ``HealthAttentionGet``
+- ``HealthAttentionSet``
+- ``HealthAttentionSetUnacknowledged``
+- ``HealthAttentionStatus``
+- ``HealthPeriodGet``
+- ``HealthPeriodSet``
+- ``HealthPeriodSetUnacknowledged``
+- ``HealthPeriodStatus``
+- ``HealthAttentionGet``
+- ``HealthAttentionSet``
+- ``HealthAttentionSetUnacknowledged``
+- ``HealthAttentionStatus``
 
 ### Remote Provisioning Message Types
 

--- a/Library/Layers/Foundation Layer/HealthClientHandler.swift
+++ b/Library/Layers/Foundation Layer/HealthClientHandler.swift
@@ -40,13 +40,15 @@ class HealthClientHandler: ModelDelegate {
     init() {
         let types: [StaticMeshMessage.Type] = [
             HealthCurrentStatus.self,
-            HealthFaultStatus.self
+            HealthFaultStatus.self,
+            HealthPeriodStatus.self,
+            HealthAttentionStatus.self
         ]
-        
         messageTypes = types.toMap()
     }
     
-    func model(_ model: NordicMesh.Model, didReceiveAcknowledgedMessage request: any NordicMesh.AcknowledgedMeshMessage, from source: NordicMesh.Address, sentTo destination: NordicMesh.MeshAddress) throws -> any NordicMesh.MeshResponse {
+    func model(_ model: Model, didReceiveAcknowledgedMessage request: any AcknowledgedMeshMessage,
+               from source: Address, sentTo destination: MeshAddress) throws -> any MeshResponse {
         switch request {
             // No acknowledged message supported by this Model.
         default:
@@ -54,7 +56,8 @@ class HealthClientHandler: ModelDelegate {
         }
     }
     
-    func model(_ model: NordicMesh.Model, didReceiveUnacknowledgedMessage message: any NordicMesh.UnacknowledgedMeshMessage, from source: NordicMesh.Address, sentTo destination: NordicMesh.MeshAddress) {
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: any UnacknowledgedMeshMessage,
+               from source: Address, sentTo destination: MeshAddress) {
         switch message {
             
         default:
@@ -63,7 +66,9 @@ class HealthClientHandler: ModelDelegate {
         }
     }
     
-    func model(_ model: NordicMesh.Model, didReceiveResponse response: any NordicMesh.MeshResponse, toAcknowledgedMessage request: any NordicMesh.AcknowledgedMeshMessage, from source: NordicMesh.Address) {
+    func model(_ model: Model, didReceiveResponse response: any MeshResponse,
+               toAcknowledgedMessage request: any AcknowledgedMeshMessage,
+               from source: NordicMesh.Address) {
         // Ignore. There are no CDB fields matching these parameters.
     }
 }

--- a/Library/Layers/Foundation Layer/HealthServerHandler.swift
+++ b/Library/Layers/Foundation Layer/HealthServerHandler.swift
@@ -1,0 +1,208 @@
+/*
+* Copyright (c) 2024, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/// A stub implementation of Health Server model.
+///
+/// To test ``HealthFaultGet`` send a ``HealthFaultTest``
+/// with an expected id of a fault set as ``HealthFaultTest/testId``.
+/// The fault will be added to the Registered Fault state.
+///
+// TODO: Currently, the Current Fault state always contains no faults.
+class HealthServerHandler: ModelDelegate {
+    weak var meshNetwork: MeshNetwork!
+    
+    /// Identifier of a most recently performed self-test/
+    private var mostRecentTestId: UInt8 = 0
+    /// The Current Fault state is empty when no warning or error condition is present.
+    ///
+    /// The FaultArray reflects a real-time state. This means when a fault condition arises,
+    /// a corresponding record is present in the state and when a fault condition is not present,
+    /// the corresponding record is removed from the state automatically.
+    private var currentFaultState: [HealthFault] = [] {
+        didSet {
+            // TODO: Changing this value should publish Health Current Status message
+            
+            // Whenever a fault condition has been present in the
+            // Current Fault state, the corresponding record is added
+            // to the Registered Fault state.
+            if !currentFaultState.isEmpty {
+                registeredFaultState = currentFaultState
+            }
+        }
+    }
+    /// Whenever a fault condition has been present in the Current Fault state,
+    /// the corresponding record is added to the Registered Fault state.
+    ///
+    /// The FaultArray is cleared with a dedicated Health Fault Clear message
+    private var registeredFaultState: [HealthFault] = []
+    /// The Company Identifier (CID) of Nordic Semiconductor ASA.
+    private let nordicSemiconductor: UInt16 = 0x0059
+    /// Returns the Company Identifier (CID) of the local Node.
+    private var companyIdentifier: UInt16 {
+        // Defaults to Nordic Semiconductor
+        return meshNetwork?.localProvisioner?.node?.companyIdentifier ?? nordicSemiconductor
+    }
+    
+    var messageTypes: [UInt32 : MeshMessage.Type]
+    var isSubscriptionSupported: Bool = true
+    var publicationMessageComposer: MessageComposer? {
+        func compose() -> MeshMessage {
+            return HealthCurrentStatus(
+                testId: mostRecentTestId,
+                companyIdentifier: companyIdentifier,
+                faults: currentFaultState
+            )
+        }
+        let status = compose()
+        return {
+            return status
+        }
+    }
+    
+    // TODO: Add some API to emulate faults
+    
+    init(_ meshNetwork: MeshNetwork) {
+        let types: [StaticMeshMessage.Type] = [
+            HealthFaultGet.self,
+            HealthFaultClear.self,
+            HealthFaultClearUnacknowledged.self,
+            HealthFaultTest.self,
+            HealthFaultTestUnacknowledged.self,
+            HealthAttentionGet.self,
+            HealthAttentionSet.self,
+            HealthAttentionSetUnacknowledged.self,
+            HealthPeriodGet.self,
+            HealthPeriodSet.self,
+            HealthPeriodSetUnacknowledged.self
+        ]
+        messageTypes = types.toMap()
+    }
+    
+    func model(_ model: Model, didReceiveAcknowledgedMessage request: any AcknowledgedMeshMessage,
+               from source: Address, sentTo destination: MeshAddress) throws -> any MeshResponse {
+        switch request {
+            
+        case is HealthAttentionGet, is HealthAttentionSet:
+            // Attention Timer isn't supported.
+            return HealthAttentionStatus()
+            
+        case is HealthPeriodGet, is HealthPeriodSet:
+            // This library does not support Fast Period Divisor.
+            // Value 0 means, that the publishing will be using
+            // Publish Period without any divisor.
+            return HealthPeriodStatus(fastPeriodDivisor: 0)
+            
+        case let request as HealthFaultGet:
+            guard request.companyIdentifier == companyIdentifier else {
+                throw ModelError.invalidMessage
+            }
+            return HealthFaultStatus(
+                testId: mostRecentTestId,
+                companyIdentifier: companyIdentifier,
+                faults: registeredFaultState
+            )
+            
+        case let request as HealthFaultTest:
+            // This code allows testing Faults.
+            // When HealthFaultTest is sent with Company ID = Nordic Semiconductor (0059),
+            // and the "testID" is grater than 0, the fault with the ID equal to the testID
+            // is added to the Registered Fault state.
+            if request.companyIdentifier == nordicSemiconductor && request.testId > 0,
+               let fault = HealthFault.fromId(request.testId) {
+                registeredFaultState.append(fault)
+            }
+            
+            guard request.companyIdentifier == companyIdentifier else {
+                throw ModelError.invalidMessage
+            }
+            mostRecentTestId = request.testId
+            return HealthFaultStatus(
+                testId: mostRecentTestId,
+                companyIdentifier: companyIdentifier,
+                faults: registeredFaultState
+            )
+            
+        case let request as HealthFaultClear:
+            guard request.companyIdentifier == companyIdentifier else {
+                throw ModelError.invalidMessage
+            }
+            registeredFaultState.removeAll()
+            return HealthFaultStatus(
+                testId: mostRecentTestId,
+                companyIdentifier: companyIdentifier
+            )
+            
+        default:
+            fatalError("Message not supported: \(request)")
+        }
+    }
+    
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: any UnacknowledgedMeshMessage,
+               from source: Address, sentTo destination: MeshAddress) {
+        switch message {
+            
+        case is HealthAttentionSetUnacknowledged,
+             is HealthPeriodSetUnacknowledged:
+            // This library supports neither of these states.
+            break;
+            
+        case let request as HealthFaultTestUnacknowledged:
+            // This code allows testing Faults.
+            // When HealthFaultTest is sent with Company ID = Nordic Semiconductor (0059),
+            // and the "testID" is grater than 0, the fault with the ID equal to the testID
+            // is added to the Registered Fault state.
+            if request.companyIdentifier == nordicSemiconductor && request.testId > 0,
+               let fault = HealthFault.fromId(request.testId) {
+                registeredFaultState.append(fault)
+            }
+            
+            guard request.companyIdentifier == companyIdentifier else {
+                break
+            }
+            mostRecentTestId = request.testId
+            
+        case let request as HealthFaultClearUnacknowledged:
+            guard request.companyIdentifier == companyIdentifier else {
+                break
+            }
+            registeredFaultState.removeAll()
+            
+        default:
+            // Ignore.
+            break
+        }
+    }
+    
+    func model(_ model: Model, didReceiveResponse response: any MeshResponse,
+               toAcknowledgedMessage request: any AcknowledgedMeshMessage,
+               from source: NordicMesh.Address) {
+        // Ignore. There are no CDB fields matching these parameters.
+    }
+}

--- a/Library/Mesh Messages/Health/HealthAttentionGet.swift
+++ b/Library/Mesh Messages/Health/HealthAttentionGet.swift
@@ -1,0 +1,62 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// A Health Attention Get is an acknowledged message used to get the current Attention Timer state
+/// of an Element.
+///
+/// The Attention Timer is intended to allow an Element to attract human attention and, among others,
+/// is used during provisioning.
+///
+/// When the Attention Timer state is on, the value determines how long (in seconds) the Element shall
+/// remain attracting human’s attention. The Element does that by behaving in a human-recognizable
+/// way (e.g., a lamp flashes, a motor makes noise, an LED blinks). The exact behavior is implementation
+/// specific and depends on the type of device. 
+public struct HealthAttentionGet: StaticAcknowledgedMeshMessage {
+    public static let opCode: UInt32 = 0x8004
+    public static let responseType: StaticMeshResponse.Type = HealthAttentionStatus.self
+    
+    public var parameters: Data? {
+        return nil
+    }
+    
+    /// Creates the Health Attention Get message.
+    public init() {
+        // Empty
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.isEmpty else {
+            return nil
+        }
+    }
+    
+}

--- a/Library/Mesh Messages/Health/HealthAttentionSet.swift
+++ b/Library/Mesh Messages/Health/HealthAttentionSet.swift
@@ -1,0 +1,81 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// A Health Attention Set is an acknowledged message used to set the current Attention Timer state
+/// of an Element.
+///
+/// The Attention Timer is intended to allow an Element to attract human attention and, among others,
+/// is used during provisioning.
+///
+/// When the Attention Timer state is on, the value determines how long (in seconds) the Element shall
+/// remain attracting human’s attention. The Element does that by behaving in a human-recognizable
+/// way (e.g., a lamp flashes, a motor makes noise, an LED blinks). The exact behavior is implementation
+/// specific and depends on the type of device.
+public struct HealthAttentionSet: StaticAcknowledgedMeshMessage {
+    public static let opCode: UInt32 = 0x8005
+    public static let responseType: StaticMeshResponse.Type = HealthAttentionStatus.self
+    
+    public var parameters: Data? {
+        return Data([attentionTimer])
+    }
+    
+    /// The duration of the Attention Timer, in seconds.
+    ///
+    /// Set to 0 if the Timer is off, or not supported.
+    public let attentionTimer: UInt8
+    
+    /// Returns whether the Attention Timer is on, or off.
+    public var isOn: Bool {
+        return attentionTimer != 0
+    }
+    
+    /// Creates the Health Attention Set message.
+    ///
+    /// - parameter duration: The duration of the Attention Timer, in seconds.
+    ///             Allowed values are 0-255 seconds and are truncated to the nearest integer value.
+    public init(_ duration: TimeInterval) {
+        self.attentionTimer = UInt8(min(0xFF, duration))
+    }
+    
+    /// Creates the Health Attention Status to disable the Attention Timer on the Element.
+    public init() {
+        self.attentionTimer = 0
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        self.attentionTimer = parameters[0]
+    }
+    
+}

--- a/Library/Mesh Messages/Health/HealthAttentionSetUnacknowledged.swift
+++ b/Library/Mesh Messages/Health/HealthAttentionSetUnacknowledged.swift
@@ -1,0 +1,80 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// A Health Attention Set Unacknowledged is an unacknowledged message used to set the current
+/// Attention Timer state of an Element.
+///
+/// The Attention Timer is intended to allow an Element to attract human attention and, among others,
+/// is used during provisioning.
+///
+/// When the Attention Timer state is on, the value determines how long (in seconds) the Element shall
+/// remain attracting human’s attention. The Element does that by behaving in a human-recognizable
+/// way (e.g., a lamp flashes, a motor makes noise, an LED blinks). The exact behavior is implementation
+/// specific and depends on the type of device.
+public struct HealthAttentionSetUnacknowledged: StaticMeshMessage {
+    public static let opCode: UInt32 = 0x8006
+    
+    public var parameters: Data? {
+        return Data([attentionTimer])
+    }
+    
+    /// The duration of the Attention Timer, in seconds.
+    ///
+    /// Set to 0 if the Timer is off, or not supported.
+    public let attentionTimer: UInt8
+    
+    /// Returns whether the Attention Timer is on, or off.
+    public var isOn: Bool {
+        return attentionTimer != 0
+    }
+    
+    /// Creates the Health Attention Set Unacknowledged message.
+    ///
+    /// - parameter duration: The duration of the Attention Timer, in seconds.
+    ///             Allowed values are 0-255 seconds and are truncated to the nearest integer value.
+    public init(_ duration: TimeInterval) {
+        self.attentionTimer = UInt8(min(0xFF, duration))
+    }
+    
+    /// Creates the Health Attention Status to disable the Attention Timer on the Element.
+    public init() {
+        self.attentionTimer = 0
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        self.attentionTimer = parameters[0]
+    }
+    
+}

--- a/Library/Mesh Messages/Health/HealthAttentionSetUnacknowledged.swift
+++ b/Library/Mesh Messages/Health/HealthAttentionSetUnacknowledged.swift
@@ -40,7 +40,7 @@ import Foundation
 /// remain attracting human’s attention. The Element does that by behaving in a human-recognizable
 /// way (e.g., a lamp flashes, a motor makes noise, an LED blinks). The exact behavior is implementation
 /// specific and depends on the type of device.
-public struct HealthAttentionSetUnacknowledged: StaticMeshMessage {
+public struct HealthAttentionSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8006
     
     public var parameters: Data? {

--- a/Library/Mesh Messages/Health/HealthAttentionStatus.swift
+++ b/Library/Mesh Messages/Health/HealthAttentionStatus.swift
@@ -1,0 +1,80 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// A Health Attention Set Unacknowledged is an unacknowledged message used to set the current
+/// Attention Timer state of an Element.
+///
+/// The Attention Timer is intended to allow an Element to attract human attention and, among others,
+/// is used during provisioning.
+///
+/// When the Attention Timer state is on, the value determines how long (in seconds) the Element shall
+/// remain attracting human’s attention. The Element does that by behaving in a human-recognizable
+/// way (e.g., a lamp flashes, a motor makes noise, an LED blinks). The exact behavior is implementation
+/// specific and depends on the type of device.
+public struct HealthAttentionStatus: StaticMeshResponse {
+    public static let opCode: UInt32 = 0x8007
+    
+    public var parameters: Data? {
+        return Data([attentionTimer])
+    }
+    
+    /// The duration of the Attention Timer, in seconds.
+    ///
+    /// Set to 0 if the Timer is off, or not supported.
+    public let attentionTimer: UInt8
+    
+    /// Returns whether the Attention Timer is on, or off.
+    public var isOn: Bool {
+        return attentionTimer != 0
+    }
+    
+    /// Creates the Health Attention Status.
+    ///
+    /// - parameter duration: The duration of the Attention Timer, in seconds.
+    ///             Allowed values are 0-255 seconds and are truncated to the nearest integer value.
+    public init(_ duration: TimeInterval) {
+        self.attentionTimer = UInt8(min(0xFF, duration))
+    }
+    
+    /// Creates the Health Attention Status for the disabled state.
+    public init() {
+        self.attentionTimer = 0
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        self.attentionTimer = parameters[0]
+    }
+    
+}

--- a/Library/Mesh Messages/Health/HealthCurrentStatus.swift
+++ b/Library/Mesh Messages/Health/HealthCurrentStatus.swift
@@ -42,7 +42,7 @@ public struct HealthCurrentStatus: StaticMeshResponse {
     
     public var parameters: Data? {
         var data = Data([testId]) + companyIdentifier
-        if let faults = faults {
+        if !faults.isEmpty {
             data += Data(faults.map { $0.id })
         }
         return data
@@ -57,18 +57,7 @@ public struct HealthCurrentStatus: StaticMeshResponse {
     /// List of faults.
     ///
     /// If no Fault fields are present (nil), it means no registered fault condition exists on an Element.
-    public let faults: [HealthFault]?
-    
-    /// Creates a Health Current Status message with no faults.
-    ///
-    /// - parameters:
-    ///   - testId: Identifier of a most recently performed test.
-    ///   - companyIdentifier: 16-bit Bluetooth assigned Company Identifier.
-    public init(testId: UInt8, companyIdentifier: UInt16) {
-        self.testId = testId
-        self.companyIdentifier = companyIdentifier
-        self.faults = nil
-    }
+    public let faults: [HealthFault]
     
     /// Creates a Health Current Status message.
     ///
@@ -76,7 +65,7 @@ public struct HealthCurrentStatus: StaticMeshResponse {
     ///   - testId: Identifier of a most recently performed test.
     ///   - companyIdentifier: 16-bit Bluetooth assigned Company Identifier.
     ///   - faults: List of faults.
-    public init(testId: UInt8, companyIdentifier: UInt16, faults: [HealthFault]) {
+    public init(testId: UInt8, companyIdentifier: UInt16, faults: [HealthFault] = []) {
         self.testId = testId
         self.companyIdentifier = companyIdentifier
         self.faults = faults
@@ -93,7 +82,7 @@ public struct HealthCurrentStatus: StaticMeshResponse {
                 .subdata(in: 3..<parameters.count - 3)
                 .compactMap { HealthFault.fromId($0) }
         } else {
-            faults = nil
+            faults = []
         }
     }
 }

--- a/Library/Mesh Messages/Health/HealthFault.swift
+++ b/Library/Mesh Messages/Health/HealthFault.swift
@@ -30,6 +30,7 @@
 * Created by Jules DOMMARTIN on 04/11/2024.
 */
 
+/// Health Fault IDs assigned to the health models.
 public enum HealthFault: Sendable {
     case noFault
     case batteryLowWarning
@@ -84,6 +85,7 @@ public enum HealthFault: Sendable {
     case mechanismJammedError
     case vendor(_ id: UInt8)
         
+    /// The ID of the fault.
     var id : UInt8 {
         switch self {
         case .noFault:
@@ -193,6 +195,7 @@ public enum HealthFault: Sendable {
         }
     }
     
+    /// Creates a ``HealthFault`` from the given ID.
     static func fromId(_ id: UInt8) -> HealthFault? {
         switch id {
         case 0x00:

--- a/Library/Mesh Messages/Health/HealthFaultClear.swift
+++ b/Library/Mesh Messages/Health/HealthFaultClear.swift
@@ -1,0 +1,62 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// A Health Fault Clear is an acknowledged message used to clear the current Registered Fault
+/// state identified by Company ID of an Element.
+public struct HealthFaultClear: StaticAcknowledgedMeshMessage {
+    public static let opCode: UInt32 = 0x802F
+    public static let responseType: StaticMeshResponse.Type = HealthFaultStatus.self
+    
+    public var parameters: Data? {
+        return Data() + companyIdentifier
+    }
+    
+    /// 16-bit Bluetooth assigned Company Identifier.
+    public let companyIdentifier: UInt16
+    
+    /// Creates the Health Fault Clear message.
+    ///
+    /// - parameter companyIdentifier: 16-bit Bluetooth assigned Company Identifier.
+    ///             It shall be used to resolve specific fault codes as specified in Bluetooth assigned
+    ///             Health Fault values.
+    public init(for companyIdentifier: UInt16) {
+        self.companyIdentifier = companyIdentifier
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 2 else {
+            return nil
+        }
+        companyIdentifier = parameters.read(fromOffset: 0)
+    }
+    
+}

--- a/Library/Mesh Messages/Health/HealthFaultClearUnacknowledged.swift
+++ b/Library/Mesh Messages/Health/HealthFaultClearUnacknowledged.swift
@@ -1,0 +1,61 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// A Health Fault Clear Unacknowledged is an unacknowledged message used to clear the current Registered Fault
+/// state identified by Company ID of an Element.
+public struct HealthFaultClearUnacknowledged: StaticMeshMessage {
+    public static let opCode: UInt32 = 0x8030
+    
+    /// 16-bit Bluetooth assigned Company Identifier.
+    public let companyIdentifier: UInt16
+    
+    public var parameters: Data? {
+        return Data() + companyIdentifier
+    }
+    
+    /// Creates the Health Fault Clear Unacknowledged message.
+    ///
+    /// - parameter companyIdentifier: 16-bit Bluetooth assigned Company Identifier.
+    ///             It shall be used to resolve specific fault codes as specified in Bluetooth assigned
+    ///             Health Fault values.
+    public init(for companyIdentifier: UInt16) {
+        self.companyIdentifier = companyIdentifier
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 2 else {
+            return nil
+        }
+        companyIdentifier = parameters.read(fromOffset: 0)
+    }
+    
+}

--- a/Library/Mesh Messages/Health/HealthFaultClearUnacknowledged.swift
+++ b/Library/Mesh Messages/Health/HealthFaultClearUnacknowledged.swift
@@ -32,7 +32,7 @@ import Foundation
 
 /// A Health Fault Clear Unacknowledged is an unacknowledged message used to clear the current Registered Fault
 /// state identified by Company ID of an Element.
-public struct HealthFaultClearUnacknowledged: StaticMeshMessage {
+public struct HealthFaultClearUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8030
     
     /// 16-bit Bluetooth assigned Company Identifier.

--- a/Library/Mesh Messages/Health/HealthFaultGet.swift
+++ b/Library/Mesh Messages/Health/HealthFaultGet.swift
@@ -1,0 +1,62 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// A Health Fault Get is an acknowledged message used to get the current Registered Fault
+/// state identified by Company ID of an Element.
+public struct HealthFaultGet: StaticAcknowledgedMeshMessage {
+    public static let opCode: UInt32 = 0x8031
+    public static let responseType: StaticMeshResponse.Type = HealthFaultStatus.self
+    
+    /// 16-bit Bluetooth assigned Company Identifier.
+    public let companyIdentifier: UInt16
+    
+    public var parameters: Data? {
+        return Data() + companyIdentifier
+    }
+    
+    /// Creates the Health Fault Get message.
+    ///
+    /// - parameter companyIdentifier: 16-bit Bluetooth assigned Company Identifier.
+    ///             It shall be used to resolve specific fault codes as specified in Bluetooth assigned
+    ///             Health Fault values.
+    public init(for companyIdentifier: UInt16) {
+        self.companyIdentifier = companyIdentifier
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 2 else {
+            return nil
+        }
+        companyIdentifier = parameters.read(fromOffset: 0)
+    }
+    
+}

--- a/Library/Mesh Messages/Health/HealthFaultStatus.swift
+++ b/Library/Mesh Messages/Health/HealthFaultStatus.swift
@@ -42,7 +42,7 @@ public struct HealthFaultStatus: StaticMeshResponse {
     
     public var parameters: Data? {
         var data = Data([testId]) + companyIdentifier
-        if let faults = faults {
+        if !faults.isEmpty {
             data += Data(faults.map { $0.id })
         }
         return data
@@ -56,19 +56,8 @@ public struct HealthFaultStatus: StaticMeshResponse {
     
     /// List of faults.
     ///
-    /// If no Fault fields are present (nil), it means no registered fault condition exists on an Element.
-    public let faults: [HealthFault]?
-    
-    /// Creates a Health Fault Status message with no faults.
-    ///
-    /// - parameters:
-    ///   - testId: Identifier of a most recently performed test.
-    ///   - companyIdentifier: 16-bit Bluetooth assigned Company Identifier.
-    public init(testId: UInt8, companyIdentifier: UInt16) {
-        self.testId = testId
-        self.companyIdentifier = companyIdentifier
-        self.faults = nil
-    }
+    /// If no Fault fields are present, it means no registered fault condition exists on an Element.
+    public let faults: [HealthFault]
     
     /// Creates a Health Fault Status message.
     ///
@@ -76,7 +65,7 @@ public struct HealthFaultStatus: StaticMeshResponse {
     ///   - testId: Identifier of a most recently performed test.
     ///   - companyIdentifier: 16-bit Bluetooth assigned Company Identifier.
     ///   - faults: List of faults.
-    public init(testId: UInt8, companyIdentifier: UInt16, faults: [HealthFault]) {
+    public init(testId: UInt8, companyIdentifier: UInt16, faults: [HealthFault] = []) {
         self.testId = testId
         self.companyIdentifier = companyIdentifier
         self.faults = faults
@@ -93,7 +82,7 @@ public struct HealthFaultStatus: StaticMeshResponse {
                 .subdata(in: 3..<parameters.count - 3)
                 .compactMap { HealthFault.fromId($0) }
         } else {
-            faults = nil
+            faults = []
         }
     }
 }

--- a/Library/Mesh Messages/Health/HealthFaultStatus.swift
+++ b/Library/Mesh Messages/Health/HealthFaultStatus.swift
@@ -32,49 +32,68 @@
 
 import Foundation
 
-
+/// A Health Fault Status is an unacknowledged message used to report the current Registered Fault
+/// state of an Element.
+///
+/// The message may contain several Fault fields, depending on the number of concurrently present
+/// fault conditions. If no Fault fields are present, it means no registered fault condition exists on an Element.
 public struct HealthFaultStatus: StaticMeshResponse {
     public static var opCode: UInt32 = 0x0005
     
     public var parameters: Data? {
-        return Data() + testId
+        var data = Data([testId]) + companyIdentifier
+        if let faults = faults {
+            data += Data(faults.map { $0.id })
+        }
+        return data
     }
-    
-    /// Test id
+
+    /// Identifier of a most recently performed test.
     public let testId: UInt8
 
-    /// Company id
+    /// 16-bit Bluetooth assigned Company Identifier.
     public let companyIdentifier: UInt16
     
-    /// List of faults
-    /// If no Fault fields are present (nil), it means no registered fault condition exists on an element.
-    public let faultArray: [HealthFault]?
+    /// List of faults.
+    ///
+    /// If no Fault fields are present (nil), it means no registered fault condition exists on an Element.
+    public let faults: [HealthFault]?
     
+    /// Creates a Health Fault Status message with no faults.
+    ///
+    /// - parameters:
+    ///   - testId: Identifier of a most recently performed test.
+    ///   - companyIdentifier: 16-bit Bluetooth assigned Company Identifier.
     public init(testId: UInt8, companyIdentifier: UInt16) {
         self.testId = testId
         self.companyIdentifier = companyIdentifier
-        self.faultArray = nil
+        self.faults = nil
     }
     
-    public init(testId: UInt8, companyIdentifier: UInt16, faultArray: [HealthFault]) {
+    /// Creates a Health Fault Status message.
+    ///
+    /// - parameters:
+    ///   - testId: Identifier of a most recently performed test.
+    ///   - companyIdentifier: 16-bit Bluetooth assigned Company Identifier.
+    ///   - faults: List of faults.
+    public init(testId: UInt8, companyIdentifier: UInt16, faults: [HealthFault]) {
         self.testId = testId
         self.companyIdentifier = companyIdentifier
-        self.faultArray = faultArray
+        self.faults = faults
     }
     
     public init?(parameters: Data) {
         guard parameters.count >= 3 else {
             return nil
         }
-        testId = parameters.read(fromOffset: 0)
+        testId = parameters[0]
         companyIdentifier = parameters.read(fromOffset: 1)
         if parameters.count > 3 {
-            faultArray = parameters
-                .subdata(in: 3 ..< parameters.count - 3)
-                .bytes
+            faults = parameters
+                .subdata(in: 3..<parameters.count - 3)
                 .compactMap { HealthFault.fromId($0) }
         } else {
-            faultArray = nil
+            faults = nil
         }
     }
 }

--- a/Library/Mesh Messages/Health/HealthFaultTest.swift
+++ b/Library/Mesh Messages/Health/HealthFaultTest.swift
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2024, Nordic Semiconductor
+* Copyright (c) 2019, Nordic Semiconductor
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification,
@@ -26,74 +26,45 @@
 * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 * POSSIBILITY OF SUCH DAMAGE.
-*
-* Created by Jules DOMMARTIN on 04/11/2024.
 */
 
 import Foundation
 
-/// A Health Current Status is an unacknowledged message used to report the Current Health
-/// state of an Element.
+/// A Health Fault Test is an acknowledged message used to invoke a self-test procedure of an Element.
 ///
-/// The message may contain several Fault fields, depending on the number of concurrently
-/// present fault conditions.If no Fault fields are present, it means no fault condition exists on an Element.
-public struct HealthCurrentStatus: StaticMeshResponse {
-    public static var opCode: UInt32 = 0x0004
-    
-    public var parameters: Data? {
-        var data = Data([testId]) + companyIdentifier
-        if let faults = faults {
-            data += Data(faults.map { $0.id })
-        }
-        return data
-    }
+/// The procedure is implementation specific and may result in changing the Health Fault state of an Element.
+public struct HealthFaultTest: StaticAcknowledgedMeshMessage {
+    public static let opCode: UInt32 = 0x8032
+    public static let responseType: StaticMeshResponse.Type = HealthFaultStatus.self
 
-    /// Identifier of a most recently performed test.
+    /// Identifier of a specific test to be performed.
     public let testId: UInt8
-
+    
     /// 16-bit Bluetooth assigned Company Identifier.
     public let companyIdentifier: UInt16
     
-    /// List of faults.
-    ///
-    /// If no Fault fields are present (nil), it means no registered fault condition exists on an Element.
-    public let faults: [HealthFault]?
-    
-    /// Creates a Health Current Status message with no faults.
-    ///
-    /// - parameters:
-    ///   - testId: Identifier of a most recently performed test.
-    ///   - companyIdentifier: 16-bit Bluetooth assigned Company Identifier.
-    public init(testId: UInt8, companyIdentifier: UInt16) {
-        self.testId = testId
-        self.companyIdentifier = companyIdentifier
-        self.faults = nil
+    public var parameters: Data? {
+        return Data([testId]) + companyIdentifier
     }
     
-    /// Creates a Health Current Status message.
+    /// Creates the Health Fault Test message.
     ///
     /// - parameters:
-    ///   - testId: Identifier of a most recently performed test.
+    ///   - testId: Identifier of a specific test to be performed.
     ///   - companyIdentifier: 16-bit Bluetooth assigned Company Identifier.
-    ///   - faults: List of faults.
-    public init(testId: UInt8, companyIdentifier: UInt16, faults: [HealthFault]) {
+    ///             It shall be used to resolve specific fault codes as specified in Bluetooth assigned
+    ///             Health Fault values.
+    public init(testId: UInt8, for companyIdentifier: UInt16) {
         self.testId = testId
         self.companyIdentifier = companyIdentifier
-        self.faults = faults
     }
     
     public init?(parameters: Data) {
-        guard parameters.count >= 3 else {
+        guard parameters.count == 3 else {
             return nil
         }
         testId = parameters[0]
         companyIdentifier = parameters.read(fromOffset: 1)
-        if parameters.count > 3 {
-            faults = parameters
-                .subdata(in: 3..<parameters.count - 3)
-                .compactMap { HealthFault.fromId($0) }
-        } else {
-            faults = nil
-        }
     }
+    
 }

--- a/Library/Mesh Messages/Health/HealthFaultTestUnacknowledged.swift
+++ b/Library/Mesh Messages/Health/HealthFaultTestUnacknowledged.swift
@@ -34,7 +34,7 @@ import Foundation
 /// of an Element.
 ///
 /// The procedure is implementation specific and may result in changing the Health Fault state of an Element.
-public struct HealthFaultTestUnacknowledged: StaticMeshMessage {
+public struct HealthFaultTestUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8033
     
     public var parameters: Data? {

--- a/Library/Mesh Messages/Health/HealthPeriodGet.swift
+++ b/Library/Mesh Messages/Health/HealthPeriodGet.swift
@@ -1,0 +1,54 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// A Health Period Get is an acknowledged message used to get the current Health Fast Period Divisor
+/// state of an Element.
+public struct HealthPeriodGet: StaticAcknowledgedMeshMessage {
+    public static let opCode: UInt32 = 0x8034
+    public static let responseType: StaticMeshResponse.Type = HealthPeriodStatus.self
+    
+    public var parameters: Data? {
+        return nil
+    }
+    
+    /// Creates the Health Period Get message.
+    public init() {
+        // Empty
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.isEmpty else {
+            return nil
+        }
+    }
+    
+}

--- a/Library/Mesh Messages/Health/HealthPeriodSet.swift
+++ b/Library/Mesh Messages/Health/HealthPeriodSet.swift
@@ -1,0 +1,67 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// A Health Period Set is an acknowledged message used to set the current Health Fast Period Divisor
+/// state of an Element.
+public struct HealthPeriodSet: StaticAcknowledgedMeshMessage {
+    public static let opCode: UInt32 = 0x8035
+    public static let responseType: StaticMeshResponse.Type = HealthPeriodStatus.self
+    
+    public var parameters: Data? {
+        return Data([fastPeriodDivisor])
+    }
+    
+    /// The Health Fast Period Divisor state controls the increased cadence of publishing
+    /// Health Current Status messages.
+    ///
+    /// Modified Publish Period is used for sending Current Health Status messages when there are
+    /// active faults to communicate. The value is used to divide the Publish Period state of the
+    /// Health Server model by `2^n` where `n `is the value of the Health Fast Period Divisor state.
+    public let fastPeriodDivisor: UInt8
+    
+    /// Creates the Health Period Set message.
+    ///
+    /// - parameter fastPeriodDivisor: Divider for the Publish Period..
+    ///             The value range for the Health Fast Period Divisor state is 0 through 15;
+    ///             all other values are Prohibited.
+    public init(fastPeriodDivisor: UInt8) {
+        self.fastPeriodDivisor = min(fastPeriodDivisor, 15)
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        fastPeriodDivisor = parameters[0]
+    }
+    
+}

--- a/Library/Mesh Messages/Health/HealthPeriodSetUnacknowledged.swift
+++ b/Library/Mesh Messages/Health/HealthPeriodSetUnacknowledged.swift
@@ -32,7 +32,7 @@ import Foundation
 
 /// A Health Period Set Unacknowledged is an unacknowledged message used to set the current Health Fast
 /// Period Divisor state of an Element.
-public struct HealthPeriodSetUnacknowledged: StaticMeshMessage {
+public struct HealthPeriodSetUnacknowledged: StaticUnacknowledgedMeshMessage {
     public static let opCode: UInt32 = 0x8036
     
     public var parameters: Data? {

--- a/Library/Mesh Messages/Health/HealthPeriodSetUnacknowledged.swift
+++ b/Library/Mesh Messages/Health/HealthPeriodSetUnacknowledged.swift
@@ -1,0 +1,66 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// A Health Period Set Unacknowledged is an unacknowledged message used to set the current Health Fast
+/// Period Divisor state of an Element.
+public struct HealthPeriodSetUnacknowledged: StaticMeshMessage {
+    public static let opCode: UInt32 = 0x8036
+    
+    public var parameters: Data? {
+        return Data([fastPeriodDivisor])
+    }
+    
+    /// The Health Fast Period Divisor state controls the increased cadence of publishing
+    /// Health Current Status messages.
+    ///
+    /// Modified Publish Period is used for sending Current Health Status messages when there are
+    /// active faults to communicate. The value is used to divide the Publish Period state of the
+    /// Health Server model by `2^n` where `n `is the value of the Health Fast Period Divisor state.
+    public let fastPeriodDivisor: UInt8
+    
+    /// Creates the Health Period Set Unacknowledged message.
+    ///
+    /// - parameter fastPeriodDivisor: Divider for the Publish Period..
+    ///             The value range for the Health Fast Period Divisor state is 0 through 15;
+    ///             all other values are Prohibited.
+    public init(fastPeriodDivisor: UInt8) {
+        self.fastPeriodDivisor = min(fastPeriodDivisor, 15)
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        fastPeriodDivisor = parameters[0]
+    }
+    
+}

--- a/Library/Mesh Messages/Health/HealthPeriodStatus.swift
+++ b/Library/Mesh Messages/Health/HealthPeriodStatus.swift
@@ -1,0 +1,65 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// A Health Period Status is an unacknowledged message used to report the Health Fast Period Divisor state of an Element.
+public struct HealthPeriodStatus: StaticMeshResponse {
+    public static let opCode: UInt32 = 0x8037
+    
+    public var parameters: Data? {
+        return Data([fastPeriodDivisor])
+    }
+    
+    /// The Health Fast Period Divisor state controls the increased cadence of publishing
+    /// Health Current Status messages.
+    ///
+    /// Modified Publish Period is used for sending Current Health Status messages when there are
+    /// active faults to communicate. The value is used to divide the Publish Period state of the
+    /// Health Server model by `2^n` where `n `is the value of the Health Fast Period Divisor state.
+    public let fastPeriodDivisor: UInt8
+    
+    /// Creates the Health Period Status message.
+    ///
+    /// - parameter fastPeriodDivisor: Divider for the Publish Period..
+    ///             The value range for the Health Fast Period Divisor state is 0 through 15;
+    ///             all other values are Prohibited.
+    public init(fastPeriodDivisor: UInt8) {
+        self.fastPeriodDivisor = min(fastPeriodDivisor, 15)
+    }
+    
+    public init?(parameters: Data) {
+        guard parameters.count == 1 else {
+            return nil
+        }
+        fastPeriodDivisor = parameters[0]
+    }
+    
+}

--- a/Library/Mesh Model/Element.swift
+++ b/Library/Mesh Model/Element.swift
@@ -191,7 +191,8 @@ internal extension Element {
                             delegate: ConfigurationServerHandler(meshNetwork)), at: 0)
         insert(model: Model(sigModelId: .configurationClientModelId,
                             delegate: ConfigurationClientHandler(meshNetwork)), at: 1)
-        insert(model: Model(sigModelId: .healthServerModelId), at: 2)
+        insert(model: Model(sigModelId: .healthServerModelId,
+                            delegate: HealthServerHandler(meshNetwork)), at: 2)
         insert(model: Model(sigModelId: .healthClientModelId,
                             delegate: HealthClientHandler()), at: 3)
         insert(model: Model(sigModelId: .privateBeaconClientModelId,


### PR DESCRIPTION
This PR adds remaining Health messages and slightly modidies the API of the 2 exising ones, added in #626.

Health messages should now be supported by the app. To test Health Faults, send `HealtFaultTest` message with `CompanyID` set to 0x0059 (Nordic) and the `testId` to expected fault id. 