### PR TITLE
Improvements in Node identification

### DIFF
--- a/Example/Source/UI/Base.lproj/Network.storyboard
+++ b/Example/Source/UI/Base.lproj/Network.storyboard
@@ -923,7 +923,7 @@
                                     <segue destination="qIn-YT-MK7" kind="presentation" identifier="configure" id="jp1-Dy-enb"/>
                                 </connections>
                             </barButtonItem>
-                            <barButtonItem title="Identify" id="zU0-Pg-Pyt">
+                            <barButtonItem enabled="NO" title="Identify" id="zU0-Pg-Pyt">
                                 <connections>
                                     <action selector="identifyPressed:" destination="DVn-IC-M3j" id="fLn-Ku-M9C"/>
                                 </connections>
@@ -1408,21 +1408,21 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="switch" id="ukA-iV-k75" customClass="SwitchCell" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="703.5" width="414" height="43"/>
+                                <rect key="frame" x="0.0" y="703.5" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ukA-iV-k75" id="q0I-rL-LSs">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P1w-ws-FGk">
-                                            <rect key="frame" x="345" y="6" width="51" height="31"/>
+                                            <rect key="frame" x="345" y="6.5" width="51" height="31"/>
                                             <color key="onTintColor" systemColor="tintColor"/>
                                             <connections>
                                                 <action selector="switchDidChange:" destination="ukA-iV-k75" eventType="valueChanged" id="PJe-b6-sbf"/>
                                             </connections>
                                         </switch>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pqx-lg-qPZ">
-                                            <rect key="frame" x="20" y="11" width="33" height="21"/>
+                                            <rect key="frame" x="20" y="11" width="33" height="21.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>

--- a/Example/Source/UI/Base.lproj/Network.storyboard
+++ b/Example/Source/UI/Base.lproj/Network.storyboard
@@ -917,14 +917,22 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Device Name" id="XGj-Sj-Rwy">
                         <barButtonItem key="backBarButtonItem" title="Node" id="P45-IY-Y5M"/>
-                        <barButtonItem key="rightBarButtonItem" enabled="NO" title="Configure" id="wUL-c1-AEZ">
-                            <connections>
-                                <segue destination="qIn-YT-MK7" kind="presentation" identifier="configure" id="jp1-Dy-enb"/>
-                            </connections>
-                        </barButtonItem>
+                        <rightBarButtonItems>
+                            <barButtonItem enabled="NO" title="Configure" id="wUL-c1-AEZ">
+                                <connections>
+                                    <segue destination="qIn-YT-MK7" kind="presentation" identifier="configure" id="jp1-Dy-enb"/>
+                                </connections>
+                            </barButtonItem>
+                            <barButtonItem title="Identify" id="zU0-Pg-Pyt">
+                                <connections>
+                                    <action selector="identifyPressed:" destination="DVn-IC-M3j" id="fLn-Ku-M9C"/>
+                                </connections>
+                            </barButtonItem>
+                        </rightBarButtonItems>
                     </navigationItem>
                     <connections>
                         <outlet property="configureButton" destination="wUL-c1-AEZ" id="2ET-Vc-xNL"/>
+                        <outlet property="identifyAction" destination="zU0-Pg-Pyt" id="MjC-Gk-clb"/>
                         <segue destination="2Zq-WA-bzR" kind="show" identifier="showElement" id="LdH-3L-wVk"/>
                         <segue destination="LqZ-nU-tB4" kind="show" identifier="showNetworkKeys" id="HeG-0V-N7l"/>
                         <segue destination="Sjk-ZU-4jx" kind="show" identifier="showAppKeys" id="zqk-vS-7T1"/>
@@ -1400,21 +1408,21 @@
                                 </connections>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="switch" id="ukA-iV-k75" customClass="SwitchCell" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="703.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="703.5" width="414" height="43"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ukA-iV-k75" id="q0I-rL-LSs">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P1w-ws-FGk">
-                                            <rect key="frame" x="345" y="6.5" width="51" height="31"/>
+                                            <rect key="frame" x="345" y="6" width="51" height="31"/>
                                             <color key="onTintColor" systemColor="tintColor"/>
                                             <connections>
                                                 <action selector="switchDidChange:" destination="ukA-iV-k75" eventType="valueChanged" id="PJe-b6-sbf"/>
                                             </connections>
                                         </switch>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pqx-lg-qPZ">
-                                            <rect key="frame" x="20" y="11" width="33" height="21.5"/>
+                                            <rect key="frame" x="20" y="11" width="33" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>

--- a/Example/Source/UIViewController+Identify.swift
+++ b/Example/Source/UIViewController+Identify.swift
@@ -1,0 +1,121 @@
+/*
+* Copyright (c) 2025, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import NordicMesh
+
+protocol SupportsNodeIdentification {
+    
+    /// Creates a new Application Key with Key Index 4095 and binds it to the given Network Key.
+    ///
+    /// - returns: The newly created Application Key, or `nil` if it could not be created
+    @discardableResult
+    func createNodeIdentificationKey(andBindToNetworkKey networkKey: NetworkKey) -> ApplicationKey?
+    
+    /// Sends ``HealthAttentionSetUnacknowledged`` message to the Health Server model
+    /// of the Node to make it blink for 3 seconds.
+    ///
+    /// If not ready, this method will also create a new Application Key with Key Index 4095 and bind it
+    /// to the Health Server model.
+    ///
+    /// - parameter node: The Node to identify.
+    /// - returns: `true` if the Node is identified and the message was sent.
+    func identify(node: Node) async -> Bool
+}
+
+extension SupportsNodeIdentification {
+    
+    func createNodeIdentificationKey(andBindToNetworkKey networkKey: NetworkKey) -> ApplicationKey? {
+       let manager = MeshNetworkManager.instance
+       guard let meshNetwork = manager.meshNetwork else {
+           return nil
+       }
+       do {
+           let key = try meshNetwork.add(applicationKey: Data.random128BitKey(),
+                                         withIndex: 4095,
+                                         name: "Node Identification Key")
+           try key.bind(to: networkKey)
+           if manager.save() {
+               return key
+           }
+       } catch {
+           return nil
+       }
+       return nil
+    }
+
+    func identify(node: Node) async -> Bool {
+        let manager = MeshNetworkManager.instance
+        guard let meshNetwork = manager.meshNetwork else {
+            return false
+        }
+        
+        // Check if the Health Server model exist (it is mandatory)
+        // and has at least one bound Application Key.
+        guard let healthServerModel = node.models(withSigModelId: .healthServerModelId).first else {
+            return false
+        }
+        
+        // If the Health Server model is not bound to any Application Key,
+        // we need to bind it to one.
+        if healthServerModel.boundApplicationKeys.isEmpty {
+            // If the Node does not know any Application Keys, create one and bind it.
+            // For security reasons we don't want to send any of the existing keys,
+            // instead we will create a new one with Key Index 4095.
+            if node.applicationKeys.isEmpty {
+                // Let's take the Network Key known to the Node.
+                let networkKey = node.networkKeys.first!
+                guard let nodeIdentificationKey = meshNetwork.applicationKeys[KeyIndex(4095)] ??
+                                                  createNodeIdentificationKey(andBindToNetworkKey: networkKey) else {
+                    return false
+                }
+                
+                // Send the newly created Application Key to the Node.
+                let request = ConfigAppKeyAdd(applicationKey: nodeIdentificationKey)
+                let response = try? await manager.send(request, to: node) as? ConfigAppKeyStatus
+                guard response?.status == .success else {
+                    return false
+                }
+            }
+            
+            // At this point, the Node should know at least one Application Key.
+            guard let applicationKey = node.applicationKeys.first,
+                  let request = ConfigModelAppBind(applicationKey: applicationKey, to: healthServerModel) else {
+                return false
+            }
+            let response = try? await manager.send(request, to: node) as? ConfigModelAppStatus
+            guard response?.status == .success else {
+                return false
+            }
+        }
+        
+        try? await manager.send(HealthAttentionSetUnacknowledged(3.0), to: healthServerModel)
+        return true
+    }
+}

--- a/Example/Source/Utils/UITableViewCell+Disabled.swift
+++ b/Example/Source/Utils/UITableViewCell+Disabled.swift
@@ -1,0 +1,67 @@
+//
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import UIKit
+
+extension UITableViewCell {
+    
+    var isEnabled: Bool {
+        get {
+            return isUserInteractionEnabled
+        }
+        set(enabled) {
+            isUserInteractionEnabled = enabled
+            if enabled {
+                if #available(iOS 13.0, *) {
+                    textLabel?.textColor = .label
+                    detailTextLabel?.textColor = .label
+                    imageView?.tintColor = .nordicLake
+                } else {
+                    textLabel?.textColor = .darkText
+                    detailTextLabel?.textColor = .darkText
+                    imageView?.tintColor = .nordicLake
+                }
+            } else {
+                if #available(iOS 13.0, *) {
+                    textLabel?.textColor = .secondaryLabel
+                    detailTextLabel?.textColor = .secondaryLabel
+                    imageView?.tintColor = .secondaryLabel
+                } else {
+                    textLabel?.textColor = .lightGray
+                    detailTextLabel?.textColor = .lightGray
+                    imageView?.tintColor = .lightGray
+                }
+            }
+        }
+    }
+    
+}

--- a/Example/Source/Utils/UIViewController+Identify.swift
+++ b/Example/Source/Utils/UIViewController+Identify.swift
@@ -1,0 +1,121 @@
+/*
+* Copyright (c) 2025, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import NordicMesh
+
+protocol SupportsNodeIdentification {
+    
+    /// Creates a new Application Key with Key Index 4095 and binds it to the given Network Key.
+    ///
+    /// - returns: The newly created Application Key, or `nil` if it could not be created
+    @discardableResult
+    func createNodeIdentificationKey(andBindToNetworkKey networkKey: NetworkKey) -> ApplicationKey?
+    
+    /// Sends ``HealthAttentionSetUnacknowledged`` message to the Health Server model
+    /// of the Node to make it blink for 3 seconds.
+    ///
+    /// If not ready, this method will also create a new Application Key with Key Index 4095 and bind it
+    /// to the Health Server model.
+    ///
+    /// - parameter node: The Node to identify.
+    /// - returns: `true` if the Node is identified and the message was sent.
+    func identify(node: Node) async -> Bool
+}
+
+extension SupportsNodeIdentification {
+    
+    func createNodeIdentificationKey(andBindToNetworkKey networkKey: NetworkKey) -> ApplicationKey? {
+       let manager = MeshNetworkManager.instance
+       guard let meshNetwork = manager.meshNetwork else {
+           return nil
+       }
+       do {
+           let key = try meshNetwork.add(applicationKey: Data.random128BitKey(),
+                                         withIndex: 4095,
+                                         name: "Node Identification Key")
+           try key.bind(to: networkKey)
+           if manager.save() {
+               return key
+           }
+       } catch {
+           return nil
+       }
+       return nil
+    }
+
+    func identify(node: Node) async -> Bool {
+        let manager = MeshNetworkManager.instance
+        guard let meshNetwork = manager.meshNetwork else {
+            return false
+        }
+        
+        // Check if the Health Server model exist (it is mandatory)
+        // and has at least one bound Application Key.
+        guard let healthServerModel = node.models(withSigModelId: .healthServerModelId).first else {
+            return false
+        }
+        
+        // If the Health Server model is not bound to any Application Key,
+        // we need to bind it to one.
+        if healthServerModel.boundApplicationKeys.isEmpty {
+            // If the Node does not know any Application Keys, create one and bind it.
+            // For security reasons we don't want to send any of the existing keys,
+            // instead we will create a new one with Key Index 4095.
+            if node.applicationKeys.isEmpty {
+                // Let's take the Network Key known to the Node.
+                let networkKey = node.networkKeys.first!
+                guard let nodeIdentificationKey = meshNetwork.applicationKeys[KeyIndex(4095)] ??
+                                                  createNodeIdentificationKey(andBindToNetworkKey: networkKey) else {
+                    return false
+                }
+                
+                // Send the newly created Application Key to the Node.
+                let request = ConfigAppKeyAdd(applicationKey: nodeIdentificationKey)
+                let response = try? await manager.send(request, to: node) as? ConfigAppKeyStatus
+                guard response?.status == .success else {
+                    return false
+                }
+            }
+            
+            // At this point, the Node should know at least one Application Key.
+            guard let applicationKey = node.applicationKeys.first,
+                  let request = ConfigModelAppBind(applicationKey: applicationKey, to: healthServerModel) else {
+                return false
+            }
+            let response = try? await manager.send(request, to: node) as? ConfigModelAppStatus
+            guard response?.status == .success else {
+                return false
+            }
+        }
+        
+        try? await manager.send(HealthAttentionSetUnacknowledged(3.0), to: healthServerModel)
+        return true
+    }
+}

--- a/Example/Source/View Controllers/Network/Configuration/NodeViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeViewController.swift
@@ -31,7 +31,7 @@
 import UIKit
 import NordicMesh
 
-class NodeViewController: ProgressViewController {
+class NodeViewController: ProgressViewController, SupportsNodeIdentification {
     
     // MARK: - Public properties
     
@@ -45,6 +45,29 @@ class NodeViewController: ProgressViewController {
     // MARK: - Outlets
     
     @IBOutlet weak var configureButton: UIBarButtonItem!
+    @IBOutlet weak var identifyAction: UIBarButtonItem!
+    
+    @IBAction func identifyPressed(_ sender: UIBarButtonItem) {
+        guard let node = node,
+              let _ = node.companyIdentifier else {
+            self.presentAlert(title: "Unknown Node", message: "Before identifying, tap the Node to obtain its Composition Data.")
+            return
+        }
+        guard let healthServerModel = node.models(withSigModelId: .healthServerModelId).first,
+              !healthServerModel.boundApplicationKeys.isEmpty else {
+            self.presentAlert(title: "Identify", message: "Attention timer requires the Health Server model to be bound to at least one Application Key.\n\nWould you like to configure \(node.name ?? "the Node") automatically?") { _ in
+                Task { [weak self] in
+                    await self?.identify(node: node) ?? false
+                }
+            }
+            return
+        }
+        
+        Task { [weak self] in
+            await self?.identify(node: node) ?? false
+        }
+    }
+    
     
     // MARK: - Implementation
     

--- a/Example/Source/View Controllers/Network/Configuration/NodeViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/NodeViewController.swift
@@ -107,6 +107,8 @@ class NodeViewController: ProgressViewController, SupportsNodeIdentification {
         let localProvisioner = MeshNetworkManager.instance.meshNetwork?.localProvisioner
         guard localProvisioner?.hasConfigurationCapabilities ?? false else {
             // The Provisioner cannot sent or receive messages.
+            configureButton.isEnabled = false
+            identifyAction.isEnabled = false
             return
         }
         
@@ -119,6 +121,7 @@ class NodeViewController: ProgressViewController, SupportsNodeIdentification {
             getTtl()
         } else {
             configureButton.isEnabled = node.deviceKey != nil
+            identifyAction.isEnabled = node.deviceKey != nil
         }
     }
     
@@ -551,6 +554,7 @@ extension NodeViewController: MeshNetworkDelegate {
                     self.tableView.reloadData()
                     self.refreshControl?.endRefreshing()
                     self.configureButton.isEnabled = true
+                    self.identifyAction.isEnabled = true
                     
                     self.performSegue(withIdentifier: "reconfigure", sender: originalNode)
                     self.originalNode = nil
@@ -567,6 +571,7 @@ extension NodeViewController: MeshNetworkDelegate {
                 self.tableView.reloadRows(at: [.ttl], with: .automatic)
                 self.refreshControl?.endRefreshing()
                 self.configureButton.isEnabled = true
+                self.identifyAction.isEnabled = true
             }
             
         case is ConfigNodeResetStatus:

--- a/Example/Source/View Controllers/Network/NetworkViewController.swift
+++ b/Example/Source/View Controllers/Network/NetworkViewController.swift
@@ -169,7 +169,7 @@ class NetworkViewController: UITableViewController, UISearchBarDelegate, Support
     }
     
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        return true
+        return MeshNetworkManager.instance.meshNetwork?.localProvisioner?.hasConfigurationCapabilities == true
     }
     
     override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {

--- a/Example/nRF Mesh.xcodeproj/project.pbxproj
+++ b/Example/nRF Mesh.xcodeproj/project.pbxproj
@@ -126,7 +126,6 @@
 		52A9C1C52313D7D80036792A /* GenericLevelViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A9C1C32313D7D80036792A /* GenericLevelViewCell.swift */; };
 		52A9C1C62313D7D80036792A /* GenericLevel.xib in Resources */ = {isa = PBXBuildFile; fileRef = 52A9C1C42313D7D80036792A /* GenericLevel.xib */; };
 		52B492DB25C8A32E0096E75D /* KeyRefreshProcedure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B492DA25C8A32E0096E75D /* KeyRefreshProcedure.swift */; };
-		52B6C50F2811712D00F6E0F3 /* UITableViewCell+Disabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B6C50E2811712D00F6E0F3 /* UITableViewCell+Disabled.swift */; };
 		52B7F67D229829F200B0A42F /* Addresses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7F67C229829F200B0A42F /* Addresses.swift */; };
 		52B7FD6D2525B40300308673 /* NodeSceneRecallViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B7FD6C2525B40300308673 /* NodeSceneRecallViewController.swift */; };
 		52BC6F4824507A5400EBEEA4 /* DisconnectCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BC6F4724507A5400EBEEA4 /* DisconnectCell.swift */; };
@@ -174,6 +173,8 @@
 		F03414832B912F95009DD792 /* LightLCModeGroupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03414822B912F95009DD792 /* LightLCModeGroupCell.swift */; };
 		F03414852B9131BA009DD792 /* LightLCOccupancyModeGroupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03414842B9131BA009DD792 /* LightLCOccupancyModeGroupCell.swift */; };
 		F03414872B91373E009DD792 /* LightLCLightOnOffGroupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03414862B91373E009DD792 /* LightLCLightOnOffGroupCell.swift */; };
+		F0464DAD2D5F79D200AE3684 /* UITableViewCell+Disabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0464DAB2D5F79D200AE3684 /* UITableViewCell+Disabled.swift */; };
+		F0464DAE2D5F79D200AE3684 /* UIViewController+Identify.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0464DAC2D5F79D200AE3684 /* UIViewController+Identify.swift */; };
 		F063C01A29C2774300A445A9 /* SelectKeysViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F063C01929C2774300A445A9 /* SelectKeysViewController.swift */; };
 		F063C01D29C27EAB00A445A9 /* IntroViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F063C01C29C27EAB00A445A9 /* IntroViewController.swift */; };
 		F085C9FB29C496AB00C2DF89 /* SelectModelsForBindingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F085C9FA29C496AB00C2DF89 /* SelectModelsForBindingViewController.swift */; };
@@ -333,7 +334,6 @@
 		52A9C1C32313D7D80036792A /* GenericLevelViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericLevelViewCell.swift; sourceTree = "<group>"; };
 		52A9C1C42313D7D80036792A /* GenericLevel.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GenericLevel.xib; sourceTree = "<group>"; };
 		52B492DA25C8A32E0096E75D /* KeyRefreshProcedure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyRefreshProcedure.swift; sourceTree = "<group>"; };
-		52B6C50E2811712D00F6E0F3 /* UITableViewCell+Disabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Disabled.swift"; sourceTree = "<group>"; };
 		52B7F67C229829F200B0A42F /* Addresses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Addresses.swift; sourceTree = "<group>"; };
 		52B7FD6C2525B40300308673 /* NodeSceneRecallViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeSceneRecallViewController.swift; sourceTree = "<group>"; };
 		52BC6F4724507A5400EBEEA4 /* DisconnectCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisconnectCell.swift; sourceTree = "<group>"; };
@@ -386,6 +386,8 @@
 		F03414822B912F95009DD792 /* LightLCModeGroupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCModeGroupCell.swift; sourceTree = "<group>"; };
 		F03414842B9131BA009DD792 /* LightLCOccupancyModeGroupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCOccupancyModeGroupCell.swift; sourceTree = "<group>"; };
 		F03414862B91373E009DD792 /* LightLCLightOnOffGroupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCLightOnOffGroupCell.swift; sourceTree = "<group>"; };
+		F0464DAB2D5F79D200AE3684 /* UITableViewCell+Disabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Disabled.swift"; sourceTree = "<group>"; };
+		F0464DAC2D5F79D200AE3684 /* UIViewController+Identify.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Identify.swift"; sourceTree = "<group>"; };
 		F063C01929C2774300A445A9 /* SelectKeysViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectKeysViewController.swift; sourceTree = "<group>"; };
 		F063C01C29C27EAB00A445A9 /* IntroViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewController.swift; sourceTree = "<group>"; };
 		F085C9FA29C496AB00C2DF89 /* SelectModelsForBindingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectModelsForBindingViewController.swift; sourceTree = "<group>"; };
@@ -698,13 +700,14 @@
 				F09DE4C629D771F20073969A /* Model+Name.swift */,
 				529B758522428A45008F1CE7 /* UIViewController+Alert.swift */,
 				52F6AD7522BA612900F0D7DF /* UIViewController+Toast.swift */,
+				F0464DAC2D5F79D200AE3684 /* UIViewController+Identify.swift */,
 				529B7642225222E8008F1CE7 /* Address+String.swift */,
 				529B764622522D37008F1CE7 /* UITableView+EmptyView.swift */,
+				F0464DAB2D5F79D200AE3684 /* UITableViewCell+Disabled.swift */,
 				529B76482252499E008F1CE7 /* UIColor+Nordic.swift */,
 				525242DF225CBFEC0044CECB /* RangeObject+String.swift */,
 				52DA9D7124F6765C0051795B /* UInt16+Time.swift */,
 				5292F8A225021B8F00EA0F2A /* ModelIdentifiers.swift */,
-				52B6C50E2811712D00F6E0F3 /* UITableViewCell+Disabled.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -1272,7 +1275,6 @@
 				5292F8A7250652BB00EA0F2A /* SceneServerGroupCell.swift in Sources */,
 				522AFFDC22BBA34900521EDC /* ActionCell.swift in Sources */,
 				52E54CE72345EDA700478F05 /* GenericState.swift in Sources */,
-				52B6C50F2811712D00F6E0F3 /* UITableViewCell+Disabled.swift in Sources */,
 				52DF5D8A228DA78A00C297C1 /* NodeViewController.swift in Sources */,
 				521215292315290F0059FB3D /* GroupControlViewController.swift in Sources */,
 				52A8EA8824E6946D004C14C7 /* HeartbeatPublicationCell.swift in Sources */,
@@ -1334,6 +1336,8 @@
 				529B7643225222E8008F1CE7 /* Address+String.swift in Sources */,
 				52248CDC251E21F000B10250 /* ExportViewController.swift in Sources */,
 				5288C2062370571100321ED3 /* ProxySelectorViewController.swift in Sources */,
+				F0464DAD2D5F79D200AE3684 /* UITableViewCell+Disabled.swift in Sources */,
+				F0464DAE2D5F79D200AE3684 /* UIViewController+Identify.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Library/Mesh API/MeshNetwork+Keys.swift
+++ b/Library/Mesh API/MeshNetwork+Keys.swift
@@ -78,6 +78,9 @@ public extension MeshNetwork {
         guard let nextIndex = index ?? nextAvailableApplicationKeyIndex else {
             throw MeshNetworkError.keyIndexOutOfRange
         }
+        guard applicationKeys[nextIndex] == nil else {
+            throw MeshNetworkError.keyIndexAlreadyExists
+        }
         let key = try ApplicationKey(name: name, index: nextIndex,
                                      key: applicationKey, boundTo: defaultNetworkKey)
         add(applicationKey: key)
@@ -145,6 +148,9 @@ public extension MeshNetwork {
     func add(networkKey: Data, withIndex index: KeyIndex? = nil, name: String) throws -> NetworkKey {
         guard let nextIndex = index ?? nextAvailableNetworkKeyIndex else {
             throw MeshNetworkError.keyIndexOutOfRange
+        }
+        guard networkKeys[nextIndex] == nil else {
+            throw MeshNetworkError.keyIndexAlreadyExists
         }
         let key = try NetworkKey(name: name, index: nextIndex, key: networkKey)
         add(networkKey: key)

--- a/Library/MeshNetworkError.swift
+++ b/Library/MeshNetworkError.swift
@@ -84,6 +84,8 @@ public enum MeshNetworkError: Error {
     /// Thrown when setting too small IV Index. The new IV Index must be greater than
     /// or equal to the previous one.
     case ivIndexTooSmall
+    /// Thrown when a key with the same index already exists in the network.
+    case keyIndexAlreadyExists
 }
 
 extension MeshNetworkError: LocalizedError {
@@ -111,6 +113,7 @@ extension MeshNetworkError: LocalizedError {
         case .noApplicationKey:                return NSLocalizedString("No Application Key.", comment: "")
         case .noNetwork:                       return NSLocalizedString("Mesh Network not created.", comment: "")
         case .ivIndexTooSmall:                 return NSLocalizedString("IV Index too small", comment: "")
+        case .keyIndexAlreadyExists:           return NSLocalizedString("Key with the same index already exists in the network.", comment: "")
         }
     }
     


### PR DESCRIPTION
This PR adds "Identify" button on the Node's screen.

It also improves the auto-configuration algorithm for the case when the Health Server isn't bound to any App Key.
Instead of sending an existing key it will create a new one with Key Index set to 4095 (max allowed) as a "safe key to share". This way no important App Key is shared to an untrusted Node.