### PR TITLE
[App] Support for Pairing Responder model

### DIFF
--- a/Example/Source/AppDelegate.swift
+++ b/Example/Source/AppDelegate.swift
@@ -182,6 +182,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Model(sigModelId: .genericOnOffClientModelId, delegate: GenericOnOffClientDelegate()),
             Model(sigModelId: .genericLevelClientModelId, delegate: GenericLevelClientDelegate()),
             Model(sigModelId: .lightLCClientModelId, delegate: LightLCClientDelegate()),
+            // Nordic Pairing Initiator model:
+            Model(vendorModelId: .lePairingInitiator,
+                  companyId: .nordicSemiconductorCompanyId,
+                  delegate: PairingInitiatorDelegate()),
             // A simple vendor model:
             Model(vendorModelId: .simpleOnOffClientModelId,
                   companyId: .nordicSemiconductorCompanyId,

--- a/Example/Source/Mesh Network/LE Pairing/Messages/PairingRequest.swift
+++ b/Example/Source/Mesh Network/LE Pairing/Messages/PairingRequest.swift
@@ -1,0 +1,54 @@
+/*
+* Copyright (c) 2025, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import NordicMesh
+
+struct PairingRequest: StaticAcknowledgedVendorMessage {
+    // The Op Code consists of:
+    // 0xC0-0000 - Vendor Op Code bitmask
+    // 0x11-0000 - The Op Code defined by...
+    // 0x00-5900 - Nordic Semiconductor ASA company ID (in Little Endian) as defined here:
+    //             https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/
+    static let opCode: UInt32 = 0xD15900 // The same Op Code as PairingResponse!
+    static let responseType: StaticMeshResponse.Type = PairingResponse.self
+    
+    var parameters: Data? {
+        return Data([0x00])
+    }
+    
+    init() {}
+    
+    init?(parameters: Data) {
+        guard parameters.count == 1 && parameters[0] == 0x00 else {
+            return nil
+        }
+    }
+}

--- a/Example/Source/Mesh Network/LE Pairing/Messages/PairingResponse.swift
+++ b/Example/Source/Mesh Network/LE Pairing/Messages/PairingResponse.swift
@@ -1,0 +1,64 @@
+/*
+* Copyright (c) 2025, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import NordicMesh
+
+struct PairingResponse: StaticVendorResponse {
+    // The Op Code consists of:
+    // 0xC0-0000 - Vendor Op Code bitmask
+    // 0x11-0000 - The Op Code defined by...
+    // 0x00-5900 - Nordic Semiconductor ASA company ID (in Little Endian) as defined here:
+    //             https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/
+    static let opCode: UInt32 = 0xD15900 // The same Op Code as PairingRequest!
+    
+    var parameters: Data? {
+        let passkeyData = Data() + passkey
+        return Data([0x01, status]) + passkeyData.dropFirst()
+    }
+    /// Message status.
+    let status: UInt8
+    /// The passkey to be used for pairing.
+    let passkey: Int
+    
+    init(status: UInt8, passkey: Int) {
+        self.status = status
+        self.passkey = passkey
+    }
+    
+    init?(parameters: Data) {
+        guard parameters.count == 5 && parameters[0] == 0x01 else {
+            return nil
+        }
+        status = parameters[1]
+        passkey = Int(parameters[2]) | Int(parameters[3]) << 8 | Int(parameters[4]) << 16
+    }
+    
+}

--- a/Example/Source/Mesh Network/LE Pairing/PairingInitiatorDelegate.swift
+++ b/Example/Source/Mesh Network/LE Pairing/PairingInitiatorDelegate.swift
@@ -1,0 +1,69 @@
+/*
+* Copyright (c) 2025, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import NordicMesh
+
+class PairingInitiatorDelegate: ModelDelegate {
+    
+    let messageTypes: [UInt32 : MeshMessage.Type]
+    let isSubscriptionSupported: Bool = false
+    
+    var publicationMessageComposer: MessageComposer? {
+        return nil
+    }
+    
+    init() {
+        let types: [StaticMeshMessage.Type] = [
+            PairingResponse.self
+        ]
+        messageTypes = types.toMap()
+    }
+    
+    // MARK: - Message handlers
+    
+    func model(_ model: Model, didReceiveAcknowledgedMessage request: AcknowledgedMeshMessage,
+               from source: Address, sentTo destination: MeshAddress) -> MeshResponse {
+        fatalError("Not possible")
+    }
+    
+    func model(_ model: Model, didReceiveUnacknowledgedMessage message: UnacknowledgedMeshMessage,
+               from source: Address, sentTo destination: MeshAddress) {
+        // The status message may be received here if the Light LC Server model
+        // has been configured to publish. Ignore this message.
+    }
+    
+    func model(_ model: Model, didReceiveResponse response: MeshResponse,
+               toAcknowledgedMessage request: AcknowledgedMeshMessage,
+               from source: Address) {
+        // Ignore.
+    }
+    
+}

--- a/Example/Source/UI/Model/PairingResponder.xib
+++ b/Example/Source/UI/Model/PairingResponder.xib
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="96" id="B4P-wJ-v4L" customClass="PairingResponderViewCell" customModule="nRF_Mesh" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="396" height="96"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="B4P-wJ-v4L" id="TF5-B3-KqO">
+                <rect key="frame" x="0.0" y="0.0" width="396" height="96"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Passkey" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qhb-a9-yuj">
+                        <rect key="frame" x="20" y="11" width="62.5" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Unknown" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gLq-q2-MiP">
+                        <rect key="frame" x="90.5" y="11" width="285.5" height="20"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="20" id="g1R-a2-MCz"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bdk-RI-pgy">
+                        <rect key="frame" x="20" y="44" width="376" height="0.5"/>
+                        <color key="backgroundColor" systemColor="opaqueSeparatorColor"/>
+                        <rect key="contentStretch" x="0.0" y="0.0" width="1" height="0.33000000000000002"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="iXA-1v-jEk"/>
+                        </constraints>
+                    </view>
+                    <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jXV-9y-UJ0">
+                        <rect key="frame" x="326" y="52.5" width="70" height="35.5"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="70" id="UjK-R1-Ciu"/>
+                        </constraints>
+                        <state key="normal" title="Get">
+                            <color key="titleColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
+                        </state>
+                        <state key="disabled">
+                            <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </state>
+                        <connections>
+                            <action selector="readTapped:" destination="B4P-wJ-v4L" eventType="touchUpInside" id="LkW-zs-nSk"/>
+                        </connections>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailingMargin" secondItem="gLq-q2-MiP" secondAttribute="trailing" id="13d-m5-X16"/>
+                    <constraint firstItem="jXV-9y-UJ0" firstAttribute="top" secondItem="bdk-RI-pgy" secondAttribute="bottom" constant="8" id="2Hr-MI-VcW"/>
+                    <constraint firstItem="gLq-q2-MiP" firstAttribute="firstBaseline" secondItem="Qhb-a9-yuj" secondAttribute="firstBaseline" id="8aC-MP-T8f"/>
+                    <constraint firstItem="Qhb-a9-yuj" firstAttribute="top" secondItem="TF5-B3-KqO" secondAttribute="topMargin" id="ALG-Sp-xdU"/>
+                    <constraint firstItem="bdk-RI-pgy" firstAttribute="leading" secondItem="TF5-B3-KqO" secondAttribute="leadingMargin" id="AVO-sC-ucT"/>
+                    <constraint firstAttribute="trailing" secondItem="bdk-RI-pgy" secondAttribute="trailing" id="AYp-DZ-a5u"/>
+                    <constraint firstItem="gLq-q2-MiP" firstAttribute="leading" secondItem="Qhb-a9-yuj" secondAttribute="trailing" constant="8" id="QpQ-KX-TtW"/>
+                    <constraint firstItem="Qhb-a9-yuj" firstAttribute="leading" secondItem="TF5-B3-KqO" secondAttribute="leadingMargin" id="Tc1-1C-SFz"/>
+                    <constraint firstItem="bdk-RI-pgy" firstAttribute="top" secondItem="Qhb-a9-yuj" secondAttribute="bottom" constant="12" id="XVk-fi-BnM"/>
+                    <constraint firstAttribute="trailing" secondItem="jXV-9y-UJ0" secondAttribute="trailing" id="okd-lJ-4Ap"/>
+                    <constraint firstAttribute="bottom" secondItem="jXV-9y-UJ0" secondAttribute="bottom" constant="8" id="uTJ-do-TSK"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="DOs-Y9-WvR"/>
+            <connections>
+                <outlet property="passkeyLabel" destination="gLq-q2-MiP" id="pCv-67-lew"/>
+                <outlet property="readButton" destination="jXV-9y-UJ0" id="WVQ-6n-qcj"/>
+            </connections>
+            <point key="canvasLocation" x="108.69565217391305" y="150.66964285714286"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="opaqueSeparatorColor">
+            <color red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Example/Source/Utils/Model+Name.swift
+++ b/Example/Source/Utils/Model+Name.swift
@@ -39,14 +39,18 @@ extension Model: @retroactive CustomDebugStringConvertible {
     public var modelName: String {
         if let companyIdentifier = companyIdentifier {
             switch (companyIdentifier, modelIdentifier) {
-            case (.nordicSemiconductorCompanyId, .simpleOnOffServerModelId): return "Simple OnOff Server"
-            case (.nordicSemiconductorCompanyId, .simpleOnOffClientModelId): return "Simple OnOff Client"
-            case (.nordicSemiconductorCompanyId, .rssiServer):               return "Rssi Server"
-            case (.nordicSemiconductorCompanyId, .rssiClient):               return "Rssi Client"
-            case (.nordicSemiconductorCompanyId, .rssiUtil):                 return "Rssi Util"
-            case (.nordicSemiconductorCompanyId, .thingy52Server):           return "Thingy52 Server"
-            case (.nordicSemiconductorCompanyId, .thingy52Client):           return "Thingy52 Client"
-            case (.nordicSemiconductorCompanyId, .chatClient):               return "Chat Client"
+            case (.nordicSemiconductorCompanyId, .simpleOnOffServerModelId):  return "Simple OnOff Server"
+            case (.nordicSemiconductorCompanyId, .simpleOnOffClientModelId):  return "Simple OnOff Client"
+            case (.nordicSemiconductorCompanyId, .rssiServer):                return "Rssi Server"
+            case (.nordicSemiconductorCompanyId, .rssiClient):                return "Rssi Client"
+            case (.nordicSemiconductorCompanyId, .rssiUtil):                  return "Rssi Util"
+            case (.nordicSemiconductorCompanyId, .thingy52Server):            return "Thingy52 Server"
+            case (.nordicSemiconductorCompanyId, .thingy52Client):            return "Thingy52 Client"
+            case (.nordicSemiconductorCompanyId, .chatClient):                return "Chat Client"
+            case (.nordicSemiconductorCompanyId, .distanceMeasurementServer): return "Distance Measurement Server"
+            case (.nordicSemiconductorCompanyId, .distanceMeasurementClient): return "Distance Measurement Client"
+            case (.nordicSemiconductorCompanyId, .lePairingInitiator):        return "LE Pairing Initiator"
+            case (.nordicSemiconductorCompanyId, .lePairingResponder):        return "LE Pairing Responder"
             default:
                 return "Vendor Model ID: \(modelIdentifier.asString())"
             }

--- a/Example/Source/Utils/ModelIdentifiers.swift
+++ b/Example/Source/Utils/ModelIdentifiers.swift
@@ -33,7 +33,14 @@ import NordicMesh
 
 extension UInt16 {
     
-    // Supported vendor models
+    /// Nordic Semiconductor Company ID.
+    ///
+    /// The value is registered with Bluetooth SIG.
+    static let nordicSemiconductorCompanyId: UInt16 = 0x0059
+    
+    // Supported vendor models for Nordic Semiconductor Company ID.
+    // See https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/protocols/bt/bt_mesh/overview/reserved_ids.html
+    // for complete list of them.
     static let simpleOnOffServerModelId: UInt16 = 0x0000
     static let simpleOnOffClientModelId: UInt16 = 0x0001
     static let rssiServer: UInt16 = 0x0005
@@ -42,7 +49,17 @@ extension UInt16 {
     static let thingy52Server: UInt16 = 0x0008
     static let thingy52Client: UInt16 = 0x0009
     static let chatClient: UInt16 = 0x000A
-    
-    static let nordicSemiconductorCompanyId: UInt16 = 0x0059
+    static let distanceMeasurementServer: UInt16 = 0x000B
+    static let distanceMeasurementClient: UInt16 = 0x000C
+    /// The LE Pairing Initiator model is a vendor model that can be used to obtain
+    /// a passkey that will authenticate a Bluetooth LE connection over a mesh network
+    /// when it is not possible to use other pairing methods.
+    static let lePairingInitiator: UInt16 = 0x000D
+    /// The LE Pairing Responder model is a vendor model that can be used to hand over
+    /// a passkey that will authenticate a Bluetooth LE connection over a mesh network
+    /// when it is not possible to use other pairing methods.
+    ///
+    /// Read mode in the [Documentation](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/bluetooth/mesh/vnd/le_pair_resp.html#bt-mesh-le-pair-resp-readme).
+    static let lePairingResponder: UInt16 = 0x000E
     
 }

--- a/Example/Source/View Controllers/Network/Configuration/Model/PairingResponderViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/PairingResponderViewCell.swift
@@ -1,0 +1,96 @@
+/*
+* Copyright (c) 2019, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import UIKit
+import NordicMesh
+
+class PairingResponderViewCell: ModelViewCell {
+    
+    // MARK: - Outlets and Actions
+    @IBOutlet weak var passkeyLabel: UILabel!
+    
+    @IBOutlet weak var readButton: UIButton!
+    @IBAction func readTapped(_ sender: UIButton) {
+        readPasskey()
+    }
+        
+    // MARK: - Implementation
+    
+    override func reload(using model: Model) {
+        let localProvisioner = MeshNetworkManager.instance.meshNetwork?.localProvisioner
+        let isEnabled = localProvisioner?.hasConfigurationCapabilities ?? false
+        
+        readButton.isEnabled = isEnabled
+    }
+    
+    override func startRefreshing() -> Bool {
+        if !model.boundApplicationKeys.isEmpty {
+            readPasskey()
+            return true
+        }
+        return false
+    }
+    
+    override func supports(_ messageType: MeshMessage.Type) -> Bool {
+        return messageType == PairingResponse.self
+    }
+    
+    override func meshNetworkManager(_ manager: MeshNetworkManager,
+                                     didReceiveMessage message: MeshMessage,
+                                     sentFrom source: Address, to destination: MeshAddress) -> Bool {
+        switch message {
+        case let status as PairingResponse:
+            if status.status == 0x00 {
+                // Passkey is 6 digits long.
+                passkeyLabel.text = String(format: "%06d", status.passkey)
+            } else {
+                passkeyLabel.text = "Error: \(status.status)"
+            }
+            return false
+            
+        default:
+            fatalError()
+        }
+    }
+}
+
+private extension PairingResponderViewCell {
+        
+    func readPasskey() {
+        guard !model.boundApplicationKeys.isEmpty else {
+            parentViewController?.presentAlert(
+                title: "Bound key required",
+                message: "Bind at least one Application Key before sending the message.")
+            return
+        }
+        
+        delegate?.send(PairingRequest(), description: "Reading passkey...")
+    }
+}

--- a/Example/Source/View Controllers/Network/Configuration/Model/VendorModelViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/VendorModelViewCell.swift
@@ -107,8 +107,7 @@ class VendorModelViewCell: ModelViewCell, UITextFieldDelegate {
                 return
             }
         }
-        guard let opCode = UInt8(opCodeField.text!, radix: 16), opCode <= 0x3F,
-              !Data(hex: parametersField.text!).isEmpty else {
+        guard let opCode = UInt8(opCodeField.text!, radix: 16), opCode <= 0x3F else {
             sendButton.isEnabled = false
             return
         }

--- a/Example/nRF Mesh.xcodeproj/project.pbxproj
+++ b/Example/nRF Mesh.xcodeproj/project.pbxproj
@@ -175,6 +175,11 @@
 		F03414872B91373E009DD792 /* LightLCLightOnOffGroupCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F03414862B91373E009DD792 /* LightLCLightOnOffGroupCell.swift */; };
 		F0464DAD2D5F79D200AE3684 /* UITableViewCell+Disabled.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0464DAB2D5F79D200AE3684 /* UITableViewCell+Disabled.swift */; };
 		F0464DAE2D5F79D200AE3684 /* UIViewController+Identify.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0464DAC2D5F79D200AE3684 /* UIViewController+Identify.swift */; };
+		F0587F6F2D96C5AA0091CDF4 /* PairingResponder.xib in Resources */ = {isa = PBXBuildFile; fileRef = F0587F6E2D96C5AA0091CDF4 /* PairingResponder.xib */; };
+		F0587F712D96C63A0091CDF4 /* PairingResponderViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0587F702D96C63A0091CDF4 /* PairingResponderViewCell.swift */; };
+		F0587F732D96EC6B0091CDF4 /* PairingInitiatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0587F722D96EC6B0091CDF4 /* PairingInitiatorDelegate.swift */; };
+		F0587F772D96ECB90091CDF4 /* PairingRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0587F762D96ECB90091CDF4 /* PairingRequest.swift */; };
+		F0587F792D96EE0F0091CDF4 /* PairingResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0587F782D96EE0F0091CDF4 /* PairingResponse.swift */; };
 		F063C01A29C2774300A445A9 /* SelectKeysViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F063C01929C2774300A445A9 /* SelectKeysViewController.swift */; };
 		F063C01D29C27EAB00A445A9 /* IntroViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F063C01C29C27EAB00A445A9 /* IntroViewController.swift */; };
 		F085C9FB29C496AB00C2DF89 /* SelectModelsForBindingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F085C9FA29C496AB00C2DF89 /* SelectModelsForBindingViewController.swift */; };
@@ -388,6 +393,11 @@
 		F03414862B91373E009DD792 /* LightLCLightOnOffGroupCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightLCLightOnOffGroupCell.swift; sourceTree = "<group>"; };
 		F0464DAB2D5F79D200AE3684 /* UITableViewCell+Disabled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Disabled.swift"; sourceTree = "<group>"; };
 		F0464DAC2D5F79D200AE3684 /* UIViewController+Identify.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Identify.swift"; sourceTree = "<group>"; };
+		F0587F6E2D96C5AA0091CDF4 /* PairingResponder.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PairingResponder.xib; sourceTree = "<group>"; };
+		F0587F702D96C63A0091CDF4 /* PairingResponderViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingResponderViewCell.swift; sourceTree = "<group>"; };
+		F0587F722D96EC6B0091CDF4 /* PairingInitiatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingInitiatorDelegate.swift; sourceTree = "<group>"; };
+		F0587F762D96ECB90091CDF4 /* PairingRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingRequest.swift; sourceTree = "<group>"; };
+		F0587F782D96EE0F0091CDF4 /* PairingResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingResponse.swift; sourceTree = "<group>"; };
 		F063C01929C2774300A445A9 /* SelectKeysViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectKeysViewController.swift; sourceTree = "<group>"; };
 		F063C01C29C27EAB00A445A9 /* IntroViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroViewController.swift; sourceTree = "<group>"; };
 		F085C9FA29C496AB00C2DF89 /* SelectModelsForBindingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectModelsForBindingViewController.swift; sourceTree = "<group>"; };
@@ -520,6 +530,7 @@
 				A7B526A6277B210000F5C60D /* GenericPowerOnOffSetup.xib */,
 				52A9C1C42313D7D80036792A /* GenericLevel.xib */,
 				5217D2E4250F90D8004FDE79 /* GenericDefaultTransitionTime.xib */,
+				F0587F6E2D96C5AA0091CDF4 /* PairingResponder.xib */,
 				5231404C230AC4680074325A /* VendorModel.xib */,
 			);
 			path = Model;
@@ -532,6 +543,7 @@
 				5231403E2301761C0074325A /* ConfigurationServerViewCell.swift */,
 				52A9C17B230EB9490036792A /* GenericOnOffViewCell.swift */,
 				A7A59BD6277225E70045A8ED /* GenericPowerOnOffViewCell.swift */,
+				F0587F702D96C63A0091CDF4 /* PairingResponderViewCell.swift */,
 				A7B526A5277B210000F5C60D /* GenericPowerOnOffSetupViewCell.swift */,
 				52A9C1C32313D7D80036792A /* GenericLevelViewCell.swift */,
 				5217D2E3250F90D8004FDE79 /* GenericDefaultTransitionTimeViewCell.swift */,
@@ -767,6 +779,7 @@
 		52DF5D8D22968F7C00C297C1 /* Mesh Network */ = {
 			isa = PBXGroup;
 			children = (
+				F0587F742D96EC8E0091CDF4 /* LE Pairing */,
 				5288C20B2371A8E000321ED3 /* Simple OnOff */,
 				52DF5D8E229691BD00C297C1 /* NetworkConnection.swift */,
 				5211EAD4250777E100089FF2 /* SceneServerDelegate.swift */,
@@ -909,6 +922,24 @@
 				F57EEAABA13E16EBDF1CADFD /* Pods_nRF_Mesh_Tests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F0587F742D96EC8E0091CDF4 /* LE Pairing */ = {
+			isa = PBXGroup;
+			children = (
+				F0587F752D96ECA40091CDF4 /* Messages */,
+				F0587F722D96EC6B0091CDF4 /* PairingInitiatorDelegate.swift */,
+			);
+			path = "LE Pairing";
+			sourceTree = "<group>";
+		};
+		F0587F752D96ECA40091CDF4 /* Messages */ = {
+			isa = PBXGroup;
+			children = (
+				F0587F762D96ECB90091CDF4 /* PairingRequest.swift */,
+				F0587F782D96EE0F0091CDF4 /* PairingResponse.swift */,
+			);
+			path = Messages;
 			sourceTree = "<group>";
 		};
 		F063C01B29C27E8500A445A9 /* Automation */ = {
@@ -1070,6 +1101,7 @@
 				52CD0A5E2330C04700A9A181 /* Network.storyboard in Resources */,
 				A7A59BD5277225A70045A8ED /* GenericPowerOnOff.xib in Resources */,
 				52E54CDB2343878B00478F05 /* Control.storyboard in Resources */,
+				F0587F6F2D96C5AA0091CDF4 /* PairingResponder.xib in Resources */,
 				3089BCA02099CA4900E30192 /* LaunchScreen.storyboard in Resources */,
 				52CD0A5B2330BF4800A9A181 /* Proxy.storyboard in Resources */,
 				607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */,
@@ -1238,6 +1270,7 @@
 				5231401622F460380074325A /* PublicationCell.swift in Sources */,
 				52E54CE32344978300478F05 /* GenericLevelServerDelegate.swift in Sources */,
 				5215600929FBFD230048B2D2 /* WizardViewController.swift in Sources */,
+				F0587F712D96C63A0091CDF4 /* PairingResponderViewCell.swift in Sources */,
 				528AB9F8228D847C000BE9DC /* NetworkViewController.swift in Sources */,
 				523F778722CCDE250030EA6A /* SetPublicationViewController.swift in Sources */,
 				52CD0A622330DCFF00A9A181 /* CustomAddressCell.swift in Sources */,
@@ -1268,6 +1301,7 @@
 				523F776822C615CE0030EA6A /* NodeAppKeysViewController.swift in Sources */,
 				523F777922CB57190030EA6A /* ModelViewController.swift in Sources */,
 				522AFFE022C2376C00521EDC /* ElementViewController.swift in Sources */,
+				F0587F732D96EC6B0091CDF4 /* PairingInitiatorDelegate.swift in Sources */,
 				5288C20E2371A91900321ED3 /* SimpleOnOffSet.swift in Sources */,
 				523F779722CE2BF60030EA6A /* SetPublicationDestinationsViewController.swift in Sources */,
 				52E54CD023437D3D00478F05 /* ModelControlCell.swift in Sources */,
@@ -1320,6 +1354,7 @@
 				52518B3322E0B43200A1FD1E /* GroupCell.swift in Sources */,
 				529B7570223FF1AE008F1CE7 /* SettingsViewController.swift in Sources */,
 				5292F8A1250137DC00EA0F2A /* NodeScenesViewController.swift in Sources */,
+				F0587F772D96ECB90091CDF4 /* PairingRequest.swift in Sources */,
 				526021F62343660200E88F06 /* ControlViewController.swift in Sources */,
 				5245737B2500E10800CF8500 /* ScenesViewController.swift in Sources */,
 				F085C9FB29C496AB00C2DF89 /* SelectModelsForBindingViewController.swift in Sources */,
@@ -1338,6 +1373,7 @@
 				5288C2062370571100321ED3 /* ProxySelectorViewController.swift in Sources */,
 				F0464DAD2D5F79D200AE3684 /* UITableViewCell+Disabled.swift in Sources */,
 				F0464DAE2D5F79D200AE3684 /* UIViewController+Identify.swift in Sources */,
+				F0587F792D96EE0F0091CDF4 /* PairingResponse.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
This PR adds support for [LE Pairing Responder](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/libraries/bluetooth/mesh/vnd/le_pair_resp.html) model:
* LE Pairing Initiator model added to the app
   * _Pairing Request_ and _Pairing Response_ messages (they have the same Op Code!)
* Custom UI to read Passkey in nRF Mesh
*  Hidden Subscriptions and Publications for LE Pairing models, as not supported

### Usage

It is possible to restrict access to the GATT SMP Service for mesh devices using _LE Pairing Responder_ model:
https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/samples/bluetooth/mesh/dfu/distributor/README.html#smp_over_bluetooth_authentication

With that feature enabled, connected client must read a passkey by sending a _Pairing Request_ message to get a _Pairing Response_ message with a **Passkey**.
When SMP Server charactertistic is accessed, the device will then initiate LE pairing procedure with MITM protection. User needs to provide the **Passkey** in pairing process. This cannot be done automatically, as pairing on the mobile phones is handled by the OS. Hence, the app needs to display the key for the user to type on the native pairing dialog.
This ensures, that only devices which know the bound App Key can control devices over SMP Server.

> [!Warning]
> Having a SMP Service unprotected is not recommended, as it gives a very easy way to erase the device to factory defaults (wipe app storage) or access shell commands over BLE.

### Screenshot

![Screenshot 2025-03-28 at 22 01 49](https://github.com/user-attachments/assets/a5f54d46-15c1-4f35-81ed-a937baa03f51)
