### PR TITLE
Finding common keys for target and proxy nodes

### DIFF
--- a/Library/Layers/Access Layer/AccessError.swift
+++ b/Library/Layers/Access Layer/AccessError.swift
@@ -45,14 +45,22 @@ public enum AccessError: Error {
     /// Thrown when the destination Address is not known and the
     /// library cannot determine the Network Key to use.
     case invalidDestination
+    /// Thrown when the target Node cannot decrypt messages
+    /// sent with the given key.
+    case invalidKey
     /// Thrown when trying to send a message from a Model that
     /// does not have any Application Key bound to it.
     case modelNotBoundToAppKey
     /// Thrown when trying to send a config message to a Node of
     /// which the Device Key is not known.
     case noDeviceKey
+    /// Thrown when a message is sent that is encrypted with a Network Key
+    /// that is not known to the connected GATT Proxy, or no GATT Proxy is
+    /// connected.
+    case cannotRelay
     /// Error thrown when the Provisioner is trying to delete
-    /// the last Network Key from the Node.
+    /// the last Network Key from the Node, or a key that is used
+    /// to secure the message.
     case cannotDelete
     /// Error thrown when trying to send a message to an address
     /// for which another message is already being sent.
@@ -70,11 +78,13 @@ extension AccessError: LocalizedError {
         switch self {
         case .invalidSource:         return NSLocalizedString("Local Provisioner does not have Unicast Address specified.", comment: "access")
         case .invalidElement:        return NSLocalizedString("Element does not belong to the local Node.", comment: "access")
-        case .invalidTtl:            return NSLocalizedString("Invalid TTL", comment: "access")
-        case .invalidDestination:    return NSLocalizedString("The destination address is invalid.", comment: "access")
+        case .invalidTtl:            return NSLocalizedString("Invalid TTL.", comment: "access")
+        case .invalidDestination:    return NSLocalizedString("The destination address is invalid or unknown.", comment: "access")
+        case .invalidKey:            return NSLocalizedString("The target Node cannot decrypt messages sent with the specified key.", comment: "access")
         case .modelNotBoundToAppKey: return NSLocalizedString("No Application Key bound to the given Model.", comment: "access")
-        case .noDeviceKey:           return NSLocalizedString("Unknown Device Key", comment: "access")
-        case .cannotDelete:          return NSLocalizedString("Cannot delete the last Network Key.", comment: "access")
+        case .noDeviceKey:           return NSLocalizedString("Unknown Device Key.", comment: "access")
+        case .cannotRelay:           return NSLocalizedString("No GATT Proxy Node is connected or the connected Proxy does not know the Network Key used to secure this message.", comment: "access")
+        case .cannotDelete:          return NSLocalizedString("Cannot delete the last Network Key or a key used to secure the message.", comment: "access")
         case .busy:                  return NSLocalizedString("Unable to send a message to specified address. Another transfer in progress.", comment: "access")
         case .timeout:               return NSLocalizedString("Request timed out.", comment: "access")
         case .cancelled:             return NSLocalizedString("Message cancelled.", comment: "access")

--- a/Library/Mesh API/Node+Address.swift
+++ b/Library/Mesh API/Node+Address.swift
@@ -39,7 +39,7 @@ public extension Node {
     
     /// The Unicast Address range assigned to all Elements of the Node.
     ///
-    /// The address range is continous and starts with ``primaryUnicastAddress``
+    /// The address range is continuous and starts with ``primaryUnicastAddress``
     /// and ends with ``lastUnicastAddress``.
     var unicastAddressRange: AddressRange {
         return AddressRange(from: primaryUnicastAddress, elementsCount: elementsCount)

--- a/Library/MeshNetworkManager+Callbacks.swift
+++ b/Library/MeshNetworkManager+Callbacks.swift
@@ -79,6 +79,25 @@ public extension MeshNetworkManager {
             print("Error: TTL value \(initialTtl!) is invalid")
             throw AccessError.invalidTtl
         }
+        // A message may be sent to a local Node, or using a GATT Proxy Node.
+        // Check if the message can be relayed to the destination using a Proxy Node.
+        // The Proxy Node must know the Network Key; otherwise it will not be able to
+        // decode the destination and decrement TTL.
+        if destination.address.isUnicast {
+            guard localNode.contains(elementWithAddress: destination.address) ||
+                  proxyFilter.proxy?.knows(networkKey: applicationKey.boundNetworkKey) == true else {
+                print("Error: The GATT Proxy Node is not connected or it cannot decrypt \(applicationKey.boundNetworkKey)")
+                throw AccessError.cannotRelay
+            }
+        } else {
+            if let proxy = proxyFilter.proxy {
+                if !proxy.knows(networkKey: applicationKey.boundNetworkKey) {
+                    logger?.w(.proxy, "\(proxy.name ?? "The GATT Proxy Node") cannot relay messages using \(applicationKey.boundNetworkKey), message will be sent only to the local Node.")
+                }
+            } else {
+                logger?.w(.proxy, "No GATT Proxy connected, message will be sent only to the local Node.")
+            }
+        }
         Task {
             do {
                 try await send(message, from: localElement, to: destination,
@@ -137,8 +156,9 @@ public extension MeshNetworkManager {
     /// Encrypts the message with the given Application Key and the Network Key
     /// bound to it, and sends it to the Node to which the Model belongs to.
     ///
-    /// The key must be bound to the given Model. If the key is not provided, the first bound
-    /// Application Key bound to the target Model will be used.
+    /// The key must be bound to the given Model. If the key is not provided, the first
+    /// Application Key bound to the target Model, which is also known by the GATT Proxy
+    /// Node, will be used.
     ///
     /// Apart from the `completion` callback, an appropriate callback of the
     /// ``MeshNetworkDelegate`` will be called when the message has been sent
@@ -170,23 +190,46 @@ public extension MeshNetworkManager {
               withTtl initialTtl: UInt8? = nil,
               using applicationKey: ApplicationKey? = nil,
               completion: ((Result<Void, Error>) -> ())? = nil) throws -> MessageHandle {
-        guard let element = model.parentElement else {
+        guard let element = model.parentElement,
+              let node = element.parentNode else {
             print("Error: Element does not belong to a Node")
             throw AccessError.invalidDestination
         }
-        guard let applicationKey = applicationKey ?? model.boundApplicationKeys.first,
-              model.isBoundTo(applicationKey) else {
-            print("Error: Model is not bound to the Application Key")
-            throw AccessError.modelNotBoundToAppKey
+        // If the Application Key is given, check if it is bound to the Model.
+        if let applicationKey = applicationKey {
+            guard model.isBoundTo(applicationKey) else {
+                print("Error: Model is not bound to the Application Key")
+                throw AccessError.invalidKey
+            }
+        } else {
+            // If not, make sure there are any bound Application Keys.
+            guard !model.boundApplicationKeys.isEmpty else {
+                print("Error: No Application Key bound to the Model")
+                throw AccessError.modelNotBoundToAppKey
+            }
+        }
+        // Check if the Application Key is known to the Proxy Node, or
+        // the message is sent to the local Node.
+        guard let applicationKey = applicationKey ?? model.boundApplicationKeys
+            .first(where: {
+                // Unless the message is sent locally, take only keys known to the Proxy Node.
+                node.isLocalProvisioner || proxyFilter.proxy?.knows(networkKey: $0.boundNetworkKey) == true
+            }),
+            node.isLocalProvisioner || proxyFilter.proxy?.knows(networkKey: applicationKey.boundNetworkKey) == true else {
+            print("Error: No GATT Proxy connected or no common Network Keys")
+            throw AccessError.cannotRelay
         }
         return try send(message, from: localElement, to: MeshAddress(element.unicastAddress),
                         withTtl: initialTtl, using: applicationKey,
                         completion: completion)
     }
     
-    /// Encrypts the message with the common Application Key bound to both given
-    /// ``Model``s and the Network Key bound to it, and sends it to the Node
-    /// to which the target Model belongs to.
+    /// Encrypts the message with the given Application Key and the Network Key
+    /// bound to it, and sends it to the Node to which the Model belongs to.
+    ///
+    /// The key must be bound to the given Model. If the key is not provided, the first
+    /// Application Key bound to the target Model, which is also known by the GATT Proxy
+    /// Node, will be used.
     ///
     /// Apart from the `completion` callback, an appropriate callback of the
     /// ``MeshNetworkDelegate`` will be called when the message has been sent
@@ -226,9 +269,12 @@ public extension MeshNetworkManager {
                         completion: completion)
     }
     
-    /// Encrypts the message with the first Application Key bound to the given
-    /// Model and a Network Key bound to it, and sends it to the Node
-    /// to which the Model belongs to.
+    /// Encrypts the message with the given Application Key and the Network Key
+    /// bound to it, and sends it to the Node to which the Model belongs to.
+    ///
+    /// The key must be bound to the given Model. If the key is not provided, the first
+    /// Application Key bound to the target Model, which is also known by the GATT Proxy
+    /// Node, will be used.
     ///
     /// Apart from the `completion` callback, an appropriate callback of the
     /// ``MeshNetworkDelegate`` will be called when the message has been sent
@@ -265,14 +311,34 @@ public extension MeshNetworkManager {
             print("Error: Mesh Network not created")
             throw MeshNetworkError.noNetwork
         }
-        guard let element = model.parentElement else {
+        guard let element = model.parentElement,
+              let node = element.parentNode else {
             print("Error: Element does not belong to a Node")
             throw AccessError.invalidDestination
         }
-        guard let applicationKey = applicationKey ?? model.boundApplicationKeys.first,
-              model.isBoundTo(applicationKey) else {
-            print("Error: Model is not bound to the Application Key")
-            throw AccessError.modelNotBoundToAppKey
+        // If the Application Key is given, check if it is bound to the Model.
+        if let applicationKey = applicationKey {
+            guard model.isBoundTo(applicationKey) else {
+                print("Error: Model is not bound to the Application Key")
+                throw AccessError.invalidKey
+            }
+        } else {
+            // If not, make sure there are any bound Application Keys.
+            guard !model.boundApplicationKeys.isEmpty else {
+                print("Error: No Application Key bound to the Model")
+                throw AccessError.modelNotBoundToAppKey
+            }
+        }
+        // Check if the Application Key is known to the Proxy Node, or
+        // the message is sent to the local Node.
+        guard let applicationKey = applicationKey ?? model.boundApplicationKeys
+              .first(where: {
+                  // Unless the message is sent locally, take only keys known to the Proxy Node.
+                  node.isLocalProvisioner || proxyFilter.proxy?.knows(networkKey: $0.boundNetworkKey) == true
+              }),
+              node.isLocalProvisioner || proxyFilter.proxy?.knows(networkKey: applicationKey.boundNetworkKey) == true else {
+            print("Error: No GATT Proxy connected or no common Network Keys")
+            throw AccessError.cannotRelay
         }
         guard let localNode = meshNetwork.localProvisioner?.node,
               let source = localElement ?? localNode.elements.first else {
@@ -308,9 +374,12 @@ public extension MeshNetworkManager {
                              to: MeshAddress(element.unicastAddress), using: networkManager)
     }
     
-    /// Encrypts the message with the common Application Key bound to both given
-    /// Models and a Network Key bound to it, and sends it to the Node
-    /// to which the target Model belongs to.
+    /// Encrypts the message with the given Application Key and the Network Key
+    /// bound to it, and sends it to the Node to which the Model belongs to.
+    ///
+    /// The key must be bound to the given Model. If the key is not provided, the first
+    /// Application Key bound to the target Model, which is also known by the GATT Proxy
+    /// Node, will be used.
     ///
     /// Apart from the `completion` callback, an appropriate callback of the
     /// ``MeshNetworkDelegate`` will be called when the message has been sent
@@ -366,7 +435,7 @@ public extension MeshNetworkManager {
     ///                  If `nil`, the default Node TTL will be used.
     ///   - networkKey:  The Network Key to sign the message. The Node must
     ///                  know this key. If `nil`, the first Network Key known to the
-    ///                  Node will be used.
+    ///                  Node, which is also known by the GATT Proxy Node, will be used.
     ///   - completion:  The completion handler called when the message
     ///                  has been sent.
     /// - throws: This method throws when the mesh network has not been created,
@@ -398,10 +467,22 @@ public extension MeshNetworkManager {
             print("Error: Unknown destination Node")
             throw AccessError.invalidDestination
         }
-        guard let networkKey = networkKey ?? node.networkKeys.first,
-              node.knows(networkKey: networkKey) else {
-            print("Fatal Error: The target Node does not know the Network Key")
-            throw AccessError.invalidDestination
+        if let networkKey = networkKey {
+            guard node.knows(networkKey: networkKey) else {
+                print("Error: Node does not know the given Network Key")
+                throw AccessError.invalidKey
+            }
+        }
+        // Check if the Network Key is known to the Proxy Node, or
+        // the message is sent to the local Node.
+        guard let networkKey = networkKey ?? node.networkKeys
+              .first(where: {
+                    // Unless the message is sent locally, take only keys known to the Proxy Node.
+                    node.isLocalProvisioner || proxyFilter.proxy?.knows(networkKey: $0) == true
+              }),
+              node.isLocalProvisioner || proxyFilter.proxy?.knows(networkKey: networkKey) == true else {
+            print("Error: No GATT Proxy connected or no common Network Keys")
+            throw AccessError.cannotRelay
         }
         guard let _ = node.deviceKey else {
             print("Error: Node's Device Key is unknown")
@@ -431,7 +512,8 @@ public extension MeshNetworkManager {
                              to: MeshAddress(destination), using: networkManager)
     }
     
-    /// Sends a Configuration Message to the primary Element on the given ``Node``.
+    /// Sends an Unacknowledged Configuration Message to the primary Element
+    /// on the given ``Node``.
     ///
     /// Apart from the `completion` callback, an appropriate callback of the
     /// ``MeshNetworkDelegate`` will be called when the message has been sent
@@ -463,7 +545,7 @@ public extension MeshNetworkManager {
                         completion: completion)
     }
     
-    /// Sends Configuration Message to the Node with given destination Address.
+    /// Sends a Configuration Message to the Node with given destination Address.
     ///
     /// The `destination` must be a Unicast Address, otherwise the method
     /// throws an ``AccessError/invalidDestination`` error.
@@ -479,7 +561,8 @@ public extension MeshNetworkManager {
     ///                  If `nil`, the default Node TTL will be used.
     ///   - networkKey:  The Network Key to sign the message. The Node must
     ///                  know this key. If `nil`, the first Network Key known to the
-    ///                  Node will be used.
+    ///                  Node (that is not being deleted), which is also known by the
+    ///                  GATT Proxy Node, will be used.
     ///   - completion:  The completion handler which is called when the response
     ///                  has been received.
     /// - throws: This method throws when the mesh network has not been created,
@@ -512,18 +595,31 @@ public extension MeshNetworkManager {
             print("Error: Unknown destination Node")
             throw AccessError.invalidDestination
         }
+        if let networkKey = networkKey {
+            guard node.knows(networkKey: networkKey) else {
+                print("Error: Node does not know the given Network Key")
+                throw AccessError.invalidKey
+            }
+        }
+        guard let networkKey = networkKey ?? node.networkKeys
+              .first(where: {
+                    // A key that is being deleted cannot be used to send a message.
+                    (message as? ConfigNetKeyDelete)?.networkKeyIndex != $0.index &&
+                    // Unless the message is sent locally, take only keys known to the Proxy Node.
+                    (node.isLocalProvisioner || proxyFilter.proxy?.knows(networkKey: $0) == true)
+              }),
+              node.isLocalProvisioner || proxyFilter.proxy?.knows(networkKey: networkKey) == true else {
+            if let configNetKeyDelete = message as? ConfigNetKeyDelete,
+               networkKey == nil || networkKey?.index == configNetKeyDelete.networkKeyIndex {
+                print("Error: Cannot delete the last Network Key or a key used to secure the message")
+                throw AccessError.cannotDelete
+            }
+            print("Error: No GATT Proxy connected or no common Network Keys")
+            throw AccessError.cannotRelay
+        }
         guard let _ = node.deviceKey else {
             print("Error: Node's Device Key is unknown")
             throw AccessError.noDeviceKey
-        }
-        // Take the Network Key given by the user, or the first Network Key
-        // known to the Node that is not being deleted, and check whether it
-        // is not being deleted.
-        guard let networkKey = networkKey ?? node.networkKeys.first(where: { (message as? ConfigNetKeyDelete)?.networkKeyIndex != $0.index }),
-              node.knows(networkKey: networkKey),
-              (message as? ConfigNetKeyDelete)?.networkKeyIndex != networkKey.index else {
-            print("Error: Cannot delete a Network Key using given key")
-            throw AccessError.cannotDelete
         }
         guard initialTtl == nil || initialTtl! <= 127 else {
             print("Error: TTL value \(initialTtl!) is invalid")
@@ -562,7 +658,8 @@ public extension MeshNetworkManager {
     ///                 If `nil`, the default Node TTL will be used.
     ///   - networkKey: The Network Key to sign the message. The Node must
     ///                 know this key. If `nil`, the first Network Key known to the
-    ///                 Node will be used.
+    ///                 Node (that is not being deleted), which is also known by the
+    ///                 GATT Proxy Node, will be used.
     ///   - completion: The completion handler which is called when the response
     ///                 has been received.
     /// - throws: This method throws when the mesh network has not been created,

--- a/Library/ProxyFilter.swift
+++ b/Library/ProxyFilter.swift
@@ -214,9 +214,10 @@ public class ProxyFilter {
     /// By default the Proxy Filter is set to ``ProxyFilerType/acceptList``.
     public private(set) var type: ProxyFilerType = .acceptList
     
-    /// The connected Proxy Node. This may be `nil` if the connected Node is unknown
-    /// to the provisioner, that is if a Node with the proxy Unicast Address was not found
-    /// in the local mesh network database. It is also `nil` if no proxy is connected.
+    /// The connected Proxy Node.
+    ///
+    /// This is `nil` if no GATT Proxy Node is connected, or the connected Node is
+    /// not in the local mesh configuration database.
     public private(set) var proxy: Node?
     
     // MARK: - Implementation


### PR DESCRIPTION
In some situations, the phone may be connected to a GATT Proxy node that has limited number of Network Keys.
Using this GATT connection it may try to send a message to another node, which has a different set of Network Keys.
This PR improves how the automatic key selection is done. 

### Before

The first App Key bound to the target Model was chosen.
The first Network Key of a target Node was chosen for messages secured with a Device Key.

### After

The library tries to find a common key that is known by the Proxy and bound to the target model or known by the target node (for messages secured with a Device Key).

## Breaking

This PR adds new `AccessError`s: 
* `.invalidKey` - thrown when the target node does not know selected key
* `.cannotRelay` - thrown when a message sent to a Unicast Address is secured with a Network Key unknown to the connected Proxy node.