### PR TITLE
UI: Show addr in publication destination lists

### DIFF
--- a/Example/Source/View Controllers/Network/Configuration/Automation/Publication/SelectPublicationDestintionsViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Automation/Publication/SelectPublicationDestintionsViewController.swift
@@ -145,8 +145,9 @@ class SelectPublicationDestinationsViewController: UITableViewController {
                 selectedIndexPath = indexPath
                 selectedDestination = nil
             }
-            cell.textLabel?.text = element.name ?? "Element \(element.index + 1)"
-            cell.detailTextLabel?.text = element.parentNode!.name ?? "Unknown Device"
+            let elementName = element.name ?? "Element \(element.index + 1)"
+            cell.textLabel?.text = "\(elementName) (0x\(element.unicastAddress.hex))"
+            cell.detailTextLabel?.text = "\(element.parentNode!.name ?? "Unknown Device") (0x\(element.parentNode!.primaryUnicastAddress.hex))"
             cell.imageView?.image = #imageLiteral(resourceName: "ic_flag_24pt")
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
         }

--- a/Example/Source/View Controllers/Network/Configuration/SetPublicationDestinationsViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/SetPublicationDestinationsViewController.swift
@@ -141,8 +141,9 @@ class SetPublicationDestinationsViewController: UITableViewController {
                 selectedIndexPath = indexPath
                 selectedDestination = nil
             }
-            cell.textLabel?.text = element.name ?? "Element \(element.index + 1)"
-            cell.detailTextLabel?.text = element.parentNode!.name ?? "Unknown Device"
+            let elementName = element.name ?? "Element \(element.index + 1)"
+            cell.textLabel?.text = "\(elementName) (0x\(element.unicastAddress.hex))"
+            cell.detailTextLabel?.text = "\(element.parentNode!.name ?? "Unknown Device") (0x\(element.parentNode!.primaryUnicastAddress.hex))"
             cell.imageView?.image = #imageLiteral(resourceName: "ic_flag_24pt")
             cell.accessoryType = indexPath == selectedIndexPath ? .checkmark : .none
         }


### PR DESCRIPTION
    Adds hexadecimal addresses to element and node names in the Set
    Publication Destinations screens. This improves clarity when multiple
    nodes share the same name by including:
    * Element unicast address alongside element number
    * Primary node address alongside device name

    The change is applied to both manual setup
    (SetPublicationDestinationsViewController) and automation flow
    (SelectPublicationDestinationsViewController).
    

This PR fixes #669 