### PR TITLE
Bugfix: Allowing sending message through an unknown proxy node

### DIFF
--- a/Library/Documentation.docc/NordicMesh.md
+++ b/Library/Documentation.docc/NordicMesh.md
@@ -732,6 +732,7 @@ Proxy Server, a proxy filter can be used.
 - ``ProxyFilerType``
 - ``ProxyFilterDelegate``
 - ``ProxyFilterSetup``
+- ``UnknownNode``
 
 ### Proxy Filter Configuration Message Types
 

--- a/Library/Layers/Network Layer/NetworkLayer.swift
+++ b/Library/Layers/Network Layer/NetworkLayer.swift
@@ -421,7 +421,7 @@ private extension NetworkLayer {
            let message = MessageType.init(parameters: controlMessage.upperTransportPdu) {
             logger?.i(.proxy, "\(message) received from: \(proxyPdu.source.hex) to: \(proxyPdu.destination.hex)")
             // Look for the proxy Node.
-            let proxyNode = meshNetwork.node(withAddress: proxyPdu.source)
+            let proxyNode = meshNetwork.node(withAddress: proxyPdu.source) ?? UnknownNode(from: proxyPdu, in: meshNetwork)
             networkManager.proxy?.handle(message, sentFrom: proxyNode)
         } else {
             logger?.w(.proxy, "Unsupported proxy configuration message (opcode: \(controlMessage.opCode))")

--- a/Library/Mesh Model/Node.swift
+++ b/Library/Mesh Model/Node.swift
@@ -273,6 +273,21 @@ public class Node: Codable {
         }
     }
     
+    /// A constructor for an Unknown Node.
+    ///
+    /// An Unknown Node is a Node that has been discovered in the network
+    /// but has not been added to the mesh network yet.
+    internal init(unicastAddress: Address, networkKey: NetworkKey) {
+        self.uuid = UUID()
+        self.name = nil
+        self.primaryUnicastAddress = unicastAddress
+        self.deviceKey = nil
+        self.security = .insecure
+        self.netKeys  = [NodeKey(index: networkKey.index, updated: false)]
+        self.appKeys  = []
+        self.elements = [Element(location: .unknown)]
+    }
+    
     /// Initializes the Provisioner's Node.
     ///
     /// The Provisioner's node has the same name and node UUID as the Provisioner.


### PR DESCRIPTION
This PR fixes #654.

It adds a new type `UnknownNode`, which is set as `ProxyFilter.proxy` when an unknown Node is connected as GATT proxy. Upon receiving a `ProxyConfigurationMessage` (`FilterStatus`) from a connected Proxy the phone will know its Unicast Address and the Network Key. These data are then used to initialize the `UnknownNode`.

When a message is sent through such Node the library will always use this Network Key, as it's unaware[^1] of other keys that the Proxy Node may know. 

[^1]: In theory, it gets a Secure Network beacon or a Private beacon for each Network Key, but these get discarded on the Network Layer before the Proxy messaegs are sent. Some more refactoring would have to be made to support more Network Keys for Unknown Nodes.