### PR TITLE
Device properties fixes

### DIFF
--- a/Library/Mesh Messages/DeviceProperty.swift
+++ b/Library/Mesh Messages/DeviceProperty.swift
@@ -234,6 +234,7 @@ public enum DeviceProperty: Sendable {
     case shortCircuitEventStatistics
     /// This property represents the time that has elapsed since the sensor last detected any activity.
     case timeSinceMotionSensed
+    /// This property represents the time that has elapsed since the sensor last detected presence.
     case timeSincePresenceDetected
     case totalDeviceEnergyUse
     case totalDeviceOffOnCycles

--- a/Library/Mesh Messages/DeviceProperty.swift
+++ b/Library/Mesh Messages/DeviceProperty.swift
@@ -232,6 +232,7 @@ public enum DeviceProperty: Sendable {
     case relativeRuntimeInAnInputCurrentRange
     case relativeRuntimeInAnInputVoltageRange
     case shortCircuitEventStatistics
+    /// This property represents the time that has elapsed since the sensor last detected any activity.
     case timeSinceMotionSensed
     case timeSincePresenceDetected
     case totalDeviceEnergyUse
@@ -907,7 +908,6 @@ internal extension DeviceProperty {
              .presentOutputCurrent,
              .presentDeviceOperatingTemperature,
              .precisePresentAmbientTemperature,
-             .timeSinceMotionSensed,
              .timeSincePresenceDetected,
              .luminaireNominalMaximumACMainsVoltage,
              .luminaireNominalMinimumACMainsVoltage,
@@ -949,6 +949,7 @@ internal extension DeviceProperty {
              .luminaireNominalInputPower,
              .luminairePowerAtMinimumDimLevel,
              .luminaireTimeOfManufacture,
+             .timeSinceMotionSensed,
              .presentAmbientLightLevel,
              .presentDeviceInputPower,
              .presentIlluminance,
@@ -1101,8 +1102,7 @@ internal extension DeviceProperty {
             guard length == valueLength else { return .count16(nil) }
             let count: UInt16 = data.read(fromOffset: offset)
             return .count16(count.withUnknownValue(0xFFFF))
-        case .timeSinceMotionSensed,
-             .timeSincePresenceDetected:
+        case .timeSincePresenceDetected:
             guard length == valueLength else { return .timeSecond16(nil) }
             let value: UInt16 = data.read(fromOffset: offset)
             return .timeSecond16(value.withUnknownValue(0xFFFF))
@@ -1205,7 +1205,8 @@ internal extension DeviceProperty {
              .lightControlTimeFadeStandbyManual,
              .lightControlTimeOccupancyDelay,
              .lightControlTimeProlong,
-             .lightControlTimeRunOn:
+             .lightControlTimeRunOn,
+             .timeSinceMotionSensed:
             guard length == valueLength else { return .timeMillisecond24(nil) }
             let value: UInt32 = data.readUInt24(fromOffset: offset)
             return .timeMillisecond24(value.withUnknownValue(0xFFFFFF))

--- a/Library/Mesh Messages/DeviceProperty.swift
+++ b/Library/Mesh Messages/DeviceProperty.swift
@@ -968,6 +968,8 @@ internal extension DeviceProperty {
              .lightControlRegulatorKiu,
              .lightControlRegulatorKpd,
              .lightControlRegulatorKpu,
+             .lightSourceOnTimeResettable,
+             .lightSourceOnTimeNotResettable,
              .sensorGain:
             return 4
             
@@ -1241,6 +1243,14 @@ internal extension DeviceProperty {
             guard value != UInt32(0xFFFFFF) else { return .apparentPower(nil) }
             guard value != UInt32(0xFFFFFE) else { return .apparentPower(.invalid) }
             return .apparentPower(.valid(Decimal(sign: .plus, exponent: -1, significand: Decimal(value))))
+            
+        // UInt32 -> UInt32?
+        case .lightSourceOnTimeResettable,
+             .lightSourceOnTimeNotResettable:
+            guard length == valueLength else { return .timeSecond32(nil) }
+            let value: UInt32 = data.read(fromOffset: offset)
+            guard value != UInt32(0xFFFFFFFF) else { return .timeSecond32(nil) }
+            return .timeSecond32(value)
 
         // UInt32 -> ValidDecimal?
         case .preciseTotalDeviceEnergyUse,


### PR DESCRIPTION
This PR fixes several issues in Device Properties:
1. _Time Since Motion Sensed_ property has switched characteristic from _Time Second 16_ to _Time Millisecond 24_.
   * It used to be _Time Second 16_ in **Mesh Device Properties 2**, and in the current version of _Device Properties_ it has a characteristic _Time Milliseond 24_.
2. A _Light Source On Time (Not) Resettable_ have _Time Second 32_ characteristic, which was implemented before, but not used. So now it's being used.