### PR TITLE
UI improvemwents

### DIFF
--- a/Example/Source/UI/Base.lproj/Groups.storyboard
+++ b/Example/Source/UI/Base.lproj/Groups.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Nue-b9-dg6">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Nue-b9-dg6">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -14,20 +14,20 @@
         <scene sceneID="OvM-cp-z6h">
             <objects>
                 <tableViewController id="GWa-8U-U7m" customClass="GroupsViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="uVa-zS-ghQ">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="77" sectionHeaderHeight="18" sectionFooterHeight="18" id="uVa-zS-ghQ">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="804"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="group" rowHeight="86" id="1fT-ky-IiZ" customClass="GroupCell" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="38" width="414" height="86"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="group" rowHeight="77" id="1fT-ky-IiZ" customClass="GroupCell" customModule="nRF_Mesh" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="38" width="414" height="77"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1fT-ky-IiZ" id="rfK-Ou-kar">
-                                    <rect key="frame" x="0.0" y="0.0" width="383.5" height="86"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383.5" height="77"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="mesh-group" translatesAutoresizingMaskIntoConstraints="NO" id="uT9-q1-V0U">
-                                            <rect key="frame" x="20" y="19" width="48" height="48"/>
+                                            <rect key="frame" x="20" y="14.5" width="48" height="48"/>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Group Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wi4-gM-J5Z">
                                             <rect key="frame" x="84" y="11" width="291.5" height="21"/>
@@ -36,13 +36,13 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Address:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MxP-9A-xOw">
-                                            <rect key="frame" x="84" y="40" width="53.5" height="16"/>
+                                            <rect key="frame" x="84" y="34" width="53.5" height="16"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="00000000-1234-5678-ABCD-0123456789AB" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gza-hl-jDH">
-                                            <rect key="frame" x="153.5" y="40" width="222" height="31.5"/>
+                                            <rect key="frame" x="153.5" y="34" width="222" height="31.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
@@ -53,13 +53,13 @@
                                         <constraint firstAttribute="trailingMargin" secondItem="wi4-gM-J5Z" secondAttribute="trailing" id="3c1-3N-iCl"/>
                                         <constraint firstItem="MxP-9A-xOw" firstAttribute="leading" secondItem="wi4-gM-J5Z" secondAttribute="leading" id="Rw5-Va-vjY"/>
                                         <constraint firstItem="wi4-gM-J5Z" firstAttribute="top" secondItem="rfK-Ou-kar" secondAttribute="topMargin" id="TrM-3m-niE"/>
+                                        <constraint firstItem="uT9-q1-V0U" firstAttribute="centerY" secondItem="rfK-Ou-kar" secondAttribute="centerY" id="W3I-F7-Ofv"/>
                                         <constraint firstItem="gza-hl-jDH" firstAttribute="trailing" secondItem="rfK-Ou-kar" secondAttribute="trailingMargin" id="XME-Xm-qm2"/>
-                                        <constraint firstItem="MxP-9A-xOw" firstAttribute="top" secondItem="wi4-gM-J5Z" secondAttribute="bottom" constant="8" id="erV-Kz-ZPY"/>
-                                        <constraint firstItem="uT9-q1-V0U" firstAttribute="top" secondItem="rfK-Ou-kar" secondAttribute="topMargin" constant="8" id="lfM-gi-oA5"/>
-                                        <constraint firstAttribute="bottomMargin" secondItem="uT9-q1-V0U" secondAttribute="bottom" constant="8" id="ltu-Qw-gqe"/>
+                                        <constraint firstItem="MxP-9A-xOw" firstAttribute="top" secondItem="wi4-gM-J5Z" secondAttribute="bottom" constant="2" id="erV-Kz-ZPY"/>
                                         <constraint firstItem="gza-hl-jDH" firstAttribute="leading" secondItem="MxP-9A-xOw" secondAttribute="trailing" constant="16" id="pGQ-uC-N7M"/>
                                         <constraint firstItem="uT9-q1-V0U" firstAttribute="leading" secondItem="rfK-Ou-kar" secondAttribute="leadingMargin" id="qgf-pp-nwW"/>
                                         <constraint firstItem="wi4-gM-J5Z" firstAttribute="leading" secondItem="uT9-q1-V0U" secondAttribute="trailing" constant="16" id="sgM-1X-fdC"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="gza-hl-jDH" secondAttribute="bottom" constant="0.5" id="xeT-h9-keQ"/>
                                     </constraints>
                                 </tableViewCellContentView>
                                 <connections>
@@ -604,7 +604,7 @@
             <objects>
                 <tableViewController id="5hl-UK-X1c" customClass="AddGroupViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="DdI-sU-xdu">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="886"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <sections>
@@ -750,7 +750,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="y7P-mW-r9X" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="WJ4-lJ-7ku">
-                        <rect key="frame" x="0.0" y="48" width="414" height="96"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="108"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" red="0.0" green="0.66274509800000003" blue="0.80784313730000001" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
                         <textAttributes key="titleTextAttributes">
@@ -797,7 +797,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="Jtn-5N-mgs"/>
+        <segue reference="6cj-je-47S"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
     <resources>

--- a/Example/Source/UI/Base.lproj/Network.storyboard
+++ b/Example/Source/UI/Base.lproj/Network.storyboard
@@ -1015,7 +1015,7 @@
             <objects>
                 <tableViewController id="veF-nS-gn0" customClass="ModelViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="huL-bC-LUM">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="886"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
@@ -1985,20 +1985,20 @@
         <scene sceneID="BVU-ZG-meK">
             <objects>
                 <tableViewController id="tod-VS-GXt" customClass="NetworkViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="120" estimatedRowHeight="120" sectionHeaderHeight="18" sectionFooterHeight="18" id="01s-7F-LfS">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="88" sectionHeaderHeight="18" sectionFooterHeight="18" id="01s-7F-LfS">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="804"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="node" rowHeight="120" id="0EL-zf-FEG" customClass="NodeViewCell" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="38" width="414" height="120"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="node" rowHeight="77" id="0EL-zf-FEG" customClass="NodeViewCell" customModule="nRF_Mesh" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="38" width="414" height="77"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0EL-zf-FEG" id="1ez-9g-bU1">
-                                    <rect key="frame" x="0.0" y="0.0" width="383.5" height="120"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="383.5" height="77"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="mesh-icon" translatesAutoresizingMaskIntoConstraints="NO" id="Txo-PC-sVO">
-                                            <rect key="frame" x="20" y="19" width="48" height="48"/>
+                                            <rect key="frame" x="20" y="14.5" width="48" height="48"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="48" id="Dk0-Yy-N4X"/>
                                                 <constraint firstAttribute="width" constant="48" id="ZHl-eU-yqH"/>
@@ -2006,62 +2006,35 @@
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Device name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="98E-5m-rAh">
                                             <rect key="frame" x="84" y="11" width="291.5" height="21"/>
-                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
+                                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Address:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="P25-FI-CJa">
-                                            <rect key="frame" x="84" y="40" width="61.5" height="16"/>
+                                            <rect key="frame" x="84" y="50" width="61.5" height="16"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Company:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="58u-KT-fcI">
-                                            <rect key="frame" x="84" y="56" width="61.5" height="16"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                            <color key="textColor" systemColor="secondaryLabelColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Elements:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qu0-To-iC2">
-                                            <rect key="frame" x="84" y="72" width="61.5" height="16"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                            <color key="textColor" systemColor="secondaryLabelColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Models:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="owI-5i-P1D">
-                                            <rect key="frame" x="84" y="88" width="61.5" height="16"/>
+                                            <rect key="frame" x="84" y="34" width="61.5" height="16"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="18L-cV-20F">
-                                            <rect key="frame" x="153.5" y="40" width="222" height="16"/>
+                                            <rect key="frame" x="153.5" y="50" width="222" height="16"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="16" id="6vD-wX-1tt"/>
+                                            </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fus-yD-CnI">
-                                            <rect key="frame" x="153.5" y="56" width="222" height="16"/>
+                                            <rect key="frame" x="153.5" y="34" width="222" height="16"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="16" id="PMh-X3-P1F"/>
-                                            </constraints>
-                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                            <color key="textColor" systemColor="secondaryLabelColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="htL-Ix-2vE">
-                                            <rect key="frame" x="153.5" y="72" width="222" height="16"/>
-                                            <constraints>
-                                                <constraint firstAttribute="height" constant="16" id="P7c-JG-sJd"/>
-                                            </constraints>
-                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                            <color key="textColor" systemColor="secondaryLabelColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ukb-VS-Bpo">
-                                            <rect key="frame" x="153.5" y="88" width="222" height="16"/>
-                                            <constraints>
-                                                <constraint firstAttribute="height" constant="16" id="uXf-Lr-Pjk"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -2070,43 +2043,28 @@
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="98E-5m-rAh" firstAttribute="top" secondItem="1ez-9g-bU1" secondAttribute="topMargin" id="0Az-Wb-F3x"/>
+                                        <constraint firstItem="P25-FI-CJa" firstAttribute="centerY" secondItem="18L-cV-20F" secondAttribute="centerY" id="0hi-vl-sr8"/>
                                         <constraint firstItem="18L-cV-20F" firstAttribute="leading" secondItem="58u-KT-fcI" secondAttribute="trailing" constant="8" id="3pg-Xx-fb5"/>
-                                        <constraint firstItem="58u-KT-fcI" firstAttribute="top" secondItem="P25-FI-CJa" secondAttribute="bottom" id="DSN-pC-jVP"/>
-                                        <constraint firstItem="Ukb-VS-Bpo" firstAttribute="top" secondItem="htL-Ix-2vE" secondAttribute="bottom" id="Dei-mj-Bkg"/>
-                                        <constraint firstItem="Ukb-VS-Bpo" firstAttribute="trailing" secondItem="1ez-9g-bU1" secondAttribute="trailingMargin" id="G4f-Wf-i9z"/>
+                                        <constraint firstItem="58u-KT-fcI" firstAttribute="centerY" secondItem="Fus-yD-CnI" secondAttribute="centerY" id="CXm-If-uYh"/>
                                         <constraint firstItem="Fus-yD-CnI" firstAttribute="leading" secondItem="18L-cV-20F" secondAttribute="leading" id="NXK-ik-Gbs"/>
-                                        <constraint firstItem="P25-FI-CJa" firstAttribute="top" secondItem="98E-5m-rAh" secondAttribute="bottom" constant="8" id="Nfb-8h-9C1"/>
                                         <constraint firstItem="98E-5m-rAh" firstAttribute="leading" secondItem="Txo-PC-sVO" secondAttribute="trailing" constant="16" id="Oup-u5-skQ"/>
-                                        <constraint firstItem="18L-cV-20F" firstAttribute="leading" secondItem="Qu0-To-iC2" secondAttribute="trailing" constant="8" id="QVt-tP-8Sg"/>
-                                        <constraint firstAttribute="bottomMargin" secondItem="owI-5i-P1D" secondAttribute="bottom" constant="5" id="SMU-1H-yGX"/>
-                                        <constraint firstItem="18L-cV-20F" firstAttribute="leading" secondItem="owI-5i-P1D" secondAttribute="trailing" constant="8" id="Ukk-wR-hbc"/>
-                                        <constraint firstAttribute="bottomMargin" secondItem="Ukb-VS-Bpo" secondAttribute="bottom" constant="5" id="V35-JX-f7e"/>
-                                        <constraint firstItem="18L-cV-20F" firstAttribute="top" secondItem="98E-5m-rAh" secondAttribute="bottom" constant="8" id="XKI-b0-0pw"/>
+                                        <constraint firstItem="Txo-PC-sVO" firstAttribute="centerY" secondItem="1ez-9g-bU1" secondAttribute="centerY" id="Oxy-gu-sFk"/>
+                                        <constraint firstItem="P25-FI-CJa" firstAttribute="top" secondItem="58u-KT-fcI" secondAttribute="bottom" id="WB8-yT-ri2"/>
                                         <constraint firstItem="Fus-yD-CnI" firstAttribute="trailing" secondItem="1ez-9g-bU1" secondAttribute="trailingMargin" id="Yiw-Th-Sdr"/>
-                                        <constraint firstItem="Fus-yD-CnI" firstAttribute="top" secondItem="18L-cV-20F" secondAttribute="bottom" id="ZnG-7w-ohY"/>
                                         <constraint firstItem="18L-cV-20F" firstAttribute="trailing" secondItem="1ez-9g-bU1" secondAttribute="trailingMargin" id="aaQ-UJ-G9S"/>
-                                        <constraint firstItem="Qu0-To-iC2" firstAttribute="leading" secondItem="98E-5m-rAh" secondAttribute="leading" id="bJ3-jm-uPm"/>
-                                        <constraint firstItem="htL-Ix-2vE" firstAttribute="leading" secondItem="18L-cV-20F" secondAttribute="leading" id="d46-Ro-dnD"/>
                                         <constraint firstItem="58u-KT-fcI" firstAttribute="leading" secondItem="98E-5m-rAh" secondAttribute="leading" id="dUW-eg-889"/>
-                                        <constraint firstItem="owI-5i-P1D" firstAttribute="top" secondItem="Qu0-To-iC2" secondAttribute="bottom" id="gVn-cv-Buu"/>
-                                        <constraint firstItem="owI-5i-P1D" firstAttribute="leading" secondItem="98E-5m-rAh" secondAttribute="leading" id="h8O-86-t0f"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="P25-FI-CJa" secondAttribute="bottom" id="iXg-Ep-QHT"/>
                                         <constraint firstAttribute="trailingMargin" secondItem="98E-5m-rAh" secondAttribute="trailing" id="lQl-wh-3El"/>
-                                        <constraint firstItem="Qu0-To-iC2" firstAttribute="top" secondItem="58u-KT-fcI" secondAttribute="bottom" id="ohW-qN-770"/>
+                                        <constraint firstItem="58u-KT-fcI" firstAttribute="top" secondItem="98E-5m-rAh" secondAttribute="bottom" constant="2" id="m3x-hx-rTO"/>
                                         <constraint firstItem="Txo-PC-sVO" firstAttribute="leading" secondItem="1ez-9g-bU1" secondAttribute="leadingMargin" id="rRf-oS-lhn"/>
                                         <constraint firstItem="P25-FI-CJa" firstAttribute="leading" secondItem="98E-5m-rAh" secondAttribute="leading" id="sD6-gW-WwI"/>
-                                        <constraint firstItem="Txo-PC-sVO" firstAttribute="top" secondItem="1ez-9g-bU1" secondAttribute="topMargin" constant="8" id="syy-Ua-kF0"/>
-                                        <constraint firstItem="Ukb-VS-Bpo" firstAttribute="leading" secondItem="18L-cV-20F" secondAttribute="leading" id="w6H-vm-rf9"/>
-                                        <constraint firstItem="htL-Ix-2vE" firstAttribute="trailing" secondItem="1ez-9g-bU1" secondAttribute="trailingMargin" id="wRY-RK-s1S"/>
                                         <constraint firstItem="18L-cV-20F" firstAttribute="leading" secondItem="P25-FI-CJa" secondAttribute="trailing" constant="8" id="xGJ-Lb-ucc"/>
-                                        <constraint firstItem="htL-Ix-2vE" firstAttribute="top" secondItem="Fus-yD-CnI" secondAttribute="bottom" id="z4K-MB-QtR"/>
                                     </constraints>
                                 </tableViewCellContentView>
                                 <connections>
                                     <outlet property="address" destination="18L-cV-20F" id="hy6-iw-14X"/>
                                     <outlet property="company" destination="Fus-yD-CnI" id="07W-Ob-b7d"/>
-                                    <outlet property="elements" destination="htL-Ix-2vE" id="gAq-86-ibS"/>
                                     <outlet property="icon" destination="Txo-PC-sVO" id="bdK-eg-OPV"/>
-                                    <outlet property="models" destination="Ukb-VS-Bpo" id="oiA-Hn-lqD"/>
                                     <outlet property="nodeName" destination="98E-5m-rAh" id="F2p-GH-EaE"/>
                                     <segue destination="DVn-IC-M3j" kind="show" identifier="open" id="ThO-5P-90Y"/>
                                 </connections>
@@ -3312,7 +3270,6 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="p59-pA-hy7"/>
         <segue reference="mtt-Te-nBR"/>
         <segue reference="ThO-5P-90Y"/>
         <segue reference="D9f-sQ-QMb"/>

--- a/Example/Source/UI/Base.lproj/Network.storyboard
+++ b/Example/Source/UI/Base.lproj/Network.storyboard
@@ -1985,7 +1985,7 @@
         <scene sceneID="BVU-ZG-meK">
             <objects>
                 <tableViewController id="tod-VS-GXt" customClass="NetworkViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="88" sectionHeaderHeight="18" sectionFooterHeight="18" id="01s-7F-LfS">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="01s-7F-LfS">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="804"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Example/Source/UI/Base.lproj/Settings.storyboard
+++ b/Example/Source/UI/Base.lproj/Settings.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xI8-8S-2a8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xI8-8S-2a8">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -692,18 +692,18 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="switch" id="5oi-GJ-525" customClass="SwitchCell" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="125" width="414" height="43"/>
+                                <rect key="frame" x="0.0" y="125" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5oi-GJ-525" id="bcE-xW-TPS">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4PU-Hv-Lxf">
-                                            <rect key="frame" x="345" y="6" width="51" height="31"/>
+                                            <rect key="frame" x="345" y="6.5" width="51" height="31"/>
                                             <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </switch>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YDJ-38-lWR">
-                                            <rect key="frame" x="20" y="11" width="33" height="21"/>
+                                            <rect key="frame" x="20" y="11" width="33" height="21.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -1186,7 +1186,7 @@
                                             <rect key="frame" x="59" y="31.5" width="44" height="14.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                            <nil key="textColor"/>
+                                            <color key="textColor" systemColor="secondaryLabelColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" image="ic_security_24pt" id="gOV-cU-wBz">
@@ -1795,10 +1795,10 @@
                                     <mask key="constraints">
                                         <exclude reference="Gaz-wJ-mS0"/>
                                         <exclude reference="TOX-Jj-dgl"/>
-                                        <exclude reference="6vt-kg-LIh"/>
                                         <exclude reference="92F-js-XTh"/>
-                                        <exclude reference="Cqc-64-YaY"/>
                                         <exclude reference="TmX-fQ-T4I"/>
+                                        <exclude reference="6vt-kg-LIh"/>
+                                        <exclude reference="Cqc-64-YaY"/>
                                         <exclude reference="MEu-rE-M9w"/>
                                         <exclude reference="9qh-eT-HHI"/>
                                         <exclude reference="Fpu-PH-Ljf"/>
@@ -1810,8 +1810,8 @@
                                 <variation key="heightClass=compact">
                                     <mask key="constraints">
                                         <include reference="Gaz-wJ-mS0"/>
-                                        <include reference="6vt-kg-LIh"/>
                                         <include reference="TmX-fQ-T4I"/>
+                                        <include reference="6vt-kg-LIh"/>
                                         <include reference="Fpu-PH-Ljf"/>
                                         <include reference="exl-h8-Bcd"/>
                                     </mask>
@@ -1953,14 +1953,9 @@
             <point key="canvasLocation" x="2041" y="-717"/>
         </scene>
     </scenes>
-    <designables>
-        <designable name="rL9-4q-WDo">
-            <size key="intrinsicContentSize" width="119" height="30"/>
-        </designable>
-    </designables>
     <inferredMetricsTieBreakers>
         <segue reference="IyH-HE-Afk"/>
-        <segue reference="Oqe-1V-Vne"/>
+        <segue reference="bNE-yM-CyO"/>
         <segue reference="N6d-TP-uON"/>
         <segue reference="fbZ-vy-Nf5"/>
         <segue reference="UIV-8t-JZp"/>
@@ -1975,10 +1970,10 @@
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="opaqueSeparatorColor">
-            <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="secondaryLabelColor">
-            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="secondarySystemGroupedBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1987,13 +1982,13 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGroupedBackgroundColor">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="tableCellGroupedBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="tertiaryLabelColor">
-            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29803921568627451" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29803921570000003" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Example/Source/View Controllers/Network/NodeViewCell.swift
+++ b/Example/Source/View Controllers/Network/NodeViewCell.swift
@@ -38,24 +38,22 @@ class NodeViewCell: UITableViewCell {
     
     @IBOutlet weak var address: UILabel!
     @IBOutlet weak var company: UILabel!
-    @IBOutlet weak var elements: UILabel!
-    @IBOutlet weak var models: UILabel!
     
     var node: Node! {
         didSet {
             nodeName.text = node.name ?? "Unknown Device"
-            address.text = node.primaryUnicastAddress.asString()
-            elements.text = "\(node.elements.count)"
+            let addressString = node.primaryUnicastAddress.asString()
+            let elementsCount = node.elements.count
+            if elementsCount == 1 {
+                address.text = "\(addressString) (1 element)"
+            } else {
+                address.text = "\(addressString) (\(elementsCount) elements)"
+            }
             
             if let companyIdentifier = node.companyIdentifier {
                 company.text = CompanyIdentifier.name(for: companyIdentifier) ?? "Unknown"
-                let modelCount = node.elements.reduce(0, { (result, element) -> Int in
-                    result + element.models.count
-                })
-                models.text = "\(modelCount)"
             } else {
                 company.text = "Unknown"
-                models.text = "Configuration not complete"
             }
         }
     }


### PR DESCRIPTION
This PR removes Models count from the Node items on Network screen. The Elements count is moved after the Adress.
This is to simplify the Node's view.

Also, Group cell was shortened to make it similar.

Bug fix: Secondary text on Provisioners screen was made Secondary Label color.