### PR TITLE
Improved support for Health Server model

### DIFF
--- a/AttentionTimerDelegate.swift
+++ b/AttentionTimerDelegate.swift
@@ -40,12 +40,12 @@ public protocol AttentionTimerDelegate: AnyObject {
     ///
     ///The app should start attracting the user's attention.
     ///
-    /// - parameter timeout: The time after which the Attention Timer will time out, in range 1-255 seconds.
-    func startAttentionTimer(timeout: TimeInterval)
+    /// - parameter duration: The time after which the Attention Timer will time out, in range 1-255 seconds.
+    func attentionTimerDidStart(duration: TimeInterval)
     
     /// A callback called when the Attention Timer state has been stopped.
     ///
     /// This callback is called when the Attention Timer times out, or is stopped
     /// remotely by a remote user.
-    func stopAttentionTimer()
+    func attentionTimerDidStop()
 }

--- a/AttentionTimerDelegate.swift
+++ b/AttentionTimerDelegate.swift
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, Nordic Semiconductor
+* Copyright (c) 2025, Nordic Semiconductor
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification,
@@ -27,43 +27,25 @@
 * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 * POSSIBILITY OF SUCH DAMAGE.
 */
-
 import Foundation
 
-/// A Health Fault Test is an acknowledged message used to invoke a self-test procedure of an Element.
+/// An Attention Timer Delegate is used to notify the app about the Attention Timer state.
 ///
-/// The procedure is implementation specific and may result in changing the Health Fault state of an Element.
-public struct HealthFaultTest: StaticAcknowledgedMeshMessage {
-    public static let opCode: UInt32 = 0x8032
-    public static let responseType: StaticMeshResponse.Type = HealthFaultStatus.self
-
-    /// Identifier of a specific test to be performed.
-    public let testId: UInt8
-    /// 16-bit Bluetooth assigned Company Identifier.
-    public let companyIdentifier: UInt16
+/// The Attention Timer is used to attract the user's attention to the device. It may be started and stopped remotely
+/// using ``HealthAttentionSet`` or ``HealthAttentionSetUnacknowledged`` messages
+/// sent to the main Element of the local Node.
+public protocol AttentionTimerDelegate: AnyObject {
     
-    public var parameters: Data? {
-        return Data([testId]) + companyIdentifier
-    }
-    
-    /// Creates the Health Fault Test message.
+    /// A callback called when the Attention Timer state has been started..
     ///
-    /// - parameters:
-    ///   - testId: Identifier of a specific test to be performed.
-    ///   - companyIdentifier: 16-bit Bluetooth assigned Company Identifier.
-    ///             It shall be used to resolve specific fault codes as specified in Bluetooth assigned
-    ///             Health Fault values.
-    public init(testId: UInt8, for companyIdentifier: UInt16) {
-        self.testId = testId
-        self.companyIdentifier = companyIdentifier
-    }
+    ///The app should start attracting the user's attention.
+    ///
+    /// - parameter timeout: The time after which the Attention Timer will time out, in range 1-255 seconds.
+    func startAttentionTimer(timeout: TimeInterval)
     
-    public init?(parameters: Data) {
-        guard parameters.count == 3 else {
-            return nil
-        }
-        testId = parameters[0]
-        companyIdentifier = parameters.read(fromOffset: 1)
-    }
-    
+    /// A callback called when the Attention Timer state has been stopped.
+    ///
+    /// This callback is called when the Attention Timer times out, or is stopped
+    /// remotely by a remote user.
+    func stopAttentionTimer()
 }

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -575,6 +575,7 @@
 		F0D9FBBB2D3A985B00031E7E /* FirmwareUpdateMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D9FBBA2D3A984700031E7E /* FirmwareUpdateMessage.swift */; };
 		F0DAF5B82D39AB78000874EA /* FirmwareUpdateInformationGet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DAF5B62D39AB78000874EA /* FirmwareUpdateInformationGet.swift */; };
 		F0DAF5BA2D39ADA9000874EA /* FirmwareUpdateInformationStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DAF5B92D39ADA9000874EA /* FirmwareUpdateInformationStatus.swift */; };
+		F0FEE6FB2D5CEBD00092B7B7 /* AttentionTimerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0FEE6FA2D5CEBC80092B7B7 /* AttentionTimerDelegate.swift */; };
 		F1DAB5AF35C9CFE683F02B4CB58706A5 /* String+FoundationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C75468A068967107F4A2CD3C43F8546 /* String+FoundationExtension.swift */; };
 		F20B124E62C51E08102EF26D00763A35 /* Division.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C05A80EB0FAD8E6E3637AF6EE94CB05 /* Division.swift */; };
 		F24756849895D639924A648E1F58818F /* MeshUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1160E46C3BFF616DED70346C1BC555E7 /* MeshUUID.swift */; };
@@ -1250,6 +1251,7 @@
 		F0D9FBBA2D3A984700031E7E /* FirmwareUpdateMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareUpdateMessage.swift; sourceTree = "<group>"; };
 		F0DAF5B62D39AB78000874EA /* FirmwareUpdateInformationGet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareUpdateInformationGet.swift; sourceTree = "<group>"; };
 		F0DAF5B92D39ADA9000874EA /* FirmwareUpdateInformationStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareUpdateInformationStatus.swift; sourceTree = "<group>"; };
+		F0FEE6FA2D5CEBC80092B7B7 /* AttentionTimerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttentionTimerDelegate.swift; sourceTree = "<group>"; };
 		F1B97AF62C69861336C37668E1A987D2 /* nRFMeshProvision.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = nRFMeshProvision.release.xcconfig; sourceTree = "<group>"; };
 		F2319EF4BFCCA5C949B924616582FB77 /* ConfigurationServerHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigurationServerHandler.swift; sourceTree = "<group>"; };
 		F266B1D0B0919999F2A837E9F8F27845 /* SceneRange.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneRange.swift; sourceTree = "<group>"; };
@@ -1341,6 +1343,7 @@
 				63D46D377C01814AE242B65111996146 /* Documentation.docc */,
 				4E49438D23B49434C2EC54291D8F7562 /* ExportConfiguration.swift */,
 				10FAE53C65025FB6E59F5C4FBBB67C5F /* MeshNetworkDelegate.swift */,
+				F0FEE6FA2D5CEBC80092B7B7 /* AttentionTimerDelegate.swift */,
 				BAB7EF22A03E0D463FFAC06EE27992AE /* MeshNetworkError.swift */,
 				C0E549AD913DA513C1ABDFBFB453ED6C /* MeshNetworkManager.swift */,
 				380B476B359A61A45744BD92F5C78D5E /* MeshNetworkManager+Callbacks.swift */,
@@ -2860,6 +2863,7 @@
 				F86D3B738531ED4B1A5BB0CE410210F0 /* NodeIdentity.swift in Sources */,
 				1D00BA0172DD19F7CB8FAC169C0333DD /* NodeIdentityState.swift in Sources */,
 				F9A30F9A5EE05793EA465C7B5F28D160 /* nRFMeshProvision-dummy.m in Sources */,
+				F0FEE6FB2D5CEBD00092B7B7 /* AttentionTimerDelegate.swift in Sources */,
 				B6CFCC7C995789EE38DED2A1FEDAE8B2 /* OnPowerUp.swift in Sources */,
 				F019B64C2D3E69E60094B0E4 /* FirmwareDistributionReceiversStatus.swift in Sources */,
 				F0D9EEF32D489E450063AF3E /* HealthServerHandler.swift in Sources */,

--- a/Example/Source/AppDelegate.swift
+++ b/Example/Source/AppDelegate.swift
@@ -235,11 +235,11 @@ extension MeshNetworkManager {
 
 extension AppDelegate: AttentionTimerDelegate {
     
-    func startAttentionTimer(timeout: TimeInterval) {
-        log(message: "Attention Timer started for \(timeout) seconds", ofCategory: .foundationModel, withLevel: .application)
+    func attentionTimerDidStart(duration: TimeInterval) {
+        log(message: "Attention Timer started for \(duration) seconds", ofCategory: .foundationModel, withLevel: .application)
     }
     
-    func stopAttentionTimer() {
+    func attentionTimerDidStop() {
         log(message: "Attention Timer stopped", ofCategory: .foundationModel, withLevel: .application)
     }
     

--- a/Example/Source/AppDelegate.swift
+++ b/Example/Source/AppDelegate.swift
@@ -107,6 +107,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         */
         meshNetworkManager.logger = self
+        meshNetworkManager.attentionTimerDelegate = self
         
         // Try loading the saved configuration.
         do {
@@ -228,6 +229,18 @@ extension MeshNetworkManager {
                 return (UIApplication.shared.delegate as! AppDelegate).connection
             }
         }
+    }
+    
+}
+
+extension AppDelegate: AttentionTimerDelegate {
+    
+    func startAttentionTimer(timeout: TimeInterval) {
+        log(message: "Attention Timer started for \(timeout) seconds", ofCategory: .foundationModel, withLevel: .application)
+    }
+    
+    func stopAttentionTimer() {
+        log(message: "Attention Timer stopped", ofCategory: .foundationModel, withLevel: .application)
     }
     
 }

--- a/Example/Source/UI/Base.lproj/Network.storyboard
+++ b/Example/Source/UI/Base.lproj/Network.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eYe-6v-26u">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eYe-6v-26u">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -1015,7 +1015,7 @@
             <objects>
                 <tableViewController id="veF-nS-gn0" customClass="ModelViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="huL-bC-LUM">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="886"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
@@ -3312,6 +3312,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
+        <segue reference="p59-pA-hy7"/>
         <segue reference="mtt-Te-nBR"/>
         <segue reference="ThO-5P-90Y"/>
         <segue reference="D9f-sQ-QMb"/>
@@ -3327,34 +3328,34 @@
         <image name="rssi_4" width="128" height="128"/>
         <image name="tab_network_outline_black_24pt" width="24" height="24"/>
         <systemColor name="labelColor">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="secondaryLabelColor">
-            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="secondarySystemFillColor">
-            <color red="0.47058823529411764" green="0.47058823529411764" blue="0.50196078431372548" alpha="0.16" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.47058823529999999" green="0.47058823529999999" blue="0.50196078430000002" alpha="0.16" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="secondarySystemGroupedBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="separatorColor">
-            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGreenColor">
-            <color red="0.20392156862745098" green="0.7803921568627451" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.20392156859999999" green="0.78039215689999997" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemGroupedBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="tintColor">
-            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Example/Source/UI/Model/HealthServer.xib
+++ b/Example/Source/UI/Model/HealthServer.xib
@@ -1,0 +1,558 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="1108" id="KGk-i7-Jjw" customClass="HealthServerViewCell" customModule="nRF_Mesh" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="1108"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="1108"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="3" minValue="0.0" maxValue="255" translatesAutoresizingMaskIntoConstraints="NO" id="vGN-7m-gox">
+                        <rect key="frame" x="14" y="11" width="166" height="34"/>
+                        <connections>
+                            <action selector="attentionTimerDidChange:" destination="KGk-i7-Jjw" eventType="valueChanged" id="c3a-wb-Dh1"/>
+                        </connections>
+                    </slider>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3 sec" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3ep-sX-djJ">
+                        <rect key="frame" x="194" y="17" width="110" height="21"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="110" id="Cb4-JC-Cy6"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iUS-CY-z5s">
+                        <rect key="frame" x="16" y="52" width="304" height="0.3333333333333357"/>
+                        <color key="backgroundColor" systemColor="separatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="LOS-Pu-OIu"/>
+                        </constraints>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Acknowledged" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IqY-nd-nP0">
+                        <rect key="frame" x="16" y="65.333333333333329" width="113" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Goj-eh-qvH">
+                        <rect key="frame" x="255" y="60.333333333333343" width="51" height="31"/>
+                        <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </switch>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jeI-VJ-oDL">
+                        <rect key="frame" x="16" y="99.333333333333329" width="304" height="0.3333333333333286"/>
+                        <color key="backgroundColor" systemColor="separatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="Sw6-dr-SZ2"/>
+                        </constraints>
+                    </view>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5UP-cy-2ja">
+                        <rect key="frame" x="257" y="107.66666666666667" width="47" height="32.000000000000014"/>
+                        <state key="normal" title="Button"/>
+                        <buttonConfiguration key="configuration" style="plain" title="Set">
+                            <fontDescription key="titleFontDescription" type="system" pointSize="15"/>
+                        </buttonConfiguration>
+                        <connections>
+                            <action selector="setAttentionTimer:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="h7y-TE-irQ"/>
+                        </connections>
+                    </button>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tm1-eA-Mr0">
+                        <rect key="frame" x="0.0" y="147.66666666666666" width="320" height="56"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ATTENTION TIMER STATUS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6fk-Us-6jq">
+                                <rect key="frame" x="16" y="31" width="178.66666666666666" height="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" red="0.42745098040000001" green="0.42745098040000001" blue="0.44705882349999998" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="bottomMargin" secondItem="6fk-Us-6jq" secondAttribute="bottom" id="TNT-ec-Ucs"/>
+                            <constraint firstItem="6fk-Us-6jq" firstAttribute="leading" secondItem="tm1-eA-Mr0" secondAttribute="leadingMargin" constant="8" id="gen-vc-9if"/>
+                            <constraint firstAttribute="height" constant="56" id="lgF-Cx-W0L"/>
+                        </constraints>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Current" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sb5-9e-FGn">
+                        <rect key="frame" x="16" y="215.66666666666666" width="58" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unknown" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ChH-uc-0Gj">
+                        <rect key="frame" x="232.33333333333334" y="215.66666666666666" width="71.666666666666657" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6aW-Tp-yrV">
+                        <rect key="frame" x="16" y="248.66666666666666" width="304" height="0.33333333333334281"/>
+                        <color key="backgroundColor" systemColor="separatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="GrC-Kd-Iet"/>
+                        </constraints>
+                    </view>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wNs-mR-qqP">
+                        <rect key="frame" x="255.33333333333334" y="257" width="48.666666666666657" height="32"/>
+                        <state key="normal" title="Button"/>
+                        <buttonConfiguration key="configuration" style="plain" title="Get">
+                            <fontDescription key="titleFontDescription" type="system" pointSize="15"/>
+                        </buttonConfiguration>
+                        <connections>
+                            <action selector="getAttentionTimer:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="Gau-T4-Bdf"/>
+                        </connections>
+                    </button>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OxU-Gv-yfq">
+                        <rect key="frame" x="0.0" y="297" width="320" height="56"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="FAST PERIOD DIVISER" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JbA-Jw-yg2">
+                                <rect key="frame" x="16" y="31" width="144.66666666666666" height="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" red="0.42745098040000001" green="0.42745098040000001" blue="0.44705882349999998" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="56" id="KWa-ms-l8Q"/>
+                            <constraint firstItem="JbA-Jw-yg2" firstAttribute="leading" secondItem="OxU-Gv-yfq" secondAttribute="leadingMargin" constant="8" id="nTI-Gm-98W"/>
+                            <constraint firstAttribute="bottomMargin" secondItem="JbA-Jw-yg2" secondAttribute="bottom" id="zCC-14-XwS"/>
+                        </constraints>
+                    </view>
+                    <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="15" translatesAutoresizingMaskIntoConstraints="NO" id="dch-DB-oJ0">
+                        <rect key="frame" x="14" y="361" width="166" height="34"/>
+                        <connections>
+                            <action selector="periodDidChange:" destination="KGk-i7-Jjw" eventType="valueChanged" id="rNn-MB-co5"/>
+                        </connections>
+                    </slider>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="P18-Mr-r3E">
+                        <rect key="frame" x="194" y="367" width="110" height="21"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="110" id="KUk-uM-b86"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a8O-hu-zLa">
+                        <rect key="frame" x="16" y="402" width="304" height="0.33333333333331439"/>
+                        <color key="backgroundColor" systemColor="separatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="vL9-5J-TnJ"/>
+                        </constraints>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Acknowledged" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NOf-Hy-xfB">
+                        <rect key="frame" x="16" y="415.33333333333331" width="113" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xqh-X8-W5l">
+                        <rect key="frame" x="255" y="410.33333333333331" width="51" height="31"/>
+                        <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </switch>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U5b-vg-ed5">
+                        <rect key="frame" x="16" y="449.33333333333331" width="304" height="0.33333333333331439"/>
+                        <color key="backgroundColor" systemColor="separatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="Frt-1c-5kM"/>
+                        </constraints>
+                    </view>
+                    <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TO9-hO-jwQ">
+                        <rect key="frame" x="257" y="457.66666666666669" width="47" height="46.333333333333314"/>
+                        <state key="normal" title="Button"/>
+                        <buttonConfiguration key="configuration" style="plain" title="Set">
+                            <fontDescription key="titleFontDescription" type="system" pointSize="15"/>
+                        </buttonConfiguration>
+                        <connections>
+                            <action selector="setPeriod:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="ZIH-W6-ZWL"/>
+                        </connections>
+                    </button>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jFj-5b-7oi">
+                        <rect key="frame" x="0.0" y="512" width="320" height="56"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="FAST PERIOD DIVISER STATUS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QMR-lF-JcY">
+                                <rect key="frame" x="16" y="31" width="200.33333333333334" height="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" red="0.42745098040000001" green="0.42745098040000001" blue="0.44705882349999998" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="QMR-lF-JcY" firstAttribute="leading" secondItem="jFj-5b-7oi" secondAttribute="leadingMargin" constant="8" id="Euk-1E-agI"/>
+                            <constraint firstAttribute="height" constant="56" id="VpY-ng-Nli"/>
+                            <constraint firstAttribute="bottomMargin" secondItem="QMR-lF-JcY" secondAttribute="bottom" id="qLc-KV-Oab"/>
+                        </constraints>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Current" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="53L-ym-gpq">
+                        <rect key="frame" x="16" y="580" width="58" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unknown" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vOh-4J-b5V">
+                        <rect key="frame" x="232.33333333333334" y="580" width="71.666666666666657" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uFc-el-jI8">
+                        <rect key="frame" x="16" y="613" width="304" height="0.33333333333337123"/>
+                        <color key="backgroundColor" systemColor="separatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="ciW-YO-H0r"/>
+                        </constraints>
+                    </view>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="c3K-iJ-blB">
+                        <rect key="frame" x="255.33333333333334" y="621.33333333333337" width="48.666666666666657" height="32"/>
+                        <state key="normal" title="Button"/>
+                        <buttonConfiguration key="configuration" style="plain" title="Get">
+                            <fontDescription key="titleFontDescription" type="system" pointSize="15"/>
+                        </buttonConfiguration>
+                        <connections>
+                            <action selector="getPeriod:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="qRj-Y5-BFG"/>
+                        </connections>
+                    </button>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iuY-0N-sN2">
+                        <rect key="frame" x="0.0" y="661.33333333333337" width="320" height="56"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="HEALTH FAULT TEST" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vff-Bz-wd9">
+                                <rect key="frame" x="16" y="31" width="137.33333333333334" height="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" red="0.42745098040000001" green="0.42745098040000001" blue="0.44705882349999998" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="bottomMargin" secondItem="Vff-Bz-wd9" secondAttribute="bottom" id="jbo-UQ-bMQ"/>
+                            <constraint firstAttribute="height" constant="56" id="lua-TG-EaQ"/>
+                            <constraint firstItem="Vff-Bz-wd9" firstAttribute="leading" secondItem="iuY-0N-sN2" secondAttribute="leadingMargin" constant="8" id="obu-uj-fiy"/>
+                        </constraints>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Test ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z0D-6F-WaL">
+                        <rect key="frame" x="15.999999999999996" y="732" width="52.666666666666657" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="252" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Decimal (0-255)" textAlignment="right" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="zPM-tU-5RI">
+                        <rect key="frame" x="76.666666666666671" y="725.33333333333337" width="227.33333333333331" height="34"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                    </textField>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tHZ-T5-F0N">
+                        <rect key="frame" x="16" y="767.33333333333337" width="304" height="0.33333333333337123"/>
+                        <color key="backgroundColor" systemColor="separatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="ipA-W5-rVb"/>
+                        </constraints>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Company ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bcg-ov-Cpr">
+                        <rect key="frame" x="16" y="782.33333333333337" width="93" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="0x" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="API-jF-Eha">
+                        <rect key="frame" x="121" y="782.33333333333337" width="19" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="252" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="HEX (e.g. 0059)" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Ol8-ni-jIq">
+                        <rect key="frame" x="148" y="775.66666666666663" width="156" height="34"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <textInputTraits key="textInputTraits"/>
+                    </textField>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sS7-cH-dEP">
+                        <rect key="frame" x="16" y="817.66666666666663" width="304" height="0.33333333333337123"/>
+                        <color key="backgroundColor" systemColor="separatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="tdV-7L-F7o"/>
+                        </constraints>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Acknowledged" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zep-96-dMO">
+                        <rect key="frame" x="16" y="831" width="113" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KWQ-zn-wE3">
+                        <rect key="frame" x="255" y="826" width="51" height="31"/>
+                        <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </switch>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nRS-QY-YuE">
+                        <rect key="frame" x="16" y="865" width="304" height="0.33333333333337123"/>
+                        <color key="backgroundColor" systemColor="separatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="Wdd-nt-Mml"/>
+                        </constraints>
+                    </view>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eXH-OW-OPs">
+                        <rect key="frame" x="251" y="873.33333333333337" width="53" height="32"/>
+                        <state key="normal" title="Button"/>
+                        <buttonConfiguration key="configuration" style="plain" title="Test">
+                            <fontDescription key="titleFontDescription" type="system" pointSize="15"/>
+                        </buttonConfiguration>
+                        <connections>
+                            <action selector="startTest:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="0nE-7y-qkL"/>
+                        </connections>
+                    </button>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zVi-xk-Rum">
+                        <rect key="frame" x="0.0" y="913.33333333333337" width="320" height="56"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="FAULT STATUS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kHX-Us-Wl5">
+                                <rect key="frame" x="16" y="31" width="98" height="17"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <color key="textColor" red="0.42745098040000001" green="0.42745098040000001" blue="0.44705882349999998" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="56" id="AhS-Uz-uxE"/>
+                            <constraint firstItem="kHX-Us-Wl5" firstAttribute="leading" secondItem="zVi-xk-Rum" secondAttribute="leadingMargin" constant="8" id="fqr-6N-jRt"/>
+                            <constraint firstAttribute="bottomMargin" secondItem="kHX-Us-Wl5" secondAttribute="bottom" id="yit-d4-sdD"/>
+                        </constraints>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Company ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dgn-Vn-UMj">
+                        <rect key="frame" x="16" y="984" width="93" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="0x" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RVZ-8f-0nn">
+                        <rect key="frame" x="121" y="984" width="19" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="252" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="HEX (e.g. 0059)" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BMZ-bb-n7M">
+                        <rect key="frame" x="148" y="977.33333333333337" width="156" height="34"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <textInputTraits key="textInputTraits"/>
+                    </textField>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uk1-lR-VZN">
+                        <rect key="frame" x="16" y="1019.3333333333334" width="304" height="0.33333333333337123"/>
+                        <color key="backgroundColor" systemColor="separatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="JVC-q0-pTl"/>
+                        </constraints>
+                    </view>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jeK-bj-iIh">
+                        <rect key="frame" x="255" y="1027.6666666666667" width="49" height="32"/>
+                        <state key="normal" title="Button"/>
+                        <buttonConfiguration key="configuration" style="plain" title="Get">
+                            <fontDescription key="titleFontDescription" type="system" pointSize="15"/>
+                        </buttonConfiguration>
+                        <connections>
+                            <action selector="getFaults:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="q7t-Lf-Q2Z"/>
+                        </connections>
+                    </button>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yO6-ij-Iv2">
+                        <rect key="frame" x="16" y="1067.6666666666667" width="304" height="0.33333333333325754"/>
+                        <color key="backgroundColor" systemColor="separatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="lH2-X3-gPn"/>
+                        </constraints>
+                    </view>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Recent Test ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yMc-3E-P5V">
+                        <rect key="frame" x="15.999999999999993" y="1076" width="110.33333333333331" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unknown" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TVQ-YO-Vcg">
+                        <rect key="frame" x="231.99999999999997" y="1076" width="71.666666666666657" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UPk-fK-H7W">
+                        <rect key="frame" x="187" y="1027.6666666666667" width="60" height="32"/>
+                        <state key="normal" title="Button"/>
+                        <buttonConfiguration key="configuration" style="plain" title="Clear">
+                            <fontDescription key="titleFontDescription" type="system" pointSize="15"/>
+                        </buttonConfiguration>
+                        <connections>
+                            <action selector="clearFaults:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="lap-H4-JnR"/>
+                            <action selector="getFaults:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="ucW-RX-PXI"/>
+                        </connections>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="sS7-cH-dEP" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="0Bq-5W-UxT"/>
+                    <constraint firstItem="zPM-tU-5RI" firstAttribute="top" secondItem="iuY-0N-sN2" secondAttribute="bottom" constant="8" symbolic="YES" id="0MD-70-q2M"/>
+                    <constraint firstItem="xqh-X8-W5l" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="1Em-Mq-MxZ"/>
+                    <constraint firstItem="a8O-hu-zLa" firstAttribute="top" secondItem="dch-DB-oJ0" secondAttribute="bottom" constant="8" symbolic="YES" id="1wT-cY-LYP"/>
+                    <constraint firstItem="6aW-Tp-yrV" firstAttribute="top" secondItem="Sb5-9e-FGn" secondAttribute="bottom" constant="12" id="28B-p3-CC9"/>
+                    <constraint firstItem="Ol8-ni-jIq" firstAttribute="top" secondItem="tHZ-T5-F0N" secondAttribute="bottom" constant="8" symbolic="YES" id="3uw-kD-q2b"/>
+                    <constraint firstItem="nRS-QY-YuE" firstAttribute="top" secondItem="KWQ-zn-wE3" secondAttribute="bottom" constant="8" symbolic="YES" id="4Ho-Et-Ktp"/>
+                    <constraint firstItem="zPM-tU-5RI" firstAttribute="centerY" secondItem="z0D-6F-WaL" secondAttribute="centerY" id="4ZB-I0-C5O"/>
+                    <constraint firstItem="yMc-3E-P5V" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" constant="-7.1054273576010019e-15" id="5PJ-3R-Pe6"/>
+                    <constraint firstItem="uk1-lR-VZN" firstAttribute="top" secondItem="BMZ-bb-n7M" secondAttribute="bottom" constant="8" symbolic="YES" id="5V2-eD-aMg"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="jeK-bj-iIh" secondAttribute="trailing" id="6cD-Gh-6Ol"/>
+                    <constraint firstItem="U5b-vg-ed5" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="6q7-Q8-ImD"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="BMZ-bb-n7M" secondAttribute="trailing" id="76F-yp-fyY"/>
+                    <constraint firstItem="uFc-el-jI8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="7bG-Zh-gQa"/>
+                    <constraint firstItem="ChH-uc-0Gj" firstAttribute="centerY" secondItem="Sb5-9e-FGn" secondAttribute="centerY" id="87W-T0-zlK"/>
+                    <constraint firstAttribute="trailing" secondItem="yO6-ij-Iv2" secondAttribute="trailing" id="8sh-Kb-pLw"/>
+                    <constraint firstAttribute="trailing" secondItem="jeI-VJ-oDL" secondAttribute="trailing" id="8vi-gI-GSF"/>
+                    <constraint firstItem="U5b-vg-ed5" firstAttribute="top" secondItem="xqh-X8-W5l" secondAttribute="bottom" constant="8" symbolic="YES" id="9NW-YB-sPZ"/>
+                    <constraint firstItem="c3K-iJ-blB" firstAttribute="top" secondItem="uFc-el-jI8" secondAttribute="bottom" constant="8" symbolic="YES" id="9nE-lW-jMR"/>
+                    <constraint firstItem="53L-ym-gpq" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="AS2-jT-pOa"/>
+                    <constraint firstItem="zVi-xk-Rum" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="Afs-0w-sRL"/>
+                    <constraint firstItem="dch-DB-oJ0" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Asy-7f-TOD"/>
+                    <constraint firstItem="tHZ-T5-F0N" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="BIL-nE-K0b"/>
+                    <constraint firstItem="sS7-cH-dEP" firstAttribute="top" secondItem="Ol8-ni-jIq" secondAttribute="bottom" constant="8" symbolic="YES" id="BPH-E8-739"/>
+                    <constraint firstAttribute="trailing" secondItem="sS7-cH-dEP" secondAttribute="trailing" id="BdZ-PD-5FL"/>
+                    <constraint firstItem="bcg-ov-Cpr" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="BxU-ky-KPK"/>
+                    <constraint firstItem="Ol8-ni-jIq" firstAttribute="centerY" secondItem="bcg-ov-Cpr" secondAttribute="centerY" id="DBI-c5-Cvz"/>
+                    <constraint firstItem="iUS-CY-z5s" firstAttribute="top" secondItem="vGN-7m-gox" secondAttribute="bottom" constant="8" symbolic="YES" id="DuF-D8-ShJ"/>
+                    <constraint firstItem="zVi-xk-Rum" firstAttribute="top" secondItem="eXH-OW-OPs" secondAttribute="bottom" constant="8" symbolic="YES" id="ECl-MB-c32"/>
+                    <constraint firstItem="TO9-hO-jwQ" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="EdD-C3-agO"/>
+                    <constraint firstItem="iUS-CY-z5s" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Fan-pW-Rvm"/>
+                    <constraint firstAttribute="trailing" secondItem="zVi-xk-Rum" secondAttribute="trailing" id="Fgr-Qx-0SU"/>
+                    <constraint firstItem="RVZ-8f-0nn" firstAttribute="leading" secondItem="Dgn-Vn-UMj" secondAttribute="trailing" constant="12" id="G8e-xh-eKZ"/>
+                    <constraint firstItem="yO6-ij-Iv2" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="GKm-RP-zHq"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="5UP-cy-2ja" secondAttribute="trailing" id="Ggc-Oa-hkh"/>
+                    <constraint firstItem="eXH-OW-OPs" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="HZH-07-EUC"/>
+                    <constraint firstItem="iuY-0N-sN2" firstAttribute="top" secondItem="c3K-iJ-blB" secondAttribute="bottom" constant="8" symbolic="YES" id="Hfa-QN-hnz"/>
+                    <constraint firstItem="API-jF-Eha" firstAttribute="centerY" secondItem="bcg-ov-Cpr" secondAttribute="centerY" id="Igf-4x-2TD"/>
+                    <constraint firstItem="jeI-VJ-oDL" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Ijp-9a-gTp"/>
+                    <constraint firstItem="jeK-bj-iIh" firstAttribute="top" secondItem="uk1-lR-VZN" secondAttribute="bottom" constant="8" symbolic="YES" id="JQH-hJ-A16"/>
+                    <constraint firstItem="BMZ-bb-n7M" firstAttribute="centerY" secondItem="Dgn-Vn-UMj" secondAttribute="centerY" id="KJE-Ce-0pt"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="zPM-tU-5RI" secondAttribute="trailing" id="KO8-QN-VPc"/>
+                    <constraint firstItem="xqh-X8-W5l" firstAttribute="top" secondItem="a8O-hu-zLa" secondAttribute="bottom" constant="8" symbolic="YES" id="L29-Cv-6GK"/>
+                    <constraint firstAttribute="trailing" secondItem="tHZ-T5-F0N" secondAttribute="trailing" id="L5c-qg-gLh"/>
+                    <constraint firstItem="BMZ-bb-n7M" firstAttribute="top" secondItem="zVi-xk-Rum" secondAttribute="bottom" constant="8" symbolic="YES" id="LWr-mh-u5o"/>
+                    <constraint firstItem="uFc-el-jI8" firstAttribute="top" secondItem="53L-ym-gpq" secondAttribute="bottom" constant="12" id="LnA-Ek-lS9"/>
+                    <constraint firstItem="NOf-Hy-xfB" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="MOW-Pb-6nl"/>
+                    <constraint firstItem="5UP-cy-2ja" firstAttribute="top" secondItem="jeI-VJ-oDL" secondAttribute="bottom" constant="8" symbolic="YES" id="MZY-0x-4h8"/>
+                    <constraint firstItem="KWQ-zn-wE3" firstAttribute="top" secondItem="sS7-cH-dEP" secondAttribute="bottom" constant="8" symbolic="YES" id="Mjh-ge-RO4"/>
+                    <constraint firstItem="zep-96-dMO" firstAttribute="centerY" secondItem="KWQ-zn-wE3" secondAttribute="centerY" id="N48-gJ-3BG"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="vOh-4J-b5V" secondAttribute="trailing" id="NVm-Fo-0mf"/>
+                    <constraint firstItem="ChH-uc-0Gj" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="OCP-SB-kbc"/>
+                    <constraint firstItem="vGN-7m-gox" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="OqL-3Y-Za0"/>
+                    <constraint firstItem="UPk-fK-H7W" firstAttribute="centerY" secondItem="jeK-bj-iIh" secondAttribute="centerY" id="Or1-3E-XIu"/>
+                    <constraint firstItem="P18-Mr-r3E" firstAttribute="leading" secondItem="dch-DB-oJ0" secondAttribute="trailing" constant="16" id="PZC-yR-Bry"/>
+                    <constraint firstAttribute="trailing" secondItem="iUS-CY-z5s" secondAttribute="trailing" id="PaH-4l-c3c"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="Goj-eh-qvH" secondAttribute="trailing" id="Pcb-Qj-e9k"/>
+                    <constraint firstItem="dch-DB-oJ0" firstAttribute="top" secondItem="OxU-Gv-yfq" secondAttribute="bottom" constant="8" symbolic="YES" id="RK3-aV-zoA"/>
+                    <constraint firstItem="Sb5-9e-FGn" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="SDP-lt-eCC"/>
+                    <constraint firstAttribute="trailing" secondItem="uFc-el-jI8" secondAttribute="trailing" id="SEs-Ph-O7X"/>
+                    <constraint firstAttribute="trailing" secondItem="sS7-cH-dEP" secondAttribute="trailing" id="SWi-Cd-w6B"/>
+                    <constraint firstItem="sS7-cH-dEP" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="Sae-eZ-QDb"/>
+                    <constraint firstItem="a8O-hu-zLa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="T0y-mR-1Nc"/>
+                    <constraint firstItem="jFj-5b-7oi" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="W3I-IG-5aY"/>
+                    <constraint firstItem="NOf-Hy-xfB" firstAttribute="centerY" secondItem="xqh-X8-W5l" secondAttribute="centerY" id="WYD-jB-J9Z"/>
+                    <constraint firstItem="wNs-mR-qqP" firstAttribute="top" secondItem="6aW-Tp-yrV" secondAttribute="bottom" constant="8" symbolic="YES" id="Woc-jC-nr7"/>
+                    <constraint firstItem="uk1-lR-VZN" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="X2B-MT-1bv"/>
+                    <constraint firstAttribute="trailing" secondItem="a8O-hu-zLa" secondAttribute="trailing" id="X6Q-Pa-GIF"/>
+                    <constraint firstItem="RVZ-8f-0nn" firstAttribute="centerY" secondItem="Dgn-Vn-UMj" secondAttribute="centerY" id="XbX-Lv-b5d"/>
+                    <constraint firstItem="6aW-Tp-yrV" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="ZrY-SQ-ufs"/>
+                    <constraint firstItem="z0D-6F-WaL" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="a4F-xE-yKX"/>
+                    <constraint firstAttribute="trailing" secondItem="6aW-Tp-yrV" secondAttribute="trailing" id="aU1-RO-8YC"/>
+                    <constraint firstItem="zep-96-dMO" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="bRe-A4-gso"/>
+                    <constraint firstItem="jFj-5b-7oi" firstAttribute="top" secondItem="TO9-hO-jwQ" secondAttribute="bottom" constant="8" symbolic="YES" id="bUL-es-U5a"/>
+                    <constraint firstItem="53L-ym-gpq" firstAttribute="top" secondItem="jFj-5b-7oi" secondAttribute="bottom" constant="12" id="blO-nT-UDx"/>
+                    <constraint firstAttribute="trailing" secondItem="U5b-vg-ed5" secondAttribute="trailing" id="bn1-Lw-Guh"/>
+                    <constraint firstAttribute="trailing" secondItem="uk1-lR-VZN" secondAttribute="trailing" id="cbr-Bx-uvb"/>
+                    <constraint firstItem="iuY-0N-sN2" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="cvK-w7-RJW"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="yMc-3E-P5V" secondAttribute="bottom" id="db8-Ux-inK"/>
+                    <constraint firstItem="c3K-iJ-blB" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="e7B-Dz-Zmc"/>
+                    <constraint firstItem="KWQ-zn-wE3" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="eLw-VY-aYl"/>
+                    <constraint firstItem="IqY-nd-nP0" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="esG-JD-aNe"/>
+                    <constraint firstItem="3ep-sX-djJ" firstAttribute="centerY" secondItem="vGN-7m-gox" secondAttribute="centerY" id="euM-fI-iCT"/>
+                    <constraint firstItem="yMc-3E-P5V" firstAttribute="top" secondItem="yO6-ij-Iv2" secondAttribute="bottom" constant="8" symbolic="YES" id="fwj-L8-zGc"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="P18-Mr-r3E" secondAttribute="trailing" id="gHL-Vs-8fG"/>
+                    <constraint firstItem="Dgn-Vn-UMj" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="gwn-TM-gfV"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="TVQ-YO-Vcg" secondAttribute="trailing" constant="0.33333333333337123" id="h9e-cR-2Z9"/>
+                    <constraint firstItem="Sb5-9e-FGn" firstAttribute="top" secondItem="tm1-eA-Mr0" secondAttribute="bottom" constant="12" id="iN0-dp-wKP"/>
+                    <constraint firstItem="eXH-OW-OPs" firstAttribute="top" secondItem="nRS-QY-YuE" secondAttribute="bottom" constant="8" symbolic="YES" id="iT0-ex-32S"/>
+                    <constraint firstItem="API-jF-Eha" firstAttribute="leading" secondItem="bcg-ov-Cpr" secondAttribute="trailing" constant="12" id="jAg-ki-vCV"/>
+                    <constraint firstItem="OxU-Gv-yfq" firstAttribute="top" secondItem="wNs-mR-qqP" secondAttribute="bottom" constant="8" symbolic="YES" id="jO5-xi-Sf0"/>
+                    <constraint firstItem="TO9-hO-jwQ" firstAttribute="top" secondItem="U5b-vg-ed5" secondAttribute="bottom" constant="8" symbolic="YES" id="jkc-4W-Gua"/>
+                    <constraint firstItem="IqY-nd-nP0" firstAttribute="centerY" secondItem="Goj-eh-qvH" secondAttribute="centerY" id="kJL-6z-Wej"/>
+                    <constraint firstItem="zPM-tU-5RI" firstAttribute="leading" secondItem="z0D-6F-WaL" secondAttribute="trailing" constant="8" id="kcf-jB-OZJ"/>
+                    <constraint firstItem="OxU-Gv-yfq" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="kxF-nG-PwE"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="3ep-sX-djJ" secondAttribute="trailing" id="lLn-nl-tcj"/>
+                    <constraint firstItem="TVQ-YO-Vcg" firstAttribute="centerY" secondItem="yMc-3E-P5V" secondAttribute="centerY" id="mIt-5h-2mK"/>
+                    <constraint firstAttribute="trailing" secondItem="tm1-eA-Mr0" secondAttribute="trailing" id="myZ-Qj-1fv"/>
+                    <constraint firstItem="vOh-4J-b5V" firstAttribute="centerY" secondItem="53L-ym-gpq" secondAttribute="centerY" id="nnw-zj-xT2"/>
+                    <constraint firstAttribute="trailing" secondItem="iuY-0N-sN2" secondAttribute="trailing" id="ofo-vt-th9"/>
+                    <constraint firstItem="tm1-eA-Mr0" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="ohQ-Lt-xnH"/>
+                    <constraint firstItem="tHZ-T5-F0N" firstAttribute="top" secondItem="zPM-tU-5RI" secondAttribute="bottom" constant="8" symbolic="YES" id="pbh-3s-1v4"/>
+                    <constraint firstItem="wNs-mR-qqP" firstAttribute="trailing" secondItem="H2p-sc-9uM" secondAttribute="trailingMargin" id="pib-0v-z1o"/>
+                    <constraint firstItem="tm1-eA-Mr0" firstAttribute="top" secondItem="5UP-cy-2ja" secondAttribute="bottom" constant="8" symbolic="YES" id="pkq-yk-BD5"/>
+                    <constraint firstItem="jeK-bj-iIh" firstAttribute="leading" secondItem="UPk-fK-H7W" secondAttribute="trailing" constant="8" symbolic="YES" id="qQ2-cV-cB0"/>
+                    <constraint firstAttribute="trailing" secondItem="nRS-QY-YuE" secondAttribute="trailing" id="qYQ-Ve-cqN"/>
+                    <constraint firstItem="Ol8-ni-jIq" firstAttribute="leading" secondItem="API-jF-Eha" secondAttribute="trailing" constant="8" id="rWi-fh-S8w"/>
+                    <constraint firstItem="vGN-7m-gox" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="uDC-yz-Wzy"/>
+                    <constraint firstItem="3ep-sX-djJ" firstAttribute="leading" secondItem="vGN-7m-gox" secondAttribute="trailing" constant="16" id="uNB-oW-xuG"/>
+                    <constraint firstItem="BMZ-bb-n7M" firstAttribute="leading" secondItem="RVZ-8f-0nn" secondAttribute="trailing" constant="8" id="uWI-zf-bb0"/>
+                    <constraint firstItem="yO6-ij-Iv2" firstAttribute="top" secondItem="jeK-bj-iIh" secondAttribute="bottom" constant="8" symbolic="YES" id="uc1-Si-7Zm"/>
+                    <constraint firstItem="jeI-VJ-oDL" firstAttribute="top" secondItem="Goj-eh-qvH" secondAttribute="bottom" constant="8" symbolic="YES" id="vhE-Vd-Sf2"/>
+                    <constraint firstAttribute="trailing" secondItem="OxU-Gv-yfq" secondAttribute="trailing" id="w4X-QV-RnX"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="Ol8-ni-jIq" secondAttribute="trailing" id="woK-a7-qBc"/>
+                    <constraint firstItem="P18-Mr-r3E" firstAttribute="centerY" secondItem="dch-DB-oJ0" secondAttribute="centerY" id="yQZ-dl-QsT"/>
+                    <constraint firstAttribute="trailing" secondItem="jFj-5b-7oi" secondAttribute="trailing" id="yqu-Cs-2G1"/>
+                    <constraint firstItem="Goj-eh-qvH" firstAttribute="top" secondItem="iUS-CY-z5s" secondAttribute="bottom" constant="8" symbolic="YES" id="zEr-F1-iMx"/>
+                    <constraint firstItem="nRS-QY-YuE" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="zdF-oj-xvc"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="attentionTimerAckSwitch" destination="Goj-eh-qvH" id="mZF-jg-gGj"/>
+                <outlet property="attentionTimerLabel" destination="3ep-sX-djJ" id="2xs-L7-R0i"/>
+                <outlet property="attentionTimerSlider" destination="vGN-7m-gox" id="9Xw-Cz-oBp"/>
+                <outlet property="companyIdField" destination="BMZ-bb-n7M" id="flI-WW-8Hg"/>
+                <outlet property="currentAttentionTimerValue" destination="ChH-uc-0Gj" id="5UZ-QN-VOQ"/>
+                <outlet property="mostRecentTestId" destination="TVQ-YO-Vcg" id="lbb-tE-ffB"/>
+                <outlet property="periodAckSwitch" destination="xqh-X8-W5l" id="MhF-Jo-jtA"/>
+                <outlet property="periodLabel" destination="P18-Mr-r3E" id="RvI-co-Rvm"/>
+                <outlet property="periodSlider" destination="dch-DB-oJ0" id="nnc-Nd-Ybk"/>
+                <outlet property="periodValue" destination="vOh-4J-b5V" id="hAE-hX-hiy"/>
+                <outlet property="testAckSwitch" destination="KWQ-zn-wE3" id="XcL-dc-eVC"/>
+                <outlet property="testCompanyIdField" destination="Ol8-ni-jIq" id="lkv-wZ-Ubv"/>
+                <outlet property="testIdField" destination="zPM-tU-5RI" id="WQc-3b-PQX"/>
+            </connections>
+            <point key="canvasLocation" x="167.93893129770993" y="307.04225352112678"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="separatorColor">
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGroupedBackgroundColor">
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Example/Source/UI/Model/LightLC.xib
+++ b/Example/Source/UI/Model/LightLC.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Example/Source/View Controllers/Network/Configuration/Model/HealthServerViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/HealthServerViewCell.swift
@@ -1,0 +1,205 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import UIKit
+import NordicMesh
+
+class HealthServerViewCell: ModelViewCell, UITextFieldDelegate {
+    
+    @IBOutlet weak var attentionTimerSlider: UISlider!
+    @IBAction func attentionTimerDidChange(_ sender: UISlider) {
+        let value = sender.value
+        attentionTimerLabel.text = "\(Int(value)) sec"
+    }
+    @IBOutlet weak var attentionTimerLabel: UILabel!
+    @IBOutlet weak var attentionTimerAckSwitch: UISwitch!
+    @IBAction func setAttentionTimer(_ sender: UIButton) {
+        let value = UInt8(attentionTimerSlider.value)
+        setAttentionTimer(value)
+    }
+    
+    @IBOutlet weak var currentAttentionTimerValue: UILabel!
+    @IBAction func getAttentionTimer(_ sender: UIButton) {
+        readAttentionTimerDuration()
+    }
+    
+    @IBOutlet weak var periodSlider: UISlider!
+    @IBAction func periodDidChange(_ sender: UISlider) {
+        let value = sender.value
+        periodLabel.text = "\(pow(2, Int(value)))"
+    }
+    @IBOutlet weak var periodLabel: UILabel!
+    @IBOutlet weak var periodAckSwitch: UISwitch!
+    @IBAction func setPeriod(_ sender: UIButton) {
+        let value = UInt8(periodSlider.value)
+        setPeriod(value)
+    }
+    
+    @IBOutlet weak var periodValue: UILabel!
+    @IBAction func getPeriod(_ sender: UIButton) {
+        readPeriod()
+    }
+    
+    @IBOutlet weak var testIdField: UITextField!
+    @IBOutlet weak var testCompanyIdField: UITextField!
+    @IBOutlet weak var testAckSwitch: UISwitch!
+    @IBAction func startTest(_ sender: UIButton) {
+        startTest()
+    }
+    
+    @IBOutlet weak var companyIdField: UITextField!
+    @IBAction func getFaults(_ sender: UIButton) {
+        readFaults()
+    }
+    @IBAction func clearFaults(_ sender: UIButton) {
+        clearFaults()
+    }
+    @IBOutlet weak var mostRecentTestId: UILabel!
+    
+    override func reload(using model: Model) {
+        let companyIdString = model.companyIdentifier?.hex ??
+                              model.parentElement?.parentNode?.companyIdentifier?.hex ??
+                              UInt16.nordicSemiconductorCompanyId.hex
+        if companyIdField.text?.isEmpty ?? true {
+            companyIdField.text = companyIdString
+        }
+        if testCompanyIdField.text?.isEmpty ?? true {
+            testCompanyIdField.text = companyIdString
+        }
+    }
+    
+    override func startRefreshing() -> Bool {
+        readAttentionTimerDuration()
+        return true
+    }
+    
+    override func supports(_ messageType: any MeshMessage.Type) -> Bool {
+        return messageType == HealthPeriodStatus.self
+            || messageType == HealthAttentionStatus.self
+            || messageType == HealthFaultStatus.self
+    }
+    
+    override func meshNetworkManager(_ manager: MeshNetworkManager,
+                                     didReceiveMessage message: any MeshMessage,
+                                     sentFrom source: Address, to destination: MeshAddress) -> Bool {
+        switch message {
+            
+        case let status as HealthAttentionStatus:
+            currentAttentionTimerValue.text = "\(status.attentionTimer) sec"
+            if delegate?.isRefreshing ?? false {
+                readPeriod()
+                return true
+            }
+            return false
+            
+        case let status as HealthPeriodStatus:
+            periodValue.text = "\(pow(2, Int(status.fastPeriodDivisor)))"
+            if delegate?.isRefreshing ?? false {
+                return readFaults()
+            }
+            return false
+            
+        case let status as HealthFaultStatus:
+            mostRecentTestId.text = "\(status.testId)"
+            return false
+            
+        default:
+            fatalError()
+        }
+    }
+}
+
+private extension HealthServerViewCell {
+    
+    func readAttentionTimerDuration() {
+        let message = HealthAttentionGet()
+        delegate?.send(message, description: "Reading Attention Timer...")
+    }
+    
+    func setAttentionTimer(_ value: UInt8) {
+        let duration = TimeInterval(value)
+        if attentionTimerAckSwitch.isOn {
+            let request = HealthAttentionSet(duration)
+            delegate?.send(request, description: "Setting Attention Timer...")
+        } else {
+            let request = HealthAttentionSetUnacknowledged(duration)
+            delegate?.send(request, description: "Setting Attention Timer...")
+        }
+    }
+    
+    func readPeriod() {
+        let message = HealthPeriodGet()
+        delegate?.send(message, description: "Reading Fast Period Divider...")
+    }
+    
+    func setPeriod(_ value: UInt8) {
+        if periodAckSwitch.isOn {
+            let request = HealthPeriodSet(fastPeriodDivisor: value)
+            delegate?.send(request, description: "Setting Fast Period Divider...")
+        } else {
+            let request = HealthPeriodSetUnacknowledged(fastPeriodDivisor: value)
+            delegate?.send(request, description: "Setting Fast Period Divider...")
+        }
+    }
+    
+    func startTest() {
+        guard let companyId = UInt16(testCompanyIdField.text!, radix: 16),
+              let testId = UInt8(testIdField.text!) else {
+            return
+        }
+        if testAckSwitch.isOn {
+            let message = HealthFaultTest(testId: testId, for: companyId)
+            delegate?.send(message, description: "Starting Test...")
+        } else {
+            let message = HealthFaultTestUnacknowledged(testId: testId, for: companyId)
+            delegate?.send(message, description: "Starting Test...")
+        }
+    }
+    
+    @discardableResult
+    func readFaults() -> Bool {
+        guard let companyId = UInt16(companyIdField.text!, radix: 16) else {
+            return false
+        }
+        let message = HealthFaultGet(for: companyId)
+        delegate?.send(message, description: "Reading Faults...")
+        return true
+    }
+    
+    func clearFaults() {
+        guard let companyId = UInt16(companyIdField.text!, radix: 16) else {
+            return
+        }
+        let message = HealthFaultClear(for: companyId)
+        delegate?.send(message, description: "Clearing Faults...")
+        return
+    }
+    
+}

--- a/Example/nRF Mesh.xcodeproj/project.pbxproj
+++ b/Example/nRF Mesh.xcodeproj/project.pbxproj
@@ -192,6 +192,8 @@
 		F0FB18F72B8E90CF00683C3F /* LightLCViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0FB18F52B8E90CF00683C3F /* LightLCViewCell.swift */; };
 		F0FB18F82B8E90CF00683C3F /* LightLC.xib in Resources */ = {isa = PBXBuildFile; fileRef = F0FB18F62B8E90CF00683C3F /* LightLC.xib */; };
 		F0FB18FA2B8E919C00683C3F /* LightLCClientDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0FB18F92B8E919C00683C3F /* LightLCClientDelegate.swift */; };
+		F0FEE6F72D5374580092B7B7 /* HealthServer.xib in Resources */ = {isa = PBXBuildFile; fileRef = F0FEE6F62D5374580092B7B7 /* HealthServer.xib */; };
+		F0FEE6F92D539CE90092B7B7 /* HealthServerViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0FEE6F82D539CDD0092B7B7 /* HealthServerViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -403,6 +405,8 @@
 		F0FB18F52B8E90CF00683C3F /* LightLCViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCViewCell.swift; sourceTree = "<group>"; };
 		F0FB18F62B8E90CF00683C3F /* LightLC.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LightLC.xib; sourceTree = "<group>"; };
 		F0FB18F92B8E919C00683C3F /* LightLCClientDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCClientDelegate.swift; sourceTree = "<group>"; };
+		F0FEE6F62D5374580092B7B7 /* HealthServer.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HealthServer.xib; sourceTree = "<group>"; };
+		F0FEE6F82D539CDD0092B7B7 /* HealthServerViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthServerViewCell.swift; sourceTree = "<group>"; };
 		F57EEAABA13E16EBDF1CADFD /* Pods_nRF_Mesh_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_nRF_Mesh_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -509,6 +513,7 @@
 				5231403B22FDA8670074325A /* ConfigurationServer.xib */,
 				52A9C17C230EB9490036792A /* GenericOnOff.xib */,
 				F0FB18F62B8E90CF00683C3F /* LightLC.xib */,
+				F0FEE6F62D5374580092B7B7 /* HealthServer.xib */,
 				A7A59BD4277225A70045A8ED /* GenericPowerOnOff.xib */,
 				A7B526A6277B210000F5C60D /* GenericPowerOnOffSetup.xib */,
 				52A9C1C42313D7D80036792A /* GenericLevel.xib */,
@@ -528,6 +533,7 @@
 				A7B526A5277B210000F5C60D /* GenericPowerOnOffSetupViewCell.swift */,
 				52A9C1C32313D7D80036792A /* GenericLevelViewCell.swift */,
 				5217D2E3250F90D8004FDE79 /* GenericDefaultTransitionTimeViewCell.swift */,
+				F0FEE6F82D539CDD0092B7B7 /* HealthServerViewCell.swift */,
 				F0FB18F52B8E90CF00683C3F /* LightLCViewCell.swift */,
 				5231404B230AC4680074325A /* VendorModelViewCell.swift */,
 			);
@@ -1072,6 +1078,7 @@
 				521599DB25E9306300F602FA /* CHANGELOG.md in Resources */,
 				F0FB18F82B8E90CF00683C3F /* LightLC.xib in Resources */,
 				52A8EA8B24E6A371004C14C7 /* SetHeartbeatPublication.storyboard in Resources */,
+				F0FEE6F72D5374580092B7B7 /* HealthServer.xib in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
 				52835250227887970097B949 /* Settings.storyboard in Resources */,
 			);
@@ -1304,6 +1311,7 @@
 				F0FB18F72B8E90CF00683C3F /* LightLCViewCell.swift in Sources */,
 				F085CA0829D70ACB00C2DF89 /* ConfigurationViewController.swift in Sources */,
 				F03414872B91373E009DD792 /* LightLCLightOnOffGroupCell.swift in Sources */,
+				F0FEE6F92D539CE90092B7B7 /* HealthServerViewCell.swift in Sources */,
 				52547F26232A3F470002AA7B /* ProvisionersViewController.swift in Sources */,
 				529EC8DA2A309C640056BB48 /* CompanyIdentifier.swift in Sources */,
 				5267FDCD2A02937E00ECD38B /* CustomConfigCell.swift in Sources */,

--- a/Example/nRF Mesh.xcodeproj/project.pbxproj
+++ b/Example/nRF Mesh.xcodeproj/project.pbxproj
@@ -1586,8 +1586,10 @@
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
 				CODE_SIGN_ENTITLEMENTS = "nRF Mesh.entitlements";
 				CURRENT_PROJECT_VERSION = 2;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = P3R8YQEV4L;
 				ENABLE_BITCODE = NO;
+				ENABLE_DEBUG_DYLIB = YES;
 				INFOPLIST_FILE = Source/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "nRF Mesh";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
@@ -1619,8 +1621,10 @@
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = NO;
 				CODE_SIGN_ENTITLEMENTS = "nRF Mesh.entitlements";
 				CURRENT_PROJECT_VERSION = 2;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = P3R8YQEV4L;
 				ENABLE_BITCODE = NO;
+				ENABLE_DEBUG_DYLIB = YES;
 				INFOPLIST_FILE = Source/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "nRF Mesh";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";

--- a/Library/Documentation.docc/MeshNetworkManager.md
+++ b/Library/Documentation.docc/MeshNetworkManager.md
@@ -29,6 +29,7 @@ Use it to create, load or import a Bluetooth mesh network and send messages.
 - ``delegate``
 - ``transmitter``
 - ``logger``
+- ``attentionTimerDelegate``
 
 ### Provisioning
 

--- a/Library/Documentation.docc/NordicMesh.md
+++ b/Library/Documentation.docc/NordicMesh.md
@@ -397,6 +397,7 @@ Provisioning is the process of adding an unprovisioned device to a mesh network 
 - ``HealthAttentionSet``
 - ``HealthAttentionSetUnacknowledged``
 - ``HealthAttentionStatus``
+- ``AttentionTimerDelegate``
 
 ### Remote Provisioning Message Types
 

--- a/Library/Layers/Foundation Layer/HealthServerHandler.swift
+++ b/Library/Layers/Foundation Layer/HealthServerHandler.swift
@@ -36,7 +36,8 @@
 ///
 // TODO: Currently, the Current Fault state always contains no faults.
 class HealthServerHandler: ModelDelegate {
-    weak var meshNetwork: MeshNetwork!
+    private weak var meshNetwork: MeshNetwork!
+    private weak var manager: MeshNetworkManager!
     
     /// Identifier of a most recently performed self-test/
     private var mostRecentTestId: UInt8 = 0
@@ -47,7 +48,9 @@ class HealthServerHandler: ModelDelegate {
     /// the corresponding record is removed from the state automatically.
     private var currentFaultState: [HealthFault] = [] {
         didSet {
-            // TODO: Changing this value should publish Health Current Status message
+            if let manager = manager {
+                publish(using: manager)
+            }
             
             // Whenever a fault condition has been present in the
             // Current Fault state, the corresponding record is added
@@ -88,7 +91,7 @@ class HealthServerHandler: ModelDelegate {
     
     // TODO: Add some API to emulate faults
     
-    init(_ meshNetwork: MeshNetwork) {
+    init(_ meshNetwork: MeshNetwork?, _ manager: MeshNetworkManager) {
         let types: [StaticMeshMessage.Type] = [
             HealthFaultGet.self,
             HealthFaultClear.self,
@@ -102,7 +105,9 @@ class HealthServerHandler: ModelDelegate {
             HealthPeriodSet.self,
             HealthPeriodSetUnacknowledged.self
         ]
-        messageTypes = types.toMap()
+        self.messageTypes = types.toMap()
+        self.meshNetwork = meshNetwork
+        self.manager = manager
     }
     
     func model(_ model: Model, didReceiveAcknowledgedMessage request: any AcknowledgedMeshMessage,

--- a/Library/Layers/Foundation Layer/HealthServerHandler.swift
+++ b/Library/Layers/Foundation Layer/HealthServerHandler.swift
@@ -121,13 +121,13 @@ class HealthServerHandler: ModelDelegate {
             attentionTimer?.invalidate()
             let duration = TimeInterval(request.attentionTimer)
             if duration > 0 {
-                manager?.attentionTimerDelegate?.startAttentionTimer(timeout: duration)
+                manager?.attentionTimerDelegate?.attentionTimerDidStart(duration: duration)
                 attentionTimer = BackgroundTimer.scheduledTimer(withTimeInterval: duration, repeats: false) { [weak self] _ in
-                    self?.manager?.attentionTimerDelegate?.stopAttentionTimer()
+                    self?.manager?.attentionTimerDelegate?.attentionTimerDidStop()
                     self?.attentionTimer = nil
                 }
             } else if let attentionTimer = attentionTimer {
-                manager?.attentionTimerDelegate?.stopAttentionTimer()
+                manager?.attentionTimerDelegate?.attentionTimerDidStop()
                 self.attentionTimer = nil
             }
             return HealthAttentionStatus(duration)
@@ -197,13 +197,13 @@ class HealthServerHandler: ModelDelegate {
             attentionTimer?.invalidate()
             let duration = TimeInterval(request.attentionTimer)
             if duration > 0 {
-                manager?.attentionTimerDelegate?.startAttentionTimer(timeout: duration)
+                manager?.attentionTimerDelegate?.attentionTimerDidStart(duration: duration)
                 attentionTimer = BackgroundTimer.scheduledTimer(withTimeInterval: duration, repeats: false) { [weak self] _ in
-                    self?.manager?.attentionTimerDelegate?.stopAttentionTimer()
+                    self?.manager?.attentionTimerDelegate?.attentionTimerDidStop()
                     self?.attentionTimer = nil
                 }
             } else if let attentionTimer = attentionTimer {
-                manager?.attentionTimerDelegate?.stopAttentionTimer()
+                manager?.attentionTimerDelegate?.attentionTimerDidStop()
                 self.attentionTimer = nil
             }
             

--- a/Library/Mesh Messages/Health/HealthAttentionSet.swift
+++ b/Library/Mesh Messages/Health/HealthAttentionSet.swift
@@ -52,7 +52,6 @@ public struct HealthAttentionSet: StaticAcknowledgedMeshMessage {
     ///
     /// Set to 0 if the Timer is off, or not supported.
     public let attentionTimer: UInt8
-    
     /// Returns whether the Attention Timer is on, or off.
     public var isOn: Bool {
         return attentionTimer != 0

--- a/Library/Mesh Messages/Health/HealthAttentionSetUnacknowledged.swift
+++ b/Library/Mesh Messages/Health/HealthAttentionSetUnacknowledged.swift
@@ -51,7 +51,6 @@ public struct HealthAttentionSetUnacknowledged: StaticUnacknowledgedMeshMessage 
     ///
     /// Set to 0 if the Timer is off, or not supported.
     public let attentionTimer: UInt8
-    
     /// Returns whether the Attention Timer is on, or off.
     public var isOn: Bool {
         return attentionTimer != 0

--- a/Library/Mesh Messages/Health/HealthAttentionStatus.swift
+++ b/Library/Mesh Messages/Health/HealthAttentionStatus.swift
@@ -51,7 +51,6 @@ public struct HealthAttentionStatus: StaticMeshResponse {
     ///
     /// Set to 0 if the Timer is off, or not supported.
     public let attentionTimer: UInt8
-    
     /// Returns whether the Attention Timer is on, or off.
     public var isOn: Bool {
         return attentionTimer != 0

--- a/Library/Mesh Messages/Health/HealthCurrentStatus.swift
+++ b/Library/Mesh Messages/Health/HealthCurrentStatus.swift
@@ -50,10 +50,8 @@ public struct HealthCurrentStatus: StaticMeshResponse {
 
     /// Identifier of a most recently performed test.
     public let testId: UInt8
-
     /// 16-bit Bluetooth assigned Company Identifier.
     public let companyIdentifier: UInt16
-    
     /// List of faults.
     ///
     /// If no Fault fields are present (nil), it means no registered fault condition exists on an Element.
@@ -79,7 +77,7 @@ public struct HealthCurrentStatus: StaticMeshResponse {
         companyIdentifier = parameters.read(fromOffset: 1)
         if parameters.count > 3 {
             faults = parameters
-                .subdata(in: 3..<parameters.count - 3)
+                .subdata(in: 3..<parameters.count)
                 .compactMap { HealthFault.fromId($0) }
         } else {
             faults = []

--- a/Library/Mesh Messages/Health/HealthFault.swift
+++ b/Library/Mesh Messages/Health/HealthFault.swift
@@ -31,7 +31,7 @@
 */
 
 /// Health Fault IDs assigned to the health models.
-public enum HealthFault: Sendable {
+public enum HealthFault: Sendable, Hashable, Equatable {
     case noFault
     case batteryLowWarning
     case batteryLowError
@@ -86,224 +86,186 @@ public enum HealthFault: Sendable {
     case vendor(_ id: UInt8)
         
     /// The ID of the fault.
-    var id : UInt8 {
+    var id: UInt8 {
         switch self {
-        case .noFault:
-            return 0x00;
-        case .batteryLowWarning:
-            return 0x01;
-        case .batteryLowError:
-            return 0x02;
-        case .supplyVoltageToLowWarning:
-            return 0x03;
-        case .supplyVoltageToLowError:
-            return 0x04;
-        case .supplyVoltageToHighWarning:
-            return 0x05;
-        case .supplyVoltageToHighError:
-            return 0x06;
-        case .powerSupplyInterruptedWarning:
-            return 0x07;
-        case .powerSupplyInterruptedError:
-            return 0x08;
-        case .noLoadWarning:
-            return 0x09;
-        case .noLoadError:
-            return 0x0A;
-        case .overloadWarning:
-            return 0x0B;
-        case .overloadError:
-            return 0x0C;
-        case .overheatWarning:
-            return 0x0D;
-        case .overheatError:
-            return 0x0E;
-        case .condensationWarning:
-            return 0x0F;
-        case .condensationError:
-            return 0x10;
-        case .vibrationWarning:
-            return 0x11;
-        case .vibrationError:
-            return 0x12;
-        case .configurationWarning:
-            return 0x13;
-        case .configurationError:
-            return 0x14;
-        case .elementNotCalibratedWarning:
-            return 0x15;
-        case .elementNotCalibratedError:
-            return 0x16;
-        case .memoryWarning:
-            return 0x17;
-        case .memoryError:
-            return 0x18;
-        case .selfTestWarning:
-            return 0x19;
-        case .selfTestError:
-            return 0x1A;
-        case .inputTooLowWarning:
-            return 0x1B;
-        case .inputTooLowError:
-            return 0x1C;
-        case .inputTooHighWarning:
-            return 0x1D;
-        case .inputTooHighError:
-            return 0x1E;
-        case .inputNoChangeWarning:
-            return 0x1F;
-        case .inputNoChangeError:
-            return 0x20;
-        case .actuatorBlockedWarning:
-            return 0x21;
-        case .actuatorBlockedError:
-            return 0x22;
-        case .housingOpenedWarning:
-            return 0x23;
-        case .housingOpenedError:
-            return 0x24;
-        case .tamperWarning:
-            return 0x25;
-        case .tamperError:
-            return 0x26;
-        case .deviceMovedWarning:
-            return 0x27;
-        case .deviceMovedError:
-            return 0x28;
-        case .deviceDroppedWarning:
-            return 0x29;
-        case .deviceDroppedError:
-            return 0x2A;
-        case .overflowWarning:
-            return 0x2B;
-        case .overflowError:
-            return 0x2C;
-        case .emptyWarning:
-            return 0x2D;
-        case .emptyError:
-            return 0x2E;
-        case .internalBusWarning:
-            return 0x2F;
-        case .internalBUError:
-            return 0x30;
-        case .mechanismJammedWarning:
-            return 0x31;
-        case .mechanismJammedError:
-            return 0x32;
-        case .vendor(let id):
-            return id
+        case .noFault:                       return 0x00
+        case .batteryLowWarning:             return 0x01
+        case .batteryLowError:               return 0x02
+        case .supplyVoltageToLowWarning:     return 0x03
+        case .supplyVoltageToLowError:       return 0x04
+        case .supplyVoltageToHighWarning:    return 0x05
+        case .supplyVoltageToHighError:      return 0x06
+        case .powerSupplyInterruptedWarning: return 0x07
+        case .powerSupplyInterruptedError:   return 0x08
+        case .noLoadWarning:                 return 0x09
+        case .noLoadError:                   return 0x0A
+        case .overloadWarning:               return 0x0B
+        case .overloadError:                 return 0x0C
+        case .overheatWarning:               return 0x0D
+        case .overheatError:                 return 0x0E
+        case .condensationWarning:           return 0x0F
+        case .condensationError:             return 0x10
+        case .vibrationWarning:              return 0x11
+        case .vibrationError:                return 0x12
+        case .configurationWarning:          return 0x13
+        case .configurationError:            return 0x14
+        case .elementNotCalibratedWarning:   return 0x15
+        case .elementNotCalibratedError:     return 0x16
+        case .memoryWarning:                 return 0x17
+        case .memoryError:                   return 0x18
+        case .selfTestWarning:               return 0x19
+        case .selfTestError:                 return 0x1A
+        case .inputTooLowWarning:            return 0x1B
+        case .inputTooLowError:              return 0x1C
+        case .inputTooHighWarning:           return 0x1D
+        case .inputTooHighError:             return 0x1E
+        case .inputNoChangeWarning:          return 0x1F
+        case .inputNoChangeError:            return 0x20
+        case .actuatorBlockedWarning:        return 0x21
+        case .actuatorBlockedError:          return 0x22
+        case .housingOpenedWarning:          return 0x23
+        case .housingOpenedError:            return 0x24
+        case .tamperWarning:                 return 0x25
+        case .tamperError:                   return 0x26
+        case .deviceMovedWarning:            return 0x27
+        case .deviceMovedError:              return 0x28
+        case .deviceDroppedWarning:          return 0x29
+        case .deviceDroppedError:            return 0x2A
+        case .overflowWarning:               return 0x2B
+        case .overflowError:                 return 0x2C
+        case .emptyWarning:                  return 0x2D
+        case .emptyError:                    return 0x2E
+        case .internalBusWarning:            return 0x2F
+        case .internalBUError:               return 0x30
+        case .mechanismJammedWarning:        return 0x31
+        case .mechanismJammedError:          return 0x32
+        case .vendor(let id):                return id
         }
     }
     
     /// Creates a ``HealthFault`` from the given ID.
     static func fromId(_ id: UInt8) -> HealthFault? {
         switch id {
-        case 0x00:
-            return .noFault;
-        case 0x01:
-            return .batteryLowWarning;
-        case 0x02:
-            return .batteryLowError;
-        case 0x03:
-            return .supplyVoltageToLowWarning;
-        case 0x04:
-            return .supplyVoltageToLowError;
-        case 0x05:
-            return .supplyVoltageToHighWarning;
-        case 0x06:
-            return .supplyVoltageToHighError;
-        case 0x07:
-            return .powerSupplyInterruptedWarning;
-        case 0x08:
-            return .powerSupplyInterruptedError;
-        case 0x09:
-            return .noLoadWarning;
-        case 0x0A:
-            return .noLoadError;
-        case 0x0B:
-            return .overloadWarning;
-        case 0x0C:
-            return .overloadError;
-        case 0x0D:
-            return .overheatWarning;
-        case 0x0E:
-            return .overheatError;
-        case 0x0F:
-            return .condensationWarning;
-        case 0x10:
-            return .condensationError;
-        case 0x11:
-            return .vibrationWarning;
-        case 0x12:
-            return .vibrationError;
-        case 0x13:
-            return .configurationWarning;
-        case 0x14:
-            return .configurationError;
-        case 0x15:
-            return .elementNotCalibratedWarning;
-        case 0x16:
-            return .elementNotCalibratedError;
-        case 0x17:
-            return .memoryWarning;
-        case 0x18:
-            return .memoryError;
-        case 0x19:
-            return .selfTestWarning;
-        case 0x1A:
-            return .selfTestError;
-        case 0x1B:
-            return .inputTooLowWarning;
-        case 0x1C:
-            return .inputTooLowError;
-        case 0x1D:
-            return .inputTooHighWarning;
-        case 0x1E:
-            return .inputTooHighError;
-        case 0x1F:
-            return .inputNoChangeWarning;
-        case 0x20:
-            return .inputNoChangeError;
-        case 0x21:
-            return .actuatorBlockedWarning;
-        case 0x22:
-            return .actuatorBlockedError;
-        case 0x23:
-            return .housingOpenedWarning;
-        case 0x24:
-            return .housingOpenedError;
-        case 0x25:
-            return .tamperWarning;
-        case 0x26:
-            return .tamperError;
-        case 0x27:
-            return .deviceMovedWarning;
-        case 0x28:
-            return .deviceMovedError;
-        case 0x29:
-            return .deviceDroppedWarning;
-        case 0x2A:
-            return .deviceDroppedError;
-        case 0x2B:
-            return .overflowWarning;
-        case 0x2C:
-            return .overflowError;
-        case 0x2D:
-            return .emptyWarning;
-        case 0x2E:
-            return .emptyError;
-        case 0x2F:
-            return .internalBusWarning;
-        case 0x30:
-            return .internalBUError;
-        case 0x31:
-            return .mechanismJammedWarning;
-        case 0x32:
-            return .mechanismJammedError;
-        case 0x80...0xFF:
-            return .vendor(id)
-        default:
-            return nil
+        case 0x00:        return .noFault
+        case 0x01:        return .batteryLowWarning
+        case 0x02:        return .batteryLowError
+        case 0x03:        return .supplyVoltageToLowWarning
+        case 0x04:        return .supplyVoltageToLowError
+        case 0x05:        return .supplyVoltageToHighWarning
+        case 0x06:        return .supplyVoltageToHighError
+        case 0x07:        return .powerSupplyInterruptedWarning
+        case 0x08:        return .powerSupplyInterruptedError
+        case 0x09:        return .noLoadWarning
+        case 0x0A:        return .noLoadError
+        case 0x0B:        return .overloadWarning
+        case 0x0C:        return .overloadError
+        case 0x0D:        return .overheatWarning
+        case 0x0E:        return .overheatError
+        case 0x0F:        return .condensationWarning
+        case 0x10:        return .condensationError
+        case 0x11:        return .vibrationWarning
+        case 0x12:        return .vibrationError
+        case 0x13:        return .configurationWarning
+        case 0x14:        return .configurationError
+        case 0x15:        return .elementNotCalibratedWarning
+        case 0x16:        return .elementNotCalibratedError
+        case 0x17:        return .memoryWarning
+        case 0x18:        return .memoryError
+        case 0x19:        return .selfTestWarning
+        case 0x1A:        return .selfTestError
+        case 0x1B:        return .inputTooLowWarning
+        case 0x1C:        return .inputTooLowError
+        case 0x1D:        return .inputTooHighWarning
+        case 0x1E:        return .inputTooHighError
+        case 0x1F:        return .inputNoChangeWarning
+        case 0x20:        return .inputNoChangeError
+        case 0x21:        return .actuatorBlockedWarning
+        case 0x22:        return .actuatorBlockedError
+        case 0x23:        return .housingOpenedWarning
+        case 0x24:        return .housingOpenedError
+        case 0x25:        return .tamperWarning
+        case 0x26:        return .tamperError
+        case 0x27:        return .deviceMovedWarning
+        case 0x28:        return .deviceMovedError
+        case 0x29:        return .deviceDroppedWarning
+        case 0x2A:        return .deviceDroppedError
+        case 0x2B:        return .overflowWarning
+        case 0x2C:        return .overflowError
+        case 0x2D:        return .emptyWarning
+        case 0x2E:        return .emptyError
+        case 0x2F:        return .internalBusWarning
+        case 0x30:        return .internalBUError
+        case 0x31:        return .mechanismJammedWarning
+        case 0x32:        return .mechanismJammedError
+        case 0x80...0xFF: return .vendor(id)
+        default:          return nil
+        }
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+    
+    public static func == (lhs: HealthFault, rhs: HealthFault) -> Bool {
+        return lhs.id == rhs.id
+    }
+}
+
+extension HealthFault: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .noFault:                       return "No Fault"
+        case .batteryLowWarning:             return "Warning: Battery Low"
+        case .batteryLowError:               return "Error: Battery Low"
+        case .supplyVoltageToLowWarning:     return "Warning: Supply Voltage Too Low"
+        case .supplyVoltageToLowError:       return "Error: Supply Voltage Too Low"
+        case .supplyVoltageToHighWarning:    return "Warning: Supply Voltage Too High"
+        case .supplyVoltageToHighError:      return "Error: Supply Voltage Too High"
+        case .powerSupplyInterruptedWarning: return "Warning: Power Supply Interrupted Warning"
+        case .powerSupplyInterruptedError:   return "Error: Power Supply Interrupted"
+        case .noLoadWarning:                 return "Warning: No Load"
+        case .noLoadError:                   return "Error: No Load"
+        case .overloadWarning:               return "Warning: Overload"
+        case .overloadError:                 return "Error: Overload"
+        case .overheatWarning:               return "Warning: Overheat"
+        case .overheatError:                 return "Error: Overheat"
+        case .condensationWarning:           return "Warning: Condensation"
+        case .condensationError:             return "Error: Condensation"
+        case .vibrationWarning:              return "Warning: Vibration"
+        case .vibrationError:                return "Error: Vibration"
+        case .configurationWarning:          return "Warning: Configuration"
+        case .configurationError:            return "Error: Configuration"
+        case .elementNotCalibratedWarning:   return "Warning: Element Not Calibrated"
+        case .elementNotCalibratedError:     return "Error: Element Not Calibrated"
+        case .memoryWarning:                 return "Memory Warning"
+        case .memoryError:                   return "Memory Error"
+        case .selfTestWarning:               return "Warning: Self Test"
+        case .selfTestError:                 return "Error: Self Test"
+        case .inputTooLowWarning:            return "Warning: Input Too Low"
+        case .inputTooLowError:              return "Error: Input Too Low"
+        case .inputTooHighWarning:           return "Warning: Input Too High"
+        case .inputTooHighError:             return "Error: Input Too High"
+        case .inputNoChangeWarning:          return "Warning: Input No Change"
+        case .inputNoChangeError:            return "Error: Input No Change"
+        case .actuatorBlockedWarning:        return "Warning: Actuator Blocked"
+        case .actuatorBlockedError:          return "Error: Actuator Blocked"
+        case .housingOpenedWarning:          return "Warning: Housing Opened"
+        case .housingOpenedError:            return "Error: Housing Opened"
+        case .tamperWarning:                 return "Warning: Tamper"
+        case .tamperError:                   return "Error: Tamper"
+        case .deviceMovedWarning:            return "Warning: Device Moved"
+        case .deviceMovedError:              return "Error: Device Moved"
+        case .deviceDroppedWarning:          return "Warning: Device Dropped"
+        case .deviceDroppedError:            return "Error: Device Dropped"
+        case .overflowWarning:               return "Warning: Overflow"
+        case .overflowError:                 return "Error: Overflow"
+        case .emptyWarning:                  return "Warning: Empty"
+        case .emptyError:                    return "Error: Empty"
+        case .internalBusWarning:            return "Warning: Internal Bus"
+        case .internalBUError:               return "Error: Internal Bus"
+        case .mechanismJammedWarning:        return "Warning: Mechanism Jammed"
+        case .mechanismJammedError:          return "Error: Mechanism Jammed"
+        case .vendor(let id):                return "Vendor (\(id))"
         }
     }
 }

--- a/Library/Mesh Messages/Health/HealthFaultStatus.swift
+++ b/Library/Mesh Messages/Health/HealthFaultStatus.swift
@@ -50,10 +50,8 @@ public struct HealthFaultStatus: StaticMeshResponse {
 
     /// Identifier of a most recently performed test.
     public let testId: UInt8
-
     /// 16-bit Bluetooth assigned Company Identifier.
     public let companyIdentifier: UInt16
-    
     /// List of faults.
     ///
     /// If no Fault fields are present, it means no registered fault condition exists on an Element.
@@ -79,7 +77,7 @@ public struct HealthFaultStatus: StaticMeshResponse {
         companyIdentifier = parameters.read(fromOffset: 1)
         if parameters.count > 3 {
             faults = parameters
-                .subdata(in: 3..<parameters.count - 3)
+                .subdata(in: 3..<parameters.count)
                 .compactMap { HealthFault.fromId($0) }
         } else {
             faults = []

--- a/Library/Mesh Messages/Health/HealthFaultTestUnacknowledged.swift
+++ b/Library/Mesh Messages/Health/HealthFaultTestUnacknowledged.swift
@@ -43,7 +43,6 @@ public struct HealthFaultTestUnacknowledged: StaticUnacknowledgedMeshMessage {
 
     /// Identifier of a specific test to be performed.
     public let testId: UInt8
-    
     /// 16-bit Bluetooth assigned Company Identifier.
     public let companyIdentifier: UInt16
     

--- a/Library/Mesh Model/Element.swift
+++ b/Library/Mesh Model/Element.swift
@@ -53,7 +53,7 @@ public class Element: Codable {
     /// Description of the Element's location.
     public internal(set) var location: Location
     /// An array of Model objects in the Element.
-    public private(set) var models: [Model]
+    public internal(set) var models: [Model]
     
     /// Parent Node. This may be `nil` if the Element was obtained in
     /// Composition Data and has not yet been added to a Node.
@@ -177,46 +177,6 @@ internal extension Element {
     func insert(model: Model, at i: Int) {
         models.insert(model, at: i)
         model.parentElement = self
-    }
-    
-    /// This methods adds the natively supported Models to the Element.
-    ///
-    /// This method should only be called for the primary Element of the
-    /// local Node.
-    ///
-    /// - parameter meshNetwork: The mesh network object.
-    func addPrimaryElementModels(_ meshNetwork: MeshNetwork) {
-        guard isPrimary else { return }
-        insert(model: Model(sigModelId: .configurationServerModelId,
-                            delegate: ConfigurationServerHandler(meshNetwork)), at: 0)
-        insert(model: Model(sigModelId: .configurationClientModelId,
-                            delegate: ConfigurationClientHandler(meshNetwork)), at: 1)
-        insert(model: Model(sigModelId: .healthServerModelId,
-                            delegate: HealthServerHandler(meshNetwork)), at: 2)
-        insert(model: Model(sigModelId: .healthClientModelId,
-                            delegate: HealthClientHandler()), at: 3)
-        insert(model: Model(sigModelId: .privateBeaconClientModelId,
-                            delegate: PrivateBeaconClientHandler(meshNetwork)), at: 4)
-        insert(model: Model(sigModelId: .sarConfigurationClientModelId,
-                            delegate: SarConfigurationClientHandler(meshNetwork)), at: 5)
-        insert(model: Model(sigModelId: .remoteProvisioningClientModelId,
-                            delegate: RemoteProvisioningClientHandler(meshNetwork)), at: 6)
-        insert(model: Model(sigModelId: .sceneClientModelId,
-                            delegate: SceneClientHandler(meshNetwork)), at: 7)
-    }
-    
-    /// Removes the models that are or should be supported natively.
-    func removePrimaryElementModels() {
-        models = models.filter { model in
-            // Health models are not yet supported.
-            !model.isHealthServer &&
-            !model.isHealthClient &&
-            // The library supports Scene Client model natively.
-            !model.isSceneClient &&
-            // The models that require Device Key should not be managed by users.
-            // Some of them are supported natively in the library.
-            !model.requiresDeviceKey
-        }
     }
     
     /// The primary Element for Provisioner's Node.

--- a/Library/Mesh Model/MeshNetwork.swift
+++ b/Library/Mesh Model/MeshNetwork.swift
@@ -89,21 +89,7 @@ public class MeshNetwork: Codable {
         get {
             return _localElements
         }
-        set {
-            var elements = newValue
-            // Some models, which are supported by the library, will be added automatically.
-            // Let's make sure they are not in the array.
-            elements.forEach { element in
-                element.removePrimaryElementModels()
-            }
-            // Remove all empty Elements.
-            elements = elements.filter { !$0.models.isEmpty }
-            // Add the required Models in the Primary Element.
-            if elements.isEmpty {
-                elements.append(Element(location: .unknown))
-            }
-            elements[0].addPrimaryElementModels(self)
-            
+        set(elements) {
             // Make sure the indexes are correct.
             for (index, element) in elements.enumerated() {
                 element.index = UInt8(index)

--- a/Library/MeshNetworkManager.swift
+++ b/Library/MeshNetworkManager.swift
@@ -48,6 +48,8 @@ public class MeshNetworkManager: NetworkParametersProvider {
     /// The delegate will receive callbacks whenever a complete
     /// Mesh Message has been received and reassembled.
     public weak var delegate: MeshNetworkDelegate?
+    /// The delegate will be created when the Attention Timer is started by a remote Node.
+    public weak var attentionTimerDelegate: AttentionTimerDelegate?
     /// The sender object should send PDUs created by the manager
     /// using any Bearer.
     public weak var transmitter: Transmitter? {

--- a/Library/MeshNetworkManager.swift
+++ b/Library/MeshNetworkManager.swift
@@ -208,10 +208,71 @@ public extension MeshNetworkManager {
             return meshNetwork?.localElements ?? []
         }
         set {
-            meshNetwork?.localElements = newValue
-            networkManager?.accessLayer.reinitializePublishers()
+            guard let meshNetwork = meshNetwork,
+                  let networkManager = networkManager else { return }
+            var elements = newValue
+            // Some models, which are supported by the library, will be added automatically.
+            // Let's make sure they are not in the array.
+            elements.forEach { element in
+                element.removePrimaryElementModels()
+            }
+            // Remove all empty Elements.
+            elements = elements.filter { !$0.models.isEmpty }
+            // Add the required Models in the Primary Element.
+            if elements.isEmpty {
+                elements.append(Element(location: .unknown))
+            }
+            elements[0].addPrimaryElementModels(meshNetwork, publisher: self)
+            
+            meshNetwork.localElements = elements
+            networkManager.accessLayer.reinitializePublishers()
         }
     }
+    
+}
+
+private extension Element {
+    
+    /// This methods adds the natively supported Models to the Element.
+    ///
+    /// This method should only be called for the primary Element of the
+    /// local Node.
+    ///
+    /// - parameter meshNetwork: The mesh network object.
+    func addPrimaryElementModels(_ meshNetwork: MeshNetwork, publisher: MeshNetworkManager) {
+        guard isPrimary else { return }
+        insert(model: Model(sigModelId: .configurationServerModelId,
+                            delegate: ConfigurationServerHandler(meshNetwork)), at: 0)
+        insert(model: Model(sigModelId: .configurationClientModelId,
+                            delegate: ConfigurationClientHandler(meshNetwork)), at: 1)
+        insert(model: Model(sigModelId: .healthServerModelId,
+                            delegate: HealthServerHandler(meshNetwork, publisher)), at: 2)
+        insert(model: Model(sigModelId: .healthClientModelId,
+                            delegate: HealthClientHandler()), at: 3)
+        insert(model: Model(sigModelId: .privateBeaconClientModelId,
+                            delegate: PrivateBeaconClientHandler(meshNetwork)), at: 4)
+        insert(model: Model(sigModelId: .sarConfigurationClientModelId,
+                            delegate: SarConfigurationClientHandler(meshNetwork)), at: 5)
+        insert(model: Model(sigModelId: .remoteProvisioningClientModelId,
+                            delegate: RemoteProvisioningClientHandler(meshNetwork)), at: 6)
+        insert(model: Model(sigModelId: .sceneClientModelId,
+                            delegate: SceneClientHandler(meshNetwork)), at: 7)
+    }
+    
+    /// Removes the models that are or should be supported natively.
+    func removePrimaryElementModels() {
+        models = models.filter { model in
+            // Health models are not yet supported.
+            !model.isHealthServer &&
+            !model.isHealthClient &&
+            // The library supports Scene Client model natively.
+            !model.isSceneClient &&
+            // The models that require Device Key should not be managed by users.
+            // Some of them are supported natively in the library.
+            !model.requiresDeviceKey
+        }
+    }
+    
 }
 
 // MARK: - Provisioning

--- a/Library/ModelDelegate.swift
+++ b/Library/ModelDelegate.swift
@@ -94,8 +94,8 @@ public protocol ModelDelegate: AnyObject {
     /// - throws: The method should throw ``ModelError``
     ///           if the receive message is invalid and no response
     ///           should be replied.
-    func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
-               from source: Address, sentTo destination: MeshAddress) throws -> MeshResponse
+    func model(_ model: Model, didReceiveAcknowledgedMessage request: any AcknowledgedMeshMessage,
+               from source: Address, sentTo destination: MeshAddress) throws -> any MeshResponse
     
     /// This method should handle the received Unacknowledged Message.
     ///
@@ -104,7 +104,7 @@ public protocol ModelDelegate: AnyObject {
     ///   - message: The Unacknowledged Message received.
     ///   - source: The source Unicast Address.
     ///   - destination: The destination address of the request.
-    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: any UnacknowledgedMeshMessage,
                from source: Address, sentTo destination: MeshAddress)
     
     /// This method should handle the received response to the
@@ -116,8 +116,8 @@ public protocol ModelDelegate: AnyObject {
     ///   - request: The Acknowledged Message sent.
     ///   - source: The Unicast Address of the Element that sent the
     ///             response.
-    func model(_ model: Model, didReceiveResponse response: MeshResponse,
-               toAcknowledgedMessage request: AcknowledgedMeshMessage,
+    func model(_ model: Model, didReceiveResponse response: any MeshResponse,
+               toAcknowledgedMessage request: any AcknowledgedMeshMessage,
                from source: Address)
     
 }

--- a/Library/Utils/BackgroundTimer.swift
+++ b/Library/Utils/BackgroundTimer.swift
@@ -35,6 +35,12 @@ internal class BackgroundTimer {
     
     let interval: TimeInterval
     let repeats: Bool
+    private var startTime: Date
+    
+    var remainingTime: TimeInterval {
+        let elapsed = Date().timeIntervalSince(startTime)
+        return max(0, interval - elapsed)
+    }
     
     /// Schedules a timer that can be started from a background DispatchQueue.
     @discardableResult
@@ -49,9 +55,11 @@ internal class BackgroundTimer {
         self.interval = interval
         self.repeats = repeats
         
+        startTime = Date()
         timer = DispatchSource.makeTimerSource(queue: queue)
         timer.setEventHandler {
             block(self)
+            self.startTime = Date()
             if !repeats {
                 self.invalidate()
             }


### PR DESCRIPTION
This PR adds the UI for Healt Server model and native support for Health Server and Health Client models in the library.

Supported server features:
* Attention timer delegate
* Faults, including test mode: send Health Fault Test with Company ID set to 0x0059 (Nordic) to the local Node to emulate a Fault with the Test ID as Fault ID.

Supported client  features:
* UI for sending all Health messages (in Health server model screen)