### PR TITLE
Bugfix: Fixed crash when received a vendor message with not-matching company id

### DIFF
--- a/Example/Source/View Controllers/Network/Configuration/Model/VendorModelViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/VendorModelViewCell.swift
@@ -196,7 +196,8 @@ class VendorModelViewCell: ModelViewCell, UITextFieldDelegate {
             return false
             
         default:
-            fatalError()
+            // A company identifier is different.
+            return false
         }
     }
 }


### PR DESCRIPTION
This crash was only on a vendor model screen.