### PR TITLE
[Improvement] Adding `.reserved` `HealthFault` to indicate unknown, instead of ignoring it

### DIFF
--- a/Library/Layers/Foundation Layer/HealthServerHandler.swift
+++ b/Library/Layers/Foundation Layer/HealthServerHandler.swift
@@ -156,8 +156,8 @@ internal class HealthServerHandler: ModelDelegate {
             // and the "testID" is grater than 0, the fault with the ID equal to the testID
             // is added to the Registered Fault state.
             if request.companyIdentifier == nordicSemiconductor {
-                if request.testId > 0,
-                   let fault = HealthFault.fromId(request.testId) {
+                if request.testId > 0 {
+                    let fault = HealthFault.fromId(request.testId)
                     currentFaultState.insert(fault)
                 } else {
                     currentFaultState.removeAll()
@@ -219,8 +219,8 @@ internal class HealthServerHandler: ModelDelegate {
             // and the "testID" is grater than 0, the fault with the ID equal to the testID
             // is added to the Registered Fault state.
             if request.companyIdentifier == nordicSemiconductor {
-                if request.testId > 0,
-                   let fault = HealthFault.fromId(request.testId) {
+                if request.testId > 0 {
+                    let fault = HealthFault.fromId(request.testId)
                     currentFaultState.insert(fault)
                 } else {
                     currentFaultState.removeAll()

--- a/Library/Mesh Messages/Health/HealthAttentionStatus.swift
+++ b/Library/Mesh Messages/Health/HealthAttentionStatus.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-/// A Health Attention Set Unacknowledged is an unacknowledged message used to set the current
+/// A Health Attention Status is an unacknowledged message used to report the current
 /// Attention Timer state of an Element.
 ///
 /// The Attention Timer is intended to allow an Element to attract human attention and, among others,

--- a/Library/Mesh Messages/Health/HealthCurrentStatus.swift
+++ b/Library/Mesh Messages/Health/HealthCurrentStatus.swift
@@ -78,7 +78,7 @@ public struct HealthCurrentStatus: StaticMeshResponse {
         if parameters.count > 3 {
             faults = parameters
                 .subdata(in: 3..<parameters.count)
-                .compactMap { HealthFault.fromId($0) }
+                .map { HealthFault.fromId($0) }
         } else {
             faults = []
         }

--- a/Library/Mesh Messages/Health/HealthFault.swift
+++ b/Library/Mesh Messages/Health/HealthFault.swift
@@ -84,6 +84,7 @@ public enum HealthFault: Sendable, Hashable, Equatable {
     case mechanismJammedWarning
     case mechanismJammedError
     case vendor(_ id: UInt8)
+    case reserved(_ id: UInt8)
         
     /// The ID of the fault.
     var id: UInt8 {
@@ -140,11 +141,12 @@ public enum HealthFault: Sendable, Hashable, Equatable {
         case .mechanismJammedWarning:        return 0x31
         case .mechanismJammedError:          return 0x32
         case .vendor(let id):                return id
+        case .reserved(let id):              return id
         }
     }
     
     /// Creates a ``HealthFault`` from the given ID.
-    static func fromId(_ id: UInt8) -> HealthFault? {
+    static func fromId(_ id: UInt8) -> HealthFault {
         switch id {
         case 0x00:        return .noFault
         case 0x01:        return .batteryLowWarning
@@ -198,7 +200,7 @@ public enum HealthFault: Sendable, Hashable, Equatable {
         case 0x31:        return .mechanismJammedWarning
         case 0x32:        return .mechanismJammedError
         case 0x80...0xFF: return .vendor(id)
-        default:          return nil
+        default:          return .reserved(id)
         }
     }
     
@@ -266,6 +268,7 @@ extension HealthFault: CustomDebugStringConvertible {
         case .mechanismJammedWarning:        return "Warning: Mechanism Jammed"
         case .mechanismJammedError:          return "Error: Mechanism Jammed"
         case .vendor(let id):                return "Vendor (\(id))"
+        case .reserved(let id):              return "Reserved (\(id))"
         }
     }
 }

--- a/Library/Mesh Messages/Health/HealthFaultStatus.swift
+++ b/Library/Mesh Messages/Health/HealthFaultStatus.swift
@@ -78,7 +78,7 @@ public struct HealthFaultStatus: StaticMeshResponse {
         if parameters.count > 3 {
             faults = parameters
                 .subdata(in: 3..<parameters.count)
-                .compactMap { HealthFault.fromId($0) }
+                .map { HealthFault.fromId($0) }
         } else {
             faults = []
         }


### PR DESCRIPTION
This may be a breaking change. `fromId` no longer returns a `nil`, instead will return `.reserverd(id)`, which is way better.