### PR TITLE
Bug fix: remove App Keys of removed Net Keys

### DIFF
--- a/Library/Mesh Model/Node.swift
+++ b/Library/Mesh Model/Node.swift
@@ -756,6 +756,14 @@ internal extension Node {
         netKeys = networkKeyIndexes
             .map { Node.NodeKey(index: $0, updated: false) }
             .sorted()
+        // Remove any Application Keys bound to Network Keys which are not in the list.
+        appKeys = appKeys.filter {
+            if let applicationKey = applicationKeys[$0.index] {
+                return networkKeyIndexes.contains(applicationKey.boundNetworkKeyIndex)
+            }
+            // If the Application Key is not known, leave it.
+            return true
+        }
         // If an insecure Node received a Network Key, make sure to lower
         // the minSecurity field of all the keys it .
         if security == .insecure {


### PR DESCRIPTION
Step to reproduce:
1. Have 2 phones connected to a network (share CDB using JSON)
2. Add a Network Key and a bound App Key to a Node using phone A
3. Refresh Net Keys and App Keys on phone B
4. Remove Net Key from that Node using phone A
5. Refresh Net Keys on phone B

### Before
Phone B did not remove the App Key bound to this Net Key.

### After
Phone B removes all App Keys  bound to Net Keys which were not reported using Config Net Key List.