### PR TITLE
Bugfix: Fixed double callback on message timeout

### DIFF
--- a/Library/Layers/NetworkManager.swift
+++ b/Library/Layers/NetworkManager.swift
@@ -491,7 +491,7 @@ internal class NetworkManager {
     ///
     /// - parameter handler: The message identifier.
     func cancel(messageWithHandler handler: MessageHandle) {
-        accessLayer.cancel(handler)
+        accessLayer.cancel(handler, andNotify: true)
     }
     
     /// Notifies a callback awaiting messages with given OpCode sent from


### PR DESCRIPTION
When a message timed out, the library was sending `meshNetworkManager(:failedToSendMessage:from:to:error)` callback twice: once with `.cancelled` and second time with `.timeout`. 
After the fix the first call won't happen.