### PR TITLE
Bugfix: App crashes when adding 4097th key

### DIFF
--- a/Example/Source/View Controllers/Settings/AppKeysViewController.swift
+++ b/Example/Source/View Controllers/Settings/AppKeysViewController.swift
@@ -87,6 +87,15 @@ class AppKeysViewController: UITableViewController, Editable {
         }
     }
     
+    override func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {
+        let keyIndex = MeshNetworkManager.instance.meshNetwork?.nextAvailableApplicationKeyIndex
+        guard let _ = keyIndex else {
+            presentAlert(title: "No Key Index available", message: "A limit of 4096 keys has been reached.")
+            return false
+        }
+        return true
+    }
+    
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "networkKeys" {
             let target = segue.destination as! NetworkKeysViewController

--- a/Example/Source/View Controllers/Settings/NetworkKeysViewController.swift
+++ b/Example/Source/View Controllers/Settings/NetworkKeysViewController.swift
@@ -54,6 +54,15 @@ class NetworkKeysViewController: UITableViewController, Editable {
         }
     }
     
+    override func shouldPerformSegue(withIdentifier identifier: String, sender: Any?) -> Bool {
+        let keyIndex = MeshNetworkManager.instance.meshNetwork?.nextAvailableNetworkKeyIndex
+        guard let _ = keyIndex else {
+            presentAlert(title: "No Key Index available", message: "A limit of 4096 keys has been reached.")
+            return false
+        }
+        return true
+    }
+    
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         let target = segue.destination as! UINavigationController
         let viewController = target.topViewController! as! EditKeyViewController

--- a/Library/Mesh API/MeshNetwork+Keys.swift
+++ b/Library/Mesh API/MeshNetwork+Keys.swift
@@ -34,30 +34,36 @@ public extension MeshNetwork {
     
     /// Next available Key Index that can be assigned to a new Application Key.
     ///
-    /// - note: This method does not look for gaps in key indexes. It returns the
-    ///         next available Key Index after the last Key Index used.
+    /// - note: This method searches for any available key index that is not used,
+    ///         looking for gaps in the key indexes. If there are no gaps, the
+    ///         next available key index will be the first one after the last one.
     var nextAvailableApplicationKeyIndex: KeyIndex? {
         if applicationKeys.isEmpty {
             return 0
         }
-        guard let lastAppKey = applicationKeys.last, (lastAppKey.index + 1).isValidKeyIndex else {
-            return nil
+        for index: KeyIndex in 1..<4056 {
+            if applicationKeys[index] == nil {
+                return index
+            }
         }
-        return lastAppKey.index + 1
+        return nil
     }
     
     /// Next available Key Index that can be assigned to a new Network Key.
     ///
-    /// - note: This method does not look for gaps in key indexes. It returns the
-    ///         next available Key Index after the last Key Index used.
+    /// - note: This method searches for any available key index that is not used,
+    ///         looking for gaps in the key indexes. If there are no gaps, the
+    ///         next available key index will be the first one after the last one.         
     var nextAvailableNetworkKeyIndex: KeyIndex? {
         if networkKeys.isEmpty {
             return 0
         }
-        guard let lastNetKey = networkKeys.last, (lastNetKey.index + 1).isValidKeyIndex else {
-            return nil
+        for index: KeyIndex in 1..<4056 {
+            if networkKeys[index] == nil {
+                return index
+            }
         }
-        return lastNetKey.index + 1
+        return nil
     }
     
     /// Adds a new Application Key and binds it to the first Network Key.


### PR DESCRIPTION
After the last changes with Node Identity buttons it was easy to create an Application Key with index 4095 (this key is added automatically when user clicks Identify button and the Node has no Application Keys).
Later on, when trying to add a new key the app was crashing despite 4093 key indexes being available.

Now, the `nextAvailable...KeyIndex` returns any available key index, going from 0 until 4095, or `nil` if someone has 4095 keys, which would be impresive.