### PR TITLE
Allowing specifying App Keys and Net Keys for sending messages

### DIFF
--- a/Library/Layers/Access Layer/AccessLayer.swift
+++ b/Library/Layers/Access Layer/AccessLayer.swift
@@ -246,9 +246,10 @@ internal class AccessLayer {
         networkManager.upperTransportLayer.send(pdu, withTtl: initialTtl, using: keySet)
     }
     
-    /// Sends the ``ConfigMessage`` to the given destination. The message is encrypted
-    /// using the Device Key which belongs to the target Node, and first
-    /// Network Key known to this Node.
+    /// Sends the ``ConfigMessage`` to the given destination.
+    ///
+    /// The message is encrypted using the Device Key which belongs to the target Node
+    /// and the given Network Key.
     ///
     /// - parameters:
     ///   - message:     The Mesh Config Message to send.
@@ -256,19 +257,14 @@ internal class AccessLayer {
     ///   - destination: The destination address. This must be a Unicast Address.
     ///   - initialTtl:  The initial TTL (Time To Live) value of the message.
     ///                  If `nil`, the default Node TTL will be used.
+    ///   - networkKey:  The Network Key to sign the message with.
     func send(_ message: ConfigMessage,
               from element: Element, to destination: Address,
-              withTtl initialTtl: UInt8?) {
+              withTtl initialTtl: UInt8?,
+              using networkKey: NetworkKey) {
         guard let networkManager = networkManager,
-              let node = meshNetwork.node(withAddress: destination),
-              var networkKey = node.networkKeys.first else {
+              let node = meshNetwork.node(withAddress: destination) else {
             return
-        }
-        // ConfigNetKeyDelete must not be signed using the key that is being deleted.
-        if let netKeyDelete = message as? ConfigNetKeyDelete,
-           netKeyDelete.networkKeyIndex == networkKey.index {
-            // Existence of another Network Key was checked in MeshNetworkManager.send(...).
-            networkKey = node.networkKeys.last!
         }
         guard let keySet = DeviceKeySet(networkKey: networkKey, node: node) else {
             return

--- a/Library/Layers/NetworkManager.swift
+++ b/Library/Layers/NetworkManager.swift
@@ -271,7 +271,7 @@ internal class NetworkManager {
         }
     }
     
-    /// Encrypts the message with the Device Key and the first Network Key
+    /// Encrypts the message with the Device Key and the given Network Key
     /// known to the target device, and sends to the given destination address.
     ///
     /// This method does not send nor return PDUs to be sent. Instead,
@@ -286,9 +286,11 @@ internal class NetworkManager {
     ///   - destination:   The destination address.
     ///   - initialTtl:    The initial TTL (Time To Live) value of the message.
     ///                    If `nil`, the default Node TTL will be used.
+    ///   - networkKey:    The Network Key to sign the message.
     func send(_ configMessage: UnacknowledgedConfigMessage,
               from element: Element, to destination: Address,
-              withTtl initialTtl: UInt8?) async throws {
+              withTtl initialTtl: UInt8?,
+              using networkKey: NetworkKey) async throws {
         let meshAddress = MeshAddress(destination)
         return try await withTaskCancellationHandler {
             return try await withCheckedThrowingContinuation { continuation in
@@ -305,7 +307,7 @@ internal class NetworkManager {
                 }
                 guard !busy else { return }
                 accessLayer.send(configMessage, from: element, to: destination,
-                                 withTtl: initialTtl)
+                                 withTtl: initialTtl, using: networkKey)
             }
         } onCancel: {
             cancel(messageWithHandler: MessageHandle(for: configMessage, sentFrom: element.unicastAddress,
@@ -313,10 +315,10 @@ internal class NetworkManager {
         }
     }
     
-    /// Encrypts the message with the Device Key and the first Network Key
+    /// Encrypts the message with the Device Key and the given Network Key
     /// known to the target device, and sends to the given destination address.
     ///
-    /// The ``ConfigNetKeyDelete`` will be signed with a different Network Key
+    /// The ``ConfigNetKeyDelete`` must be signed with a different Network Key
     /// that is removing.
     ///
     /// This method does not send nor return PDUs to be sent. Instead,
@@ -331,9 +333,11 @@ internal class NetworkManager {
     ///   - destination:   The destination address.
     ///   - initialTtl:    The initial TTL (Time To Live) value of the message.
     ///                    If `nil`, the default Node TTL will be used.
+    ///   - networkKey:    The Network Key to sign the message.
     func send(_ configMessage: AcknowledgedConfigMessage,
               from element: Element, to destination: Address,
-              withTtl initialTtl: UInt8?) async throws -> ConfigResponse {
+              withTtl initialTtl: UInt8?,
+              using networkKey: NetworkKey) async throws -> ConfigResponse {
         let meshAddress = MeshAddress(destination)
         return try await withTaskCancellationHandler {
             return try await withCheckedThrowingContinuation { continuation in
@@ -353,7 +357,7 @@ internal class NetworkManager {
                 }
                 guard !busy else { return }
                 accessLayer.send(configMessage, from: element, to: destination,
-                                 withTtl: initialTtl)
+                                 withTtl: initialTtl, using: networkKey)
             }
         } onCancel: {
             cancel(messageWithHandler: MessageHandle(for: configMessage, sentFrom: element.unicastAddress,


### PR DESCRIPTION
This PR extends the existing API for sending mesh messages by allowing specifying a key (an App Key or a Net Key) which shall be used to encrypt the message with.

Before, a first App Key bound to the selected Model, or the first Net Key on the list of known keys for a given Node was used. However, there are situations, when a message needs to be sent using a different key to reach its destination. For example, when the Proxy Node knows only a one, non-primary key, all messages must be sent using this key or they won't be relayed to the network.

The nRF Mesh app continues to use the first found key on the destination Node, just like before.