### PR TITLE
Option to retry failed auto-reconfiguration

### DIFF
--- a/Example/Source/View Controllers/Network/Configuration/Automation/ConfigurationViewController.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Automation/ConfigurationViewController.swift
@@ -60,6 +60,7 @@ class ConfigurationViewController: UIViewController,
             }
             
             // Roll back and retry the failed task.
+            progress.retryLast()
             current -= 1
             executeNext()
         } else if isDfu {
@@ -716,6 +717,7 @@ private extension ConfigurationViewController {
     
     func failed() {
         DispatchQueue.main.async {
+            self.progress.addFail()
             self.tableView.reloadData()
             self.statusView.text = "Configuration failed"
             self.doneButton.title = "Retry"

--- a/Example/Source/View Controllers/Network/Configuration/Automation/Views/MulticolorProgressView.swift
+++ b/Example/Source/View Controllers/Network/Configuration/Automation/Views/MulticolorProgressView.swift
@@ -60,6 +60,11 @@ class MulticolorProgressView: UIView {
         self.skipped += 1
         setNeedsDisplay()
     }
+    
+    func retryLast() {
+        self.fail -= 1
+        setNeedsDisplay()
+    }
 
     override func draw(_ rect: CGRect) {
         guard let context = UIGraphicsGetCurrentContext() else {


### PR DESCRIPTION
This PR improves the behavior of "auto reconfiguration". If one message fails to be sent teh app will now allow to Retry (and continue), instead of aborting. That way the configuration of the old Node won't be lost and user will be able to continue upon fixing connectiviti issues.

Also, if there's no GATT Proxy connection, the Retry button will enable Automatic Connection to increase changes of any Node getting connected.

<img width="300" alt="Autoconfiguration failed" src="https://github.com/user-attachments/assets/079e32f9-4880-4aff-93ff-f50182c241a7" /> <img width="300" alt="Retrying" src="https://github.com/user-attachments/assets/3e5f06cf-7937-4a08-a374-6eabf466cf79" /> <img width="300" alt="Configuration complete" src="https://github.com/user-attachments/assets/43eb23d3-b4bf-447b-866e-5e9d36b3e478" />
