### PR TITLE
Feature: Option to show and modify IV Index

### DIFF
--- a/Example/Source/UI/Base.lproj/Settings.storyboard
+++ b/Example/Source/UI/Base.lproj/Settings.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xI8-8S-2a8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xI8-8S-2a8">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,7 +14,7 @@
             <objects>
                 <tableViewController id="gHg-68-SP7" customClass="SettingsViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="snl-A1-Ofa">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="804"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="756"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
                         <sections>
@@ -156,8 +156,32 @@
                                             <segue destination="Uyp-yQ-ieM" kind="show" identifier="scenes" id="iif-3e-KHR"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="detailButton" indentationWidth="10" id="a2Z-S6-Q2g">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="OYo-cV-6XW" detailTextLabel="oDG-Hq-gw5" style="IBUITableViewCellStyleValue1" id="xsi-md-3oO">
                                         <rect key="frame" x="0.0" y="291.5" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xsi-md-3oO" id="w06-tn-t2k">
+                                            <rect key="frame" x="0.0" y="0.0" width="383.5" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="IV Index" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="OYo-cV-6XW">
+                                                    <rect key="frame" x="20" y="12" width="61" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="oDG-Hq-gw5">
+                                                    <rect key="frame" x="331.5" y="12" width="44" height="20.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="detailButton" indentationWidth="10" id="a2Z-S6-Q2g">
+                                        <rect key="frame" x="0.0" y="335" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="a2Z-S6-Q2g" id="6S6-XT-IdC">
                                             <rect key="frame" x="0.0" y="0.0" width="370" height="43.5"/>
@@ -190,7 +214,7 @@
                             <tableViewSection id="FvS-k6-TaC" userLabel="Last modified">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="OlU-MF-6J1" detailTextLabel="SBO-dD-tsb" style="IBUITableViewCellStyleValue1" id="yyK-b9-xEp">
-                                        <rect key="frame" x="0.0" y="371" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="414.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yyK-b9-xEp" id="Ore-cg-4T2">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -218,7 +242,7 @@
                             <tableViewSection id="7bQ-xV-k6b" userLabel="Reset">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="kTS-5C-p3m">
-                                        <rect key="frame" x="0.0" y="450.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="494" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kTS-5C-p3m" id="iHV-Te-vz4">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -251,7 +275,7 @@
                             <tableViewSection headerTitle="About" id="gwN-Jl-hSP">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="J1o-5V-HnD" detailTextLabel="Qhb-tk-JeS" style="IBUITableViewCellStyleValue1" id="1MM-rJ-FPE">
-                                        <rect key="frame" x="0.0" y="550" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="593.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1MM-rJ-FPE" id="uR8-7U-URZ">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -275,7 +299,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="BG3-t8-mCG" detailTextLabel="fDc-fX-1P3" style="IBUITableViewCellStyleValue1" id="IPP-lc-s2K">
-                                        <rect key="frame" x="0.0" y="593.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="637" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="IPP-lc-s2K" id="sYz-kX-Yki">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -299,7 +323,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="bmb-GE-0fo" detailTextLabel="gMC-tN-6V1" style="IBUITableViewCellStyleValue1" id="zFK-z4-8In">
-                                        <rect key="frame" x="0.0" y="637" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="680.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zFK-z4-8In" id="nlX-72-Yxw">
                                             <rect key="frame" x="0.0" y="0.0" width="383.5" height="43.5"/>
@@ -323,7 +347,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Q2i-fZ-V0F" detailTextLabel="Doj-5y-HHP" style="IBUITableViewCellStyleValue1" id="pvP-x7-HAu">
-                                        <rect key="frame" x="0.0" y="680.5" width="414" height="43.5"/>
+                                        <rect key="frame" x="0.0" y="724" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pvP-x7-HAu" id="CqP-g9-7ug">
                                             <rect key="frame" x="0.0" y="0.0" width="383.5" height="43.5"/>
@@ -365,6 +389,7 @@
                         <outlet property="appBuildNumberLabel" destination="fDc-fX-1P3" id="uoI-cF-l2D"/>
                         <outlet property="appKeysLabel" destination="tgb-2X-xJN" id="YOK-xc-ONR"/>
                         <outlet property="appVersionLabel" destination="Qhb-tk-JeS" id="LbT-9w-B5J"/>
+                        <outlet property="ivIndexLabel" destination="oDG-Hq-gw5" id="PQZ-Eh-4xQ"/>
                         <outlet property="lastModifiedLabel" destination="SBO-dD-tsb" id="WXb-6u-lFO"/>
                         <outlet property="networkKeysLabel" destination="EmX-2O-NSn" id="pMO-8P-aaU"/>
                         <outlet property="networkNameLabel" destination="2pZ-ON-hY3" id="dHa-pS-pA8"/>
@@ -387,7 +412,7 @@
                 <navigationController id="vXp-W8-Fgq" sceneMemberID="viewController">
                     <navigationItem key="navigationItem" id="4pS-2L-dsn"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" largeTitles="YES" id="UU2-oM-bYo">
-                        <rect key="frame" x="0.0" y="48" width="414" height="96"/>
+                        <rect key="frame" x="0.0" y="96" width="414" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <textAttributes key="titleTextAttributes">
                             <color key="textColor" red="0.0" green="0.66274509800000003" blue="0.80784313730000001" alpha="1" colorSpace="calibratedRGB"/>
@@ -413,7 +438,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jLa-Ti-Jt9">
-                                <rect key="frame" x="0.0" y="144" width="414" height="752"/>
+                                <rect key="frame" x="0.0" y="192" width="414" height="704"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l2e-ZF-DXN" userLabel="Content View">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="617"/>
@@ -653,7 +678,7 @@
             <objects>
                 <tableViewController id="K8u-UB-rgv" customClass="ExportViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="qqN-Gd-MOa">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="886"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
@@ -692,18 +717,18 @@
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="switch" id="5oi-GJ-525" customClass="SwitchCell" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="125" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="125" width="414" height="43"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="5oi-GJ-525" id="bcE-xW-TPS">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4PU-Hv-Lxf">
-                                            <rect key="frame" x="345" y="6.5" width="51" height="31"/>
+                                            <rect key="frame" x="345" y="6" width="51" height="31"/>
                                             <color key="onTintColor" red="0.0" green="0.46666666670000001" blue="0.7843137255" alpha="1" colorSpace="calibratedRGB"/>
                                         </switch>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YDJ-38-lWR">
-                                            <rect key="frame" x="20" y="11" width="33" height="21.5"/>
+                                            <rect key="frame" x="20" y="11" width="33" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -755,7 +780,7 @@
             <objects>
                 <tableViewController title="App Keys" id="bs4-xQ-JR5" customClass="AppKeysViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="WWv-zz-LTi">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="752"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
@@ -817,7 +842,7 @@
             <objects>
                 <tableViewController id="Uyp-yQ-ieM" customClass="ScenesViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="HKO-U1-6so">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="752"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
@@ -868,7 +893,7 @@
             <objects>
                 <tableViewController id="6pB-yE-iXh" customClass="EditSceneViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="vd7-OH-9gd">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="886"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <sections>
@@ -964,7 +989,7 @@
                     <toolbarItems/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" largeTitles="YES" id="87M-ir-23X">
-                        <rect key="frame" x="0.0" y="48" width="414" height="96"/>
+                        <rect key="frame" x="0.0" y="96" width="414" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <color key="barTintColor" red="0.0" green="0.66274509800000003" blue="0.80784313730000001" alpha="1" colorSpace="calibratedRGB"/>
@@ -989,7 +1014,7 @@
             <objects>
                 <tableViewController title="Network Keys" id="6zD-fu-xO1" customClass="NetworkKeysViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="0TR-Pr-99f">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="752"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
@@ -1040,7 +1065,7 @@
             <objects>
                 <tableViewController id="bRw-vT-o6e" customClass="EditKeyViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="id9-ef-2Ob">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="886"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
@@ -1164,7 +1189,7 @@
             <objects>
                 <tableViewController title="Provisioners" id="uVY-wa-E27" customClass="ProvisionersViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="gf1-Ko-g6i">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="752"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="704"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
@@ -1222,7 +1247,7 @@
             <objects>
                 <tableViewController title="Edit Provisioner" id="EYc-nY-Nbe" customClass="EditProvisionerViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="gTf-B9-SHT">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="886"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <sections>
@@ -1602,11 +1627,11 @@
             <objects>
                 <viewController title="Edit Ranges" id="3Kg-8S-AEi" customClass="EditRangesViewController" customModule="nRF_Mesh" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="L5K-Kr-PdN">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="886"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="838"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="tOh-ew-Yim">
-                                <rect key="frame" x="0.0" y="108" width="414" height="628"/>
+                                <rect key="frame" x="0.0" y="108" width="414" height="580"/>
                                 <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="rangeCell" id="95A-UO-M24" customClass="RangeCell" customModule="nRF_Mesh" customModuleProvider="target">
@@ -1652,7 +1677,7 @@
                                 </prototypes>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uRg-oT-DXw">
-                                <rect key="frame" x="0.0" y="736" width="414" height="150"/>
+                                <rect key="frame" x="0.0" y="688" width="414" height="150"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b4v-3n-4el" userLabel="Separator">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="0.5"/>
@@ -1829,11 +1854,11 @@
                                 </variation>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vfg-0i-ekZ">
-                                <rect key="frame" x="0.0" y="886" width="414" height="0.0"/>
+                                <rect key="frame" x="0.0" y="838" width="414" height="0.0"/>
                                 <color key="backgroundColor" systemColor="tableCellGroupedBackgroundColor"/>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rL9-4q-WDo" customClass="FabView" customModule="nRF_Mesh" customModuleProvider="target">
-                                <rect key="frame" x="147.5" y="698" width="119" height="30"/>
+                                <rect key="frame" x="147.5" y="650" width="119" height="30"/>
                                 <state key="normal" title="Resolve Conflicts"/>
                                 <connections>
                                     <action selector="resolveConflitsTapped:" destination="3Kg-8S-AEi" eventType="touchUpInside" id="efR-rL-RiR"/>

--- a/Example/Source/Utils/UIViewController+Alert.swift
+++ b/Example/Source/Utils/UIViewController+Alert.swift
@@ -49,6 +49,7 @@ extension Selector {
     static let key32Required = #selector(UIViewController.key32Required(_:))
     static let publicKeyRequired = #selector(UIViewController.publicKeyRequired(_:))
     static let ttlRequired = #selector(UIViewController.ttlRequired(_:))
+    static let ivIndexRequired = #selector(UIViewController.ivIndexRequired(_:))
     
 }
 
@@ -211,7 +212,7 @@ extension UIViewController {
                          .unicastAddressRequired, .groupAddressRequired,
                          .scene, .sceneRequired, .hexRequired:
                         textField.autocapitalizationType = .allCharacters
-                    case .ttlRequired:
+                    case .ttlRequired, .ivIndexRequired:
                         textField.keyboardType = .numberPad
                     default:
                         break
@@ -279,6 +280,12 @@ extension UIViewController {
         let alert = getAlert(from: textField)
         let ttl = UInt8(textField.text!)
         alert.setValid(ttl != nil && (ttl! == 0 || ttl! >= 2) && ttl! <= 127)
+    }
+    
+    @objc func ivIndexRequired(_ textField: UITextField) {
+        let alert = getAlert(from: textField)
+        let ivIndex = UInt32(textField.text!)
+        alert.setValid(ivIndex != nil)
     }
     
     @objc func numberRequired(_ textField: UITextField) {

--- a/Example/Source/View Controllers/Settings/SettingsViewController.swift
+++ b/Example/Source/View Controllers/Settings/SettingsViewController.swift
@@ -141,8 +141,8 @@ class SettingsViewController: UITableViewController {
         if indexPath.isIvUpdateTestMode {
             presentAlert(title: "Info",
                          message: "IV Update test mode allows to transition to the subsequent "
-                                + "IV Index without having to wait at least 96 hours. The "
-                                + "transition will be done upon receiving a valid Secure Network beacon.")
+                                + "IV Index without having to wait at least 96 hours.\n\n"
+                                + "The transition is initiated when a valid Secure Network beacon is received.")
         }
     }
     

--- a/Example/Source/View Controllers/Settings/SettingsViewController.swift
+++ b/Example/Source/View Controllers/Settings/SettingsViewController.swift
@@ -148,6 +148,14 @@ class SettingsViewController: UITableViewController {
     
 }
 
+extension SettingsViewController: IvIndexObserver {
+    
+    func ivIndexDidChange(to ivIndex: IvIndex) {
+        ivIndexLabel.text = "\(ivIndex.index)\(ivIndex.updateActive ? " (update active)" : "")"
+    }
+    
+}
+
 extension SettingsViewController: WizardDelegate {
     
     /// Opens the Document Picker to select the Mesh Network configuration to import.
@@ -234,8 +242,10 @@ private extension SettingsViewController {
         let alert = UIAlertController(title: "IV Index", message: "Provide the initial value of IV Index.", preferredStyle: .alert)
         alert.addTextField { textField in
             textField.text = "\(network.ivIndex.index)"
-            textField.placeholder = "0 - 4294967295"
-            textField.keyboardType = .numberPad
+            textField.placeholder     = "0 - 4294967295"
+            textField.clearButtonMode = .whileEditing
+            textField.returnKeyType   = .done
+            textField.keyboardType    = .numberPad
             textField.addTarget(self, action: .ivIndexRequired, for: .editingChanged)
             textField.addTarget(self, action: .ivIndexRequired, for: .editingDidBegin)
         }
@@ -267,7 +277,6 @@ private extension SettingsViewController {
             }
             let updateActive = switchView.isOn
             try? network.setIvIndex(index, updateActive: updateActive)
-            self.ivIndexLabel.text = "\(index)\(updateActive ? " (update active)" : "")"
         })
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
         
@@ -322,13 +331,15 @@ private extension SettingsViewController {
         guard let meshNetwork = MeshNetworkManager.instance.meshNetwork else {
             return
         }
+        // Assign the view controller as the IV Index observer.
+        meshNetwork.ivIndexObserver = self
+        ivIndexDidChange(to: meshNetwork.ivIndex)
+        
         networkNameLabel.text  = meshNetwork.meshName
         provisionersLabel.text = "\(meshNetwork.provisioners.count)"
         networkKeysLabel.text  = "\(meshNetwork.networkKeys.count)"
         appKeysLabel.text      = "\(meshNetwork.applicationKeys.count)"
         scenesLabel.text       = "\(meshNetwork.scenes.count)"
-        let ivIndex = meshNetwork.ivIndex
-        ivIndexLabel.text      = "\(ivIndex.index)\(ivIndex.updateActive ? " (update active)" : "")"
         lastModifiedLabel.text = dateFormatter.string(from: meshNetwork.timestamp)
         tableView.reloadData()
     }

--- a/Library/Mesh Messages/FirmwareUpdateMessage.swift
+++ b/Library/Mesh Messages/FirmwareUpdateMessage.swift
@@ -314,8 +314,8 @@ public enum FirmwareDistributionPhase: UInt8, Sendable {
     
     /// A flag indicating whether the firmware distribution is not in progress.
     ///
-    /// When the Distributor is in ``.completed`` or ``.failed`` state, the Distributor
-    /// needs to be reset to ``.idle`` state using ``FirmwareDistributionCancel``
+    /// When the Distributor is in ``completed`` or ``failed`` state, the Distributor
+    /// needs to be reset to ``idle`` state using ``FirmwareDistributionCancel``
     /// message before starting a new firmware distribution.
     public var isBusy: Bool {
         return self != .idle && self != .failed && self != .completed && self != .applyingUpdate

--- a/Library/Mesh Model/IvIndex.swift
+++ b/Library/Mesh Model/IvIndex.swift
@@ -44,22 +44,9 @@ import Foundation
 /// beacon and in the Friend Update message shall be set to 1. When this state is
 /// active, a node shall transmit using the current IV Index - 1 and shall process
 /// messages from the current IV Index - 1 and also the current IV Index.
-internal struct IvIndex {
-    var index: UInt32 = 0
-    var updateActive: Bool = false
-    
-    /// The IV Index used for transmitting messages.
-    var transmitIndex: UInt32 {
-        return updateActive && index > 0 ? index - 1 : index
-    }
-    
-    /// The IV Index that is to be used for decrypting messages.
-    ///
-    /// - parameter ivi: The IVI bit of the received Network PDU.
-    /// - returns: The IV Index to be used to decrypt the message.
-    func index(for ivi: UInt8) -> UInt32 {
-        return ivi == index & 1 ? index : max(1, index) - 1
-    }
+public struct IvIndex {
+    public var index: UInt32 = 0
+    public var updateActive: Bool = false
 }
 
 internal extension IvIndex {
@@ -89,14 +76,31 @@ internal extension IvIndex {
 
 extension IvIndex: Comparable {
     
-    static func < (lhs: IvIndex, rhs: IvIndex) -> Bool {
+    public static func < (lhs: IvIndex, rhs: IvIndex) -> Bool {
         return lhs.index < rhs.index ||
               (lhs.index == rhs.index && lhs.updateActive && !rhs.updateActive)
+    }
+    
+    public static func == (lhs: IvIndex, rhs: IvIndex) -> Bool {
+        return lhs.index == rhs.index && lhs.updateActive == rhs.updateActive
     }
     
 }
 
 internal extension IvIndex {
+    
+    /// The IV Index used for transmitting messages.
+    var transmitIndex: UInt32 {
+        return updateActive && index > 0 ? index - 1 : index
+    }
+    
+    /// The IV Index that is to be used for decrypting messages.
+    ///
+    /// - parameter ivi: The IVI bit of the received Network PDU.
+    /// - returns: The IV Index to be used to decrypt the message.
+    func index(for ivi: UInt8) -> UInt32 {
+        return ivi == index & 1 ? index : max(1, index) - 1
+    }
     
     /// The following IV Index, or `nil` if maximum value has been reached.
     var next: IvIndex? {
@@ -120,7 +124,7 @@ internal extension IvIndex {
 
 extension IvIndex: CustomDebugStringConvertible {
     
-    var debugDescription: String {
+    public var debugDescription: String {
         return "IV Index: \(index) (\(updateActive ? "update active" : "normal operation"))"
     }
     

--- a/Library/Mesh Model/MeshNetwork.swift
+++ b/Library/Mesh Model/MeshNetwork.swift
@@ -72,7 +72,15 @@ public class MeshNetwork: Codable {
     internal var networkExclusions: [ExclusionList]?
     
     /// The IV Index of the mesh network.
-    internal var ivIndex: IvIndex {
+    ///
+    /// - warning: This property is an internal value of the mesh network and is exposed only for advanced users.
+    ///
+    /// The  value is set automatically to 0 when a new mesh network is created.
+    ///
+    /// - note: The IV Index is automatically set to the value obtained from the Secure Network beacon
+    ///         or Private beacon when connected to a GATT Proxy Node. It should not be modified by the user,
+    ///         unless necessary. In that case use ``setIvIndex(_:updateActive:)`` method.
+    public internal(set) var ivIndex: IvIndex {
         didSet {
             // Clean up the network exclusions.
             networkExclusions?.cleanUp(forIvIndex: ivIndex)

--- a/Library/Mesh Model/MeshNetwork.swift
+++ b/Library/Mesh Model/MeshNetwork.swift
@@ -30,6 +30,20 @@
 
 import Foundation
 
+/// An observer protocol for the IV Index changes in the mesh network.
+///
+/// - warning: This protocol is for advanced users and should be used with caution.
+///            The IV Index is managed internally by the library. Tracking changes
+///            to the IV Index is not necessary for most applications.
+public protocol IvIndexObserver: AnyObject {
+    /// Called when the IV Index of the mesh network has changed.
+    ///
+    /// - note: This method is called from the main dispatch queue.
+    ///
+    /// - parameter ivIndex: The new IV Index value.
+    func ivIndexDidChange(to ivIndex: IvIndex)
+}
+
 /// The Bluetooth Mesh Network configuration.
 ///
 /// The mesh network object contains information about known Nodes, Provisioners,
@@ -71,6 +85,10 @@ public class MeshNetwork: Codable {
     /// An array containing Unicast Addresses that cannot be assigned to new Nodes.
     internal var networkExclusions: [ExclusionList]?
     
+    /// The observer for the IV Index changes in the mesh network.
+    ///
+    /// - warning: This property is for advanced users and should be used with caution.
+    public weak var ivIndexObserver: IvIndexObserver?
     /// The IV Index of the mesh network.
     ///
     /// - warning: This property is an internal value of the mesh network and is exposed only for advanced users.
@@ -82,10 +100,25 @@ public class MeshNetwork: Codable {
     ///         unless necessary. In that case use ``setIvIndex(_:updateActive:)`` method.
     public internal(set) var ivIndex: IvIndex {
         didSet {
+            guard ivIndex != oldValue else { return }
+            
+            let before = networkExclusions?.count ?? 0
             // Clean up the network exclusions.
             networkExclusions?.cleanUp(forIvIndex: ivIndex)
             if networkExclusions?.isEmpty ?? false {
                 networkExclusions = nil
+            }
+            let after = networkExclusions?.count ?? 0
+            
+            if before != after {
+                // Why the notification isn't posted here?
+                // It is, but the timestamp setter. One is enough.
+                timestamp = Date()
+            }
+            // Notify the observer about the IV Index change.
+            let ivIndex = ivIndex
+            DispatchQueue.main.async { [weak self] in
+                self?.ivIndexObserver?.ivIndexDidChange(to: ivIndex)
             }
         }
     }

--- a/Library/ProxyFilter.swift
+++ b/Library/ProxyFilter.swift
@@ -368,7 +368,7 @@ public extension ProxyFilter {
         
         // Clear the Proxy Network Key. This way we make sure the
         // Network Layer will handle the new incoming Secure Network beacon
-        // propertly, even if it belongs to a non-primary network.
+        // property, even if it belongs to a non-primary network.
         manager?.networkManager?.networkLayer.proxyNetworkKey = nil
         
         // Notify the delegate.


### PR DESCRIPTION
This PR adds a new row in Settings screen displaying the current IV Index value and "update active" flag.
When a network has no Nodes it also allows to set a custom value of the IV Index.

Thsi featrue was requested to be able to provision nodes to already existing network located in a remote location, when the phone is not able to connect to it to get a Secure Network beacon.

![Screenshot 2025-06-05 at 22 28 07 Medium](https://github.com/user-attachments/assets/48ffb29b-5d08-4558-a52b-38927528c359) ![Screenshot 2025-06-05 at 22 28 13 Medium](https://github.com/user-attachments/assets/2311a067-0f0a-40e6-8d1d-c82e13213384) ![Screenshot 2025-06-05 at 22 28 16 Medium](https://github.com/user-attachments/assets/554dd703-534b-4423-9e38-bab3710bb3ea) ![Screenshot 2025-06-05 at 22 31 37 Medium](https://github.com/user-attachments/assets/6d9d416f-5203-404c-9dbf-c6cf8084315f)
