### PR TITLE
Refactoring: App Key is bound to a Model, not the other way around

### DIFF
--- a/Example/Source/View Controllers/Network/Configuration/Automation/ConfigurationViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Automation/ConfigurationViewController.swift
@@ -154,7 +154,7 @@ class ConfigurationViewController: UIViewController,
                 if originalModel.supportsApplicationKeyBinding,
                    let targetModel = targetElement.model(withModelId: originalModel.modelId) {
                     let boundApplicationKeys = meshNetwork.applicationKeys
-                        .filter { originalModel.isBoundTo($0) }
+                        .filter { $0.isBound(to: originalModel) }
                     boundApplicationKeys.forEach { applicationKey in
                         tasks.append(.bind(applicationKey, to: targetModel))
                     }
@@ -257,7 +257,7 @@ class ConfigurationViewController: UIViewController,
         // When all the keys are sent, start binding them to Models.
         models.forEach { model in
             applicationKeys.forEach { applicationKey in
-                if !model.isBoundTo(applicationKey) {
+                if !applicationKey.isBound(to: model) {
                     tasks.append(.bind(applicationKey, to: model))
                 }
             }

--- a/Library/Mesh API/Model+Keys.swift
+++ b/Library/Mesh API/Model+Keys.swift
@@ -41,7 +41,7 @@ public extension Model {
     /// In that case use ``Model/isBoundTo(_:)`` instead.
     var boundApplicationKeys: [ApplicationKey] {
         return parentElement?.parentNode?.applicationKeys
-            .filter { isBoundTo($0) } ?? []
+            .filter { $0.isBound(to: self) } ?? []
     }
     
     /// Whether the given Application Key is bound to this Model.
@@ -51,6 +51,7 @@ public extension Model {
     /// - parameter applicationKey: The key to check.
     /// - returns: `True` if the key is bound to this Model,
     ///            otherwise `false`.
+    @available(*, deprecated, message: "Use applicationKey.isBound(to: model) instead.")
     func isBoundTo(_ applicationKey: ApplicationKey) -> Bool {
         return bind.contains(applicationKey.index)
     }
@@ -61,6 +62,18 @@ public extension Model {
     /// - since: 4.0.0 
     var supportsApplicationKeyBinding: Bool {
         return !requiresDeviceKey
+    }
+    
+}
+
+public extension ApplicationKey {
+    
+    /// Returns whether the Application Key is bound to the given Model.
+    ///
+    /// - parameter model: The Model to check.
+    /// - returns: `True`, if the Application Key is bound to the Model.
+    func isBound(to model: Model) -> Bool {
+        return model.bind.contains(index)
     }
     
 }

--- a/Library/MeshNetworkManager.swift
+++ b/Library/MeshNetworkManager.swift
@@ -501,8 +501,8 @@ public extension MeshNetworkManager {
         }
         // If the Application Key is given, check if it is bound to the Model.
         if let applicationKey = applicationKey {
-            guard model.isBoundTo(applicationKey) else {
-                print("Error: Model is not bound to the Application Key")
+            guard applicationKey.isBound(to: model) else {
+                print("Error: Application Key is not bound to the Model")
                 throw AccessError.invalidKey
             }
         } else {
@@ -613,8 +613,8 @@ public extension MeshNetworkManager {
         }
         // If the Application Key is given, check if it is bound to the Model.
         if let applicationKey = applicationKey {
-            guard model.isBoundTo(applicationKey) else {
-                print("Error: Model is not bound to the Application Key")
+            guard applicationKey.isBound(to: model) else {
+                print("Error: Application Key is not bound to the Model")
                 throw AccessError.invalidKey
             }
         } else {


### PR DESCRIPTION
This PR improves public API..

A method `Model.isBoundTo(AppKey)` was refactored to `AppKey.isBound(to: Model)`.

Reasons:
1. It is an Application Key that is bound to a Model, not the other way around
2. There already were methdos `isBound(to: ..)` for Application Key and Network Key.

The previous method has been **deprecated**.