### PR TITLE
Adding `0x` to all hex values in logs

### DIFF
--- a/Example/Source/View Controllers/Network/Configuration/Model/VendorModelViewCell.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Model/VendorModelViewCell.swift
@@ -77,8 +77,8 @@ struct RuntimeAcknowledgedVendorMessage: RuntimeVendorMessage, AcknowledgedVendo
 extension RuntimeUnacknowledgedVendorMessage: CustomDebugStringConvertible {
 
     var debugDescription: String {
-        let hexOpCode = String(format: "%2X", opCode)
-        return "RuntimeVendorMessage(opCode: \(hexOpCode), parameters: \(parameters!.hex), isSegmented: \(isSegmented), security: \(security))"
+        let hexOpCode = String(format: "%02X", opCode)
+        return "RuntimeVendorMessage(opCode: 0x\(hexOpCode), parameters: 0x\(parameters!.hex), isSegmented: \(isSegmented), security: \(security))"
     }
     
 }
@@ -86,9 +86,9 @@ extension RuntimeUnacknowledgedVendorMessage: CustomDebugStringConvertible {
 extension RuntimeAcknowledgedVendorMessage: CustomDebugStringConvertible {
 
     var debugDescription: String {
-        let hexOpCode = String(format: "%2X", opCode)
-        let hexResponseOpCode = String(format: "%2X", responseOpCode)
-        return "RuntimeVendorMessage(opCode: \(hexOpCode), responseOpCode: \(hexResponseOpCode) parameters: \(parameters!.hex), isSegmented: \(isSegmented), security: \(security))"
+        let hexOpCode = String(format: "%02X", opCode)
+        let hexResponseOpCode = String(format: "%02X", responseOpCode)
+        return "RuntimeVendorMessage(opCode: 0x\(hexOpCode), responseOpCode: 0x\(hexResponseOpCode) parameters: 0x\(parameters!.hex), isSegmented: \(isSegmented), security: \(security))"
     }
     
 }

--- a/Library/Layers/Access Layer/AccessLayer.swift
+++ b/Library/Layers/Access Layer/AccessLayer.swift
@@ -229,7 +229,7 @@ internal class AccessLayer {
             m = transactionMessage
         }
         
-        logger?.i(.model, "Sending \(m) from: \(element), to: \(destination.hex)")
+        logger?.i(.model, "Sending \(m) from: \(element), to: 0x\(destination.hex)")
         let pdu = AccessPdu(fromMeshMessage: m,
                             sentFrom: element.unicastAddress, to: destination,
                             userInitiated: true)
@@ -270,7 +270,7 @@ internal class AccessLayer {
             return
         }
         
-        logger?.i(.foundationModel, "Sending \(message) to: \(destination.hex)")
+        logger?.i(.foundationModel, "Sending \(message) to: 0x\(destination.hex)")
         let pdu = AccessPdu(fromMeshMessage: message,
                             sentFrom: element.unicastAddress, to: MeshAddress(destination),
                             userInitiated: true)
@@ -295,7 +295,7 @@ internal class AccessLayer {
                from element: Element, to destination: Address,
                using keySet: KeySet) {
         let category: LogCategory = message is ConfigMessage ? .foundationModel : .model
-        logger?.i(category, "Replying with \(message) from: \(element), to: \(destination.hex)")
+        logger?.i(category, "Replying with \(message) from: 0x\(element), to: 0x\(destination.hex)")
         let pdu = AccessPdu(fromMeshMessage: message,
                             sentFrom: element.unicastAddress, to: MeshAddress(destination),
                             userInitiated: false)
@@ -323,7 +323,7 @@ internal class AccessLayer {
     /// - parameter handle: The message handle.
     func cancel(_ handle: MessageHandle) {
         guard let networkManager = networkManager else { return }
-        logger?.i(.access, "Cancelling messages with opcode: \(handle.opCode.hex), sent from: \(handle.source.hex) to: \(handle.destination.hex)")
+        logger?.i(.access, "Cancelling messages with opcode: 0x\(handle.opCode.hex), sent from: 0x\(handle.source.hex) to: 0x\(handle.destination.hex)")
         mutex.sync {
             if let index = reliableMessageContexts.firstIndex(where: {
                                $0.request.opCode == handle.opCode &&
@@ -397,7 +397,7 @@ private extension AccessLayer {
                        let message = delegate.decode(accessPdu) {
                         // Save and log only the first decoded message (see method's comment).
                         if newMessage == nil {
-                            logger?.i(.model, "\(message) received from: \(accessPdu.source.hex), to: \(accessPdu.destination.hex)")
+                            logger?.i(.model, "\(message) received from: 0x\(accessPdu.source.hex), to: 0x\(accessPdu.destination.hex)")
                             newMessage = message
                         } else if let newMessage = newMessage, type(of: message) != type(of: newMessage) {
                             // If another model's delegate decoded the same message to a different
@@ -451,7 +451,7 @@ private extension AccessLayer {
                     newMessage = message
                     // Is this message targeting the local Node?
                     if localNode.contains(elementWithAddress: accessPdu.destination.address) {
-                        logger?.i(.foundationModel, "\(message) received from: \(accessPdu.source.hex)")
+                        logger?.i(.foundationModel, "\(message) received from: 0x\(accessPdu.source.hex)")
                         if let response = delegate.model(model, didReceiveMessage: message,
                                                          sentFrom: accessPdu.source, to: accessPdu.destination,
                                                          asResponseTo: request) {
@@ -464,7 +464,7 @@ private extension AccessLayer {
                         _ = networkManager.delegate?.networkDidChange()
                     } else {
                         // If not, it was received by adding another Node's address to the Proxy Filter.
-                        logger?.i(.foundationModel, "\(message) received from: \(accessPdu.source.hex), to: \(accessPdu.destination.hex)")
+                        logger?.i(.foundationModel, "\(message) received from: 0x\(accessPdu.source.hex), to: 0x\(accessPdu.destination.hex)")
                     }
                     // A message can only be handled by a single Model, so we can break here.
                     break
@@ -628,7 +628,7 @@ private extension AccessLayer {
                       let networkManager = self.networkManager else { return }
                 self.logger?.w(.access, "Response to \(pdu) not received (timeout)")
                 let category: LogCategory = request is AcknowledgedConfigMessage ? .foundationModel : .model
-                self.logger?.w(category, "\(request) sent from: \(pdu.source.hex), to: \(pdu.destination.hex) timed out")
+                self.logger?.w(category, "\(request) sent from: 0x\(pdu.source.hex), to: 0x\(pdu.destination.hex) timed out")
                 self.cancel(MessageHandle(for: request,
                                           sentFrom: pdu.source, to: pdu.destination,
                                           using: networkManager))

--- a/Library/Layers/Lower Transport Layer/LowerTransportLayer.swift
+++ b/Library/Layers/Lower Transport Layer/LowerTransportLayer.swift
@@ -543,7 +543,7 @@ private extension LowerTransportLayer {
                             }
                         }
                         self.logger?.w(.lowerTransport, "Discard timeout expired, cancelling message " +
-                                                        "(src: \(Address(key >> 16).hex), seqZero: \(key & 0x1FFF), " +
+                                                        "(src: 0x\(Address(key >> 16).hex), seqZero: \(key & 0x1FFF), " +
                                                         "received segments: 0x\(marks.hex))")
                     }
                     self.discardTimers.removeValue(forKey: key)?.invalidate()

--- a/Library/Layers/Lower Transport Layer/SegmentedControlMessage.swift
+++ b/Library/Layers/Lower Transport Layer/SegmentedControlMessage.swift
@@ -94,7 +94,7 @@ internal struct SegmentedControlMessage: SegmentedMessage {
 extension SegmentedControlMessage: CustomDebugStringConvertible {
     
     var debugDescription: String {
-        return "Segmented \(type) (opCode: \(opCode), seqZero: \(sequenceZero), segO: \(segmentOffset), segN: \(lastSegmentNumber), data: 0x\(upperTransportPdu.hex))"
+        return "Segmented \(type) (opCode: 0x\(opCode.hex), seqZero: \(sequenceZero), segO: \(segmentOffset), segN: \(lastSegmentNumber), data: 0x\(upperTransportPdu.hex))"
     }
     
 }

--- a/Library/Layers/Network Layer/NetworkLayer.swift
+++ b/Library/Layers/Network Layer/NetworkLayer.swift
@@ -217,7 +217,7 @@ internal class NetworkLayer {
         // to configure the Proxy Server. This allows sniffing the network without
         // an option to send messages.
         let source = meshNetwork.localProvisioner?.node?.primaryUnicastAddress ?? Address.maxUnicastAddress
-        logger?.i(.proxy, "Sending \(message) from: \(source.hex) to: 0000")
+        logger?.i(.proxy, "Sending \(message) from: 0x\(source.hex) to: 0000")
         let pdu = ControlMessage(fromProxyConfigurationMessage: message,
                                  sentFrom: source, usingNetworkKey: networkKey,
                                  andIvIndex: meshNetwork.ivIndex)
@@ -419,12 +419,12 @@ private extension NetworkLayer {
         
         if let MessageType = MessageType,
            let message = MessageType.init(parameters: controlMessage.upperTransportPdu) {
-            logger?.i(.proxy, "\(message) received from: \(proxyPdu.source.hex) to: \(proxyPdu.destination.hex)")
+            logger?.i(.proxy, "\(message) received from: 0x\(proxyPdu.source.hex) to: 0x\(proxyPdu.destination.hex)")
             // Look for the proxy Node.
             let proxyNode = meshNetwork.node(withAddress: proxyPdu.source) ?? UnknownNode(from: proxyPdu, in: meshNetwork)
             networkManager.proxy?.handle(message, sentFrom: proxyNode)
         } else {
-            logger?.w(.proxy, "Unsupported proxy configuration message (opcode: \(controlMessage.opCode))")
+            logger?.w(.proxy, "Unsupported proxy configuration message (opcode: 0x\(controlMessage.opCode.hex))")
         }
     }
     

--- a/Library/Layers/Network Layer/NetworkPdu.swift
+++ b/Library/Layers/Network Layer/NetworkPdu.swift
@@ -268,7 +268,7 @@ extension NetworkPdu: CustomDebugStringConvertible {
         let encryptedDataSize = pdu.count - micSize - 9
         let encryptedData = pdu.subdata(in: 9..<9 + encryptedDataSize)
         let mic = pdu.advanced(by: 9 + encryptedDataSize)
-        return "Network PDU (ivi: \(ivi), nid: 0x\(nid.hex), ctl: \(type.rawValue), ttl: \(ttl), seq: \(sequence), src: \(source.hex), dst: \(destination.hex), transportPdu: 0x\(encryptedData.hex), netMic: 0x\(mic.hex))"
+        return "Network PDU (ivi: \(ivi), nid: 0x\(nid.hex), ctl: \(type.rawValue), ttl: \(ttl), seq: \(sequence), src: 0x\(source.hex), dst: 0x\(destination.hex), transportPdu: 0x\(encryptedData.hex), netMic: 0x\(mic.hex))"
     }
     
 }

--- a/Library/Layers/Network Layer/PrivateBeacon.swift
+++ b/Library/Layers/Network Layer/PrivateBeacon.swift
@@ -84,7 +84,7 @@ internal struct PrivateBeacon: NetworkBeaconPdu {
 extension PrivateBeacon: CustomDebugStringConvertible {
     
     var debugDescription: String {
-        return "Private beacon (Network ID: \(networkKey.networkId.hex), \(ivIndex), Key Refresh Flag: \(keyRefreshFlag))"
+        return "Private beacon (Network ID: 0x\(networkKey.networkId.hex), \(ivIndex), Key Refresh Flag: \(keyRefreshFlag))"
     }
     
 }

--- a/Library/Layers/Network Layer/SecureNetworkBeacon.swift
+++ b/Library/Layers/Network Layer/SecureNetworkBeacon.swift
@@ -83,7 +83,7 @@ internal struct SecureNetworkBeacon: NetworkBeaconPdu {
 extension SecureNetworkBeacon: CustomDebugStringConvertible {
     
     var debugDescription: String {
-        return "Secure Network beacon (Network ID: \(networkKey.networkId.hex), \(ivIndex), Key Refresh Flag: \(keyRefreshFlag))"
+        return "Secure Network beacon (Network ID: 0x\(networkKey.networkId.hex), \(ivIndex), Key Refresh Flag: \(keyRefreshFlag))"
     }
     
 }

--- a/Library/Layers/Network Layer/UnprovisionedDeviceBeacon.swift
+++ b/Library/Layers/Network Layer/UnprovisionedDeviceBeacon.swift
@@ -89,7 +89,8 @@ internal struct UnprovisionedDeviceBeaconDecoder {
 extension UnprovisionedDeviceBeacon: CustomDebugStringConvertible {
     
     var debugDescription: String {
-        return "Unprovisioned Device beacon (UUID: \(deviceUuid.uuidString), OOB Info: \(oob), URI hash: \(uriHash?.hex ?? "None"))"
+        let uriHashHex = uriHash.map { "0x\($0.hex)" } ?? "None"
+        return "Unprovisioned Device beacon (UUID: \(deviceUuid.uuidString), OOB Info: \(oob), URI hash: \(uriHashHex))"
     }
     
 }

--- a/Library/Layers/Upper Transport Layer/UpperTransportLayer.swift
+++ b/Library/Layers/Upper Transport Layer/UpperTransportLayer.swift
@@ -82,11 +82,11 @@ internal class UpperTransportLayer {
             switch controlMessage.opCode {
             case HeartbeatMessage.opCode:
                 if let heartbeat = HeartbeatMessage(fromControlMessage: controlMessage) {
-                    logger?.i(.upperTransport, "\(heartbeat) received from \(heartbeat.source.hex)")
+                    logger?.i(.upperTransport, "\(heartbeat) received from 0x\(heartbeat.source.hex)")
                     handle(heartbeat: heartbeat)
                 }
             default:
-                logger?.w(.upperTransport, "Unsupported Control Message received (opCode: \(controlMessage.opCode))")
+                logger?.w(.upperTransport, "Unsupported Control Message received (opCode: 0x\(controlMessage.opCode.hex))")
                 // Other Control Messages are not supported.
                 break
             }
@@ -263,7 +263,7 @@ private extension UpperTransportLayer {
     ///   - heartbeat: The Heartbeat message to be sent.
     ///   - networkKey: The Network Key to encrypt the message with.
     func send(heartbeat: HeartbeatMessage, usingNetworkKey networkKey: NetworkKey) {
-        logger?.i(.upperTransport, "Sending \(heartbeat) to \(heartbeat.destination.hex) " +
+        logger?.i(.upperTransport, "Sending \(heartbeat) to 0x\(heartbeat.destination.hex) " +
                                    "encrypted using key: \(networkKey)")
         networkManager?.lowerTransportLayer.send(heartbeat: heartbeat, usingNetworkKey: networkKey)
     }

--- a/Library/Mesh Messages/ConfigMessage.swift
+++ b/Library/Mesh Messages/ConfigMessage.swift
@@ -440,7 +440,7 @@ extension RemainingHeartbeatPublicationCount: CustomDebugStringConvertible {
         case .indefinitely:
             return "Indefinitely"
         case .invalid(let value):
-            return "Invalid: \(value.hex)"
+            return "Invalid: 0x\(value.hex)"
         case .range(let range):
             return range.description
         case .exact(let value):
@@ -457,7 +457,7 @@ extension RemainingHeartbeatSubscriptionPeriod: CustomDebugStringConvertible {
         case .disabled:
             return "Disabled"
         case .invalid(let value):
-            return "Invalid: \(value.hex)"
+            return "Invalid: 0x\(value.hex)"
         case .range(let range):
             return "\(range.description) sec"
         case .exact(let value):
@@ -472,7 +472,7 @@ extension HeartbeatSubscriptionCount: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
         case .invalid(let value):
-            return "Invalid: \(value.hex)"
+            return "Invalid: 0x\(value.hex)"
         case .range(let range):
             return range.description
         case .exact(let value):

--- a/Library/Mesh Messages/Foundation/Configuration/ConfigCompositionDataStatus.swift
+++ b/Library/Mesh Messages/Foundation/Configuration/ConfigCompositionDataStatus.swift
@@ -169,7 +169,7 @@ public struct ModelData: Sendable, CustomDebugStringConvertible {
     
     public var debugDescription: String {
         if let companyId = companyIdentifier {
-            return "\(modelIdentifier.hex) (companyId: \(companyId.hex))"
+            return "\(modelIdentifier.hex) (companyId: 0x\(companyId.hex))"
         }
         return modelIdentifier.hex
     }
@@ -252,7 +252,7 @@ public struct Page0: CompositionDataPage, CustomDebugStringConvertible {
     }
     
     public var debugDescription: String {
-        return "Page0(companyId: \(companyIdentifier.hex), productId: \(productIdentifier.hex), versionId: \(versionIdentifier.hex), " +
+        return "Page0(companyId: 0x\(companyIdentifier.hex), productId: 0x\(productIdentifier.hex), versionId: 0x\(versionIdentifier.hex), " +
                "minimumRPL: \(minimumNumberOfReplayProtectionList), features: \(features), elements: \(elements))"
     }
 }

--- a/Library/Mesh Messages/Foundation/DFU/FirmwareDistributionReceiversList.swift
+++ b/Library/Mesh Messages/Foundation/DFU/FirmwareDistributionReceiversList.swift
@@ -104,7 +104,7 @@ public struct FirmwareDistributionReceiversList: StaticMeshResponse {
         }
         
         public var debugDescription: String {
-            return "Receiver(address: \(address.hex), phase: \(phase), updateStatus: \(updateStatus), transferStatus: \(transferStatus), progress: \(transferProgress), imageIndex: \(imageIndex))"
+            return "Receiver(address: 0x\(address.hex), phase: \(phase), updateStatus: \(updateStatus), transferStatus: \(transferStatus), progress: \(transferProgress), imageIndex: \(imageIndex))"
         }
     }
     

--- a/Library/Mesh Messages/UnknownMessage.swift
+++ b/Library/Mesh Messages/UnknownMessage.swift
@@ -56,7 +56,7 @@ extension UnknownMessage: CustomDebugStringConvertible {
     
     public var debugDescription: String {
         let opCodeHex = opCode.hex.suffix(6)
-        let parametersHex = parameters?.hex ?? "nil"
+        let parametersHex = parameters.map { "0x\($0.hex)" } ?? "nil"
         return "UnknownMessage(opCode: 0x\(opCodeHex), parameters: \(parametersHex))"
     }
     

--- a/Library/Mesh Model/Group.swift
+++ b/Library/Mesh Model/Group.swift
@@ -130,21 +130,21 @@ public class Group: Codable {
         self.groupAddress = try container.decode(String.self, forKey: .groupAddress)
         guard let address = MeshAddress(hex: groupAddress) else {
             throw DecodingError.dataCorruptedError(forKey: .groupAddress, in: container,
-                                                   debugDescription: "Invalid Group address: \(groupAddress).")
+                                                   debugDescription: "Invalid Group address: 0x\(groupAddress).")
         }
         guard address.address.isGroup || address.address.isVirtual else {
             throw DecodingError.dataCorruptedError(forKey: .groupAddress, in: container,
-                                                   debugDescription: "Not a Group address: \(groupAddress).")
+                                                   debugDescription: "Not a Group address: 0x\(groupAddress).")
         }
         guard !address.address.isSpecialGroup else {
             throw DecodingError.dataCorruptedError(forKey: .groupAddress, in: container,
-                                                   debugDescription: "Illegal Group address: \(groupAddress).")
+                                                   debugDescription: "Illegal Group address: 0x\(groupAddress).")
         }
         self.address = address
         self.parentAddress = try container.decode(String.self, forKey: .parentAddress)
         guard let parentAddress = MeshAddress(hex: parentAddress) else {
             throw DecodingError.dataCorruptedError(forKey: .parentAddress, in: container,
-                                                   debugDescription: "Invalid Group address: \(groupAddress).")
+                                                   debugDescription: "Invalid Group address: 0x\(groupAddress).")
         }
         guard parentAddress.address.isUnassigned ||
               parentAddress.address.isGroup ||

--- a/Library/Mesh Model/HeartbeatPublication.swift
+++ b/Library/Mesh Model/HeartbeatPublication.swift
@@ -292,7 +292,7 @@ private extension HeartbeatPublication {
             // Maximum value.
             return 0xFFFF
         default:
-            fatalError("PeriodLog out or range: \(periodLog) (required: 0x00-0x11)")
+            fatalError("PeriodLog out or range: 0x\(periodLog.hex) (required: 0x00-0x11)")
         }
     }
     

--- a/Library/Mesh Model/HeartbeatSubscription.swift
+++ b/Library/Mesh Model/HeartbeatSubscription.swift
@@ -259,7 +259,7 @@ private extension HeartbeatSubscription {
             // Maximum value.
             return 0xFFFF
         default:
-            fatalError("PeriodLog out or range: \(periodLog) (required: 0x00-0x11)")
+            fatalError("PeriodLog out or range: 0x\(periodLog.hex) (required: 0x00-0x11)")
         }
     }
     


### PR DESCRIPTION
Some values in logs were displayed without 0x (i.e. addresses), while other had it (i.e. data). For consistency, this PR adds `0x` notation to all hex values. I hope I didn't miss anything.