### PR TITLE
Bugfix: Properly notifying the manager of closed bearer

### DIFF
--- a/Example/Source/View Controllers/Proxy/ProxyViewController.swift
+++ b/Example/Source/View Controllers/Proxy/ProxyViewController.swift
@@ -184,11 +184,6 @@ extension ProxyViewController: BearerDelegate {
         addButton.isEnabled = false
         // Make sure the ProxyFilter is not busy.
         MeshNetworkManager.instance.proxyFilter.proxyDidDisconnect()
-        // The bearer has closed. Attempt to send a message
-        // will fail, but the Proxy Filter will receive .bearerClosed
-        // error, upon which it will clear the filter list and notify
-        // the delegate.
-        MeshNetworkManager.instance.proxyFilter.clear()
     }
     
 }

--- a/Library/Layers/Network Layer/NetworkLayer.swift
+++ b/Library/Layers/Network Layer/NetworkLayer.swift
@@ -64,7 +64,7 @@ internal class NetworkLayer {
     ///              stored Network Key may be invalid. Therefore, it may be, that the
     ///              key with this index is no longer stored on the connected Node
     ///              and the Proxy Configuration messages will not work.
-    private var proxyNetworkKey: NetworkKey?
+    internal var proxyNetworkKey: NetworkKey?
     
     init(_ networkManager: NetworkManager) {
         self.networkManager = networkManager

--- a/Library/ProxyFilter.swift
+++ b/Library/ProxyFilter.swift
@@ -366,6 +366,11 @@ public extension ProxyFilter {
     func proxyDidDisconnect() {
         newNetworkCreated()
         
+        // Clear the Proxy Network Key. This way we make sure the
+        // Network Layer will handle the new incoming Secure Network beacon
+        // propertly, even if it belongs to a non-primary network.
+        manager?.networkManager?.networkLayer.proxyNetworkKey = nil
+        
         // Notify the delegate.
         delegateQueue.async { [delegate] in
             delegate?.proxyFilterUpdated(type: .acceptList, addresses: [])


### PR DESCRIPTION
When a used intentionally disconnects a GATT Proxy node it notifies the library using `proxyFilter.proxyDidDisconnect()`.
However, this method wasn't clearing the `proxyNetworkKey` in the `NetworkLayer`. When a new proxy was connected, the proxy change might not have been discovered causing no Proxy Filter setup.

To work around that, the app was trying to send a dummy message, which was failing on `bearerClosed` error.
Unfortunately, if the new bearer was connected prior to disconnectinf the previous one, this trick didn't work.

This change explicitly clears the `proxyNetworkKey` in the `NetworkLayer`.